### PR TITLE
Use properties instead of explicit get/set methods.

### DIFF
--- a/Dynastream/Fit/DeveloperDataLookup.cs
+++ b/Dynastream/Fit/DeveloperDataLookup.cs
@@ -51,7 +51,7 @@ namespace Dynastream.Fit
 
         public void Add(DeveloperDataIdMesg mesg)
         {
-            byte? index = mesg.GetDeveloperDataIndex();
+            byte? index = mesg.DeveloperDataIndex;
             if (index == null)
                 return;
 
@@ -75,8 +75,8 @@ namespace Dynastream.Fit
         {
             DeveloperFieldDescription desc = null;
 
-            byte? developerDataIndex = mesg.GetDeveloperDataIndex();
-            byte? fieldDefinitionNumber = mesg.GetFieldDefinitionNumber();
+            byte? developerDataIndex = mesg.DeveloperDataIndex;
+            byte? fieldDefinitionNumber = mesg.FieldDefinitionNumber;
             if ((developerDataIndex != null) &&
                 (fieldDefinitionNumber != null))
             {

--- a/Dynastream/Fit/DeveloperField.cs
+++ b/Dynastream/Fit/DeveloperField.cs
@@ -47,7 +47,7 @@ namespace Dynastream.Fit
             {
                 if (m_definition.IsDefined)
                 {
-                    return m_definition.DeveloperIdMesg.GetApplicationVersion() ?? 0;
+                    return m_definition.DeveloperIdMesg.ApplicationVersion ?? 0;
                 }
 
                 return 0;
@@ -90,7 +90,7 @@ namespace Dynastream.Fit
             {
                 if (m_definition.IsDefined)
                 {
-                    return m_definition.DescriptionMesg.GetFitBaseTypeId() ?? Fit.UInt8;
+                    return m_definition.DescriptionMesg.FitBaseTypeId ?? Fit.UInt8;
                 }
 
                 return Fit.UInt8;
@@ -103,7 +103,7 @@ namespace Dynastream.Fit
             {
                 if (m_definition.IsDefined)
                 {
-                    return m_definition.DescriptionMesg.GetScale() ?? 1.0;
+                    return m_definition.DescriptionMesg.Scale ?? 1.0;
                 }
 
                 return 1.0;
@@ -116,7 +116,7 @@ namespace Dynastream.Fit
             {
                 if (m_definition.IsDefined)
                 {
-                    return m_definition.DescriptionMesg.GetOffset() ?? 0.0;
+                    return m_definition.DescriptionMesg.Offset ?? 0.0;
                 }
 
                 return 0.0;
@@ -145,7 +145,7 @@ namespace Dynastream.Fit
             {
                 if (m_definition.IsDefined)
                 {
-                    return m_definition.DescriptionMesg.GetNativeFieldNum() ?? Fit.FieldNumInvalid;
+                    return m_definition.DescriptionMesg.NativeFieldNum ?? Fit.FieldNumInvalid;
                 }
 
                 return Fit.FieldNumInvalid;

--- a/Dynastream/Fit/DeveloperFieldDefinition.cs
+++ b/Dynastream/Fit/DeveloperFieldDefinition.cs
@@ -83,8 +83,8 @@ namespace Dynastream.Fit
         /// </exception>
         public DeveloperFieldDefinition(FieldDescriptionMesg desc, DeveloperDataIdMesg devId, byte size)
         {
-            byte? fieldDefinitionNumber = desc.GetFieldDefinitionNumber();
-            byte? developerDataIndex = desc.GetDeveloperDataIndex();
+            byte? fieldDefinitionNumber = desc.FieldDefinitionNumber;
+            byte? developerDataIndex = desc.DeveloperDataIndex;
             if ((developerDataIndex != null) &&
                 (fieldDefinitionNumber != null))
             {

--- a/Dynastream/Fit/DeveloperFieldDescription.cs
+++ b/Dynastream/Fit/DeveloperFieldDescription.cs
@@ -30,7 +30,7 @@ namespace Dynastream.Fit
         /// </summary>
         public uint ApplicationVersion
         {
-            get { return m_developerDataId.GetApplicationVersion() ?? uint.MaxValue; }
+            get { return m_developerDataId.ApplicationVersion ?? uint.MaxValue; }
         }
 
         /// <summary>
@@ -80,7 +80,7 @@ namespace Dynastream.Fit
         /// </summary>
         public byte FieldDefinitionNumber
         {
-            get { return m_fieldDescription.GetFieldDefinitionNumber() ?? byte.MaxValue; }
+            get { return m_fieldDescription.FieldDefinitionNumber ?? byte.MaxValue; }
         }
 
         internal DeveloperFieldDescription(

--- a/Dynastream/Fit/Mesg.cs
+++ b/Dynastream/Fit/Mesg.cs
@@ -34,7 +34,7 @@ namespace Dynastream.Fit
         #endregion
 
         #region Properties
-        public string Name { get; set; }
+        public string MessageName { get; set; }
         public ushort Num { get; set; }
         public byte LocalNum
         {
@@ -76,11 +76,11 @@ namespace Dynastream.Fit
         {
             if (mesg == null)
             {
-                this.Name = "unknown";
+                this.MessageName = "unknown";
                 this.Num = (ushort)MesgNum.Invalid;
                 return;
             }
-            this.Name = mesg.Name;
+            this.MessageName = mesg.MessageName;
             this.Num = mesg.Num;
             this.LocalNum = mesg.LocalNum;
             this.systemTimeOffset = mesg.systemTimeOffset;
@@ -102,9 +102,9 @@ namespace Dynastream.Fit
             }
         }
 
-        public Mesg(string name, ushort num)
+        public Mesg(string messageName, ushort num)
         {
-            this.Name = name;
+            this.MessageName = messageName;
             this.Num = num;
         }
 

--- a/Dynastream/Fit/Profile/Mesgs/AadAccelFeaturesMesg.cs
+++ b/Dynastream/Fit/Profile/Mesgs/AadAccelFeaturesMesg.cs
@@ -21,191 +21,178 @@ using System.Linq;
 
 namespace Dynastream.Fit
 {
-    /// <summary>
-    /// Implements the AadAccelFeatures profile message.
-    /// </summary>
-    public class AadAccelFeaturesMesg : Mesg
-    {
-        #region Fields
-        #endregion
+	/// <summary>
+	/// Implements the AadAccelFeatures profile message.
+	/// </summary>
+	public class AadAccelFeaturesMesg : Mesg
+	{
+		#region Fields
+		#endregion
 
-        /// <summary>
-        /// Field Numbers for <see cref="AadAccelFeaturesMesg"/>
-        /// </summary>
-        public sealed class FieldDefNum
-        {
-            public const byte Timestamp = 253;
-            public const byte Time = 0;
-            public const byte EnergyTotal = 1;
-            public const byte ZeroCrossCnt = 2;
-            public const byte Instance = 3;
-            public const byte TimeAboveThreshold = 4;
-            public const byte Invalid = Fit.FieldNumInvalid;
-        }
+		/// <summary>
+		/// Field Numbers for <see cref="AadAccelFeaturesMesg"/>
+		/// </summary>
+		public sealed class FieldDefNum
+		{
+			public const byte Timestamp = 253;
+			public const byte Time = 0;
+			public const byte EnergyTotal = 1;
+			public const byte ZeroCrossCnt = 2;
+			public const byte Instance = 3;
+			public const byte TimeAboveThreshold = 4;
+			public const byte Invalid = Fit.FieldNumInvalid;
+		}
 
-        #region Constructors
-        public AadAccelFeaturesMesg() : base(Profile.GetMesg(MesgNum.AadAccelFeatures))
-        {
-        }
+		#region Constructors
+		public AadAccelFeaturesMesg() : base(Profile.GetMesg(MesgNum.AadAccelFeatures))
+		{
+		}
 
-        public AadAccelFeaturesMesg(Mesg mesg) : base(mesg)
-        {
-        }
-        #endregion // Constructors
+		public AadAccelFeaturesMesg(Mesg mesg) : base(mesg)
+		{
+		}
+		#endregion // Constructors
 
-        #region Methods
-        ///<summary>
-        /// Retrieves the Timestamp field</summary>
-        /// <returns>Returns DateTime representing the Timestamp field</returns>
-        public DateTime GetTimestamp()
-        {
-            Object val = GetFieldValue(253, 0, Fit.SubfieldIndexMainField);
-            if(val == null)
-            {
-                return null;
-            }
+		#region Methods
+		///<summary>
+		/// Retrieves the Timestamp field</summary>
+		/// <returns>Returns DateTime representing the Timestamp field</returns>
+		public DateTime Timestamp
+		{
+			get
+			{
+				Object val = GetFieldValue(253, 0, Fit.SubfieldIndexMainField);
+				if (val == null)
+				{
+					return null;
+				}
 
-            return TimestampToDateTime(Convert.ToUInt32(val));
-            
-        }
+				return TimestampToDateTime(Convert.ToUInt32(val));
 
-        /// <summary>
-        /// Set Timestamp field</summary>
-        /// <param name="timestamp_">Nullable field value to be set</param>
-        public void SetTimestamp(DateTime timestamp_)
-        {
-            SetFieldValue(253, 0, timestamp_.GetTimeStamp(), Fit.SubfieldIndexMainField);
-        }
-        
-        ///<summary>
-        /// Retrieves the Time field
-        /// Units: s
-        /// Comment: Time interval length in seconds</summary>
-        /// <returns>Returns nullable ushort representing the Time field</returns>
-        public ushort? GetTime()
-        {
-            Object val = GetFieldValue(0, 0, Fit.SubfieldIndexMainField);
-            if(val == null)
-            {
-                return null;
-            }
+			}
+			set
+			{
+				SetFieldValue(253, 0, value.GetTimeStamp(), Fit.SubfieldIndexMainField);
+			}
+		}
 
-            return (Convert.ToUInt16(val));
-            
-        }
+		///<summary>
+		/// Retrieves the Time field
+		/// Units: s
+		/// Comment: Time interval length in seconds</summary>
+		/// <returns>Returns nullable ushort representing the Time field</returns>
+		public ushort? Time
+		{
+			get
+			{
+				Object val = GetFieldValue(0, 0, Fit.SubfieldIndexMainField);
+				if (val == null)
+				{
+					return null;
+				}
 
-        /// <summary>
-        /// Set Time field
-        /// Units: s
-        /// Comment: Time interval length in seconds</summary>
-        /// <param name="time_">Nullable field value to be set</param>
-        public void SetTime(ushort? time_)
-        {
-            SetFieldValue(0, 0, time_, Fit.SubfieldIndexMainField);
-        }
-        
-        ///<summary>
-        /// Retrieves the EnergyTotal field
-        /// Comment: Total accelerometer energy in the interval</summary>
-        /// <returns>Returns nullable uint representing the EnergyTotal field</returns>
-        public uint? GetEnergyTotal()
-        {
-            Object val = GetFieldValue(1, 0, Fit.SubfieldIndexMainField);
-            if(val == null)
-            {
-                return null;
-            }
+				return (Convert.ToUInt16(val));
 
-            return (Convert.ToUInt32(val));
-            
-        }
+			}
+			set
+			{
+				SetFieldValue(0, 0, value, Fit.SubfieldIndexMainField);
+			}
+		}
 
-        /// <summary>
-        /// Set EnergyTotal field
-        /// Comment: Total accelerometer energy in the interval</summary>
-        /// <param name="energyTotal_">Nullable field value to be set</param>
-        public void SetEnergyTotal(uint? energyTotal_)
-        {
-            SetFieldValue(1, 0, energyTotal_, Fit.SubfieldIndexMainField);
-        }
-        
-        ///<summary>
-        /// Retrieves the ZeroCrossCnt field
-        /// Comment: Count of zero crossings</summary>
-        /// <returns>Returns nullable ushort representing the ZeroCrossCnt field</returns>
-        public ushort? GetZeroCrossCnt()
-        {
-            Object val = GetFieldValue(2, 0, Fit.SubfieldIndexMainField);
-            if(val == null)
-            {
-                return null;
-            }
+		///<summary>
+		/// Retrieves the EnergyTotal field
+		/// Comment: Total accelerometer energy in the interval</summary>
+		/// <returns>Returns nullable uint representing the EnergyTotal field</returns>
+		public uint? EnergyTotal
+		{
+			get
+			{
+				Object val = GetFieldValue(1, 0, Fit.SubfieldIndexMainField);
+				if (val == null)
+				{
+					return null;
+				}
 
-            return (Convert.ToUInt16(val));
-            
-        }
+				return (Convert.ToUInt32(val));
 
-        /// <summary>
-        /// Set ZeroCrossCnt field
-        /// Comment: Count of zero crossings</summary>
-        /// <param name="zeroCrossCnt_">Nullable field value to be set</param>
-        public void SetZeroCrossCnt(ushort? zeroCrossCnt_)
-        {
-            SetFieldValue(2, 0, zeroCrossCnt_, Fit.SubfieldIndexMainField);
-        }
-        
-        ///<summary>
-        /// Retrieves the Instance field
-        /// Comment: Instance ID of zero crossing algorithm</summary>
-        /// <returns>Returns nullable byte representing the Instance field</returns>
-        public byte? GetInstance()
-        {
-            Object val = GetFieldValue(3, 0, Fit.SubfieldIndexMainField);
-            if(val == null)
-            {
-                return null;
-            }
+			}
+			set
+			{
+				SetFieldValue(1, 0, value, Fit.SubfieldIndexMainField);
+			}
+		}
 
-            return (Convert.ToByte(val));
-            
-        }
+		///<summary>
+		/// Retrieves the ZeroCrossCnt field
+		/// Comment: Count of zero crossings</summary>
+		/// <returns>Returns nullable ushort representing the ZeroCrossCnt field</returns>
+		public ushort? ZeroCrossCnt
+		{
+			get
+			{
+				Object val = GetFieldValue(2, 0, Fit.SubfieldIndexMainField);
+				if (val == null)
+				{
+					return null;
+				}
 
-        /// <summary>
-        /// Set Instance field
-        /// Comment: Instance ID of zero crossing algorithm</summary>
-        /// <param name="instance_">Nullable field value to be set</param>
-        public void SetInstance(byte? instance_)
-        {
-            SetFieldValue(3, 0, instance_, Fit.SubfieldIndexMainField);
-        }
-        
-        ///<summary>
-        /// Retrieves the TimeAboveThreshold field
-        /// Units: s
-        /// Comment: Total accelerometer time above threshold in the interval</summary>
-        /// <returns>Returns nullable float representing the TimeAboveThreshold field</returns>
-        public float? GetTimeAboveThreshold()
-        {
-            Object val = GetFieldValue(4, 0, Fit.SubfieldIndexMainField);
-            if(val == null)
-            {
-                return null;
-            }
+				return (Convert.ToUInt16(val));
 
-            return (Convert.ToSingle(val));
-            
-        }
+			}
+			set
+			{
+				SetFieldValue(2, 0, value, Fit.SubfieldIndexMainField);
+			}
+		}
 
-        /// <summary>
-        /// Set TimeAboveThreshold field
-        /// Units: s
-        /// Comment: Total accelerometer time above threshold in the interval</summary>
-        /// <param name="timeAboveThreshold_">Nullable field value to be set</param>
-        public void SetTimeAboveThreshold(float? timeAboveThreshold_)
-        {
-            SetFieldValue(4, 0, timeAboveThreshold_, Fit.SubfieldIndexMainField);
-        }
-        
-        #endregion // Methods
-    } // Class
+		///<summary>
+		/// Retrieves the Instance field
+		/// Comment: Instance ID of zero crossing algorithm</summary>
+		/// <returns>Returns nullable byte representing the Instance field</returns>
+		public byte? Instance
+		{
+			get
+			{
+				Object val = GetFieldValue(3, 0, Fit.SubfieldIndexMainField);
+				if (val == null)
+				{
+					return null;
+				}
+
+				return (Convert.ToByte(val));
+
+			}
+			set
+			{
+				SetFieldValue(3, 0, value, Fit.SubfieldIndexMainField);
+			}
+		}
+
+		///<summary>
+		/// Retrieves the TimeAboveThreshold field
+		/// Units: s
+		/// Comment: Total accelerometer time above threshold in the interval</summary>
+		/// <returns>Returns nullable float representing the TimeAboveThreshold field</returns>
+		public float? TimeAboveThreshold
+		{
+			get
+			{
+				Object val = GetFieldValue(4, 0, Fit.SubfieldIndexMainField);
+				if (val == null)
+				{
+					return null;
+				}
+
+				return (Convert.ToSingle(val));
+
+			}
+			set
+			{
+				SetFieldValue(4, 0, value, Fit.SubfieldIndexMainField);
+			}
+		}
+
+		#endregion // Methods
+	} // Class
 } // namespace

--- a/Dynastream/Fit/Profile/Mesgs/AccelerometerDataMesg.cs
+++ b/Dynastream/Fit/Profile/Mesgs/AccelerometerDataMesg.cs
@@ -21,489 +21,483 @@ using System.Linq;
 
 namespace Dynastream.Fit
 {
-    /// <summary>
-    /// Implements the AccelerometerData profile message.
-    /// </summary>
-    public class AccelerometerDataMesg : Mesg
-    {
-        #region Fields
-        #endregion
+	/// <summary>
+	/// Implements the AccelerometerData profile message.
+	/// </summary>
+	public class AccelerometerDataMesg : Mesg
+	{
+		#region Fields
+		#endregion
 
-        /// <summary>
-        /// Field Numbers for <see cref="AccelerometerDataMesg"/>
-        /// </summary>
-        public sealed class FieldDefNum
-        {
-            public const byte Timestamp = 253;
-            public const byte TimestampMs = 0;
-            public const byte SampleTimeOffset = 1;
-            public const byte AccelX = 2;
-            public const byte AccelY = 3;
-            public const byte AccelZ = 4;
-            public const byte CalibratedAccelX = 5;
-            public const byte CalibratedAccelY = 6;
-            public const byte CalibratedAccelZ = 7;
-            public const byte CompressedCalibratedAccelX = 8;
-            public const byte CompressedCalibratedAccelY = 9;
-            public const byte CompressedCalibratedAccelZ = 10;
-            public const byte Invalid = Fit.FieldNumInvalid;
-        }
+		/// <summary>
+		/// Field Numbers for <see cref="AccelerometerDataMesg"/>
+		/// </summary>
+		public sealed class FieldDefNum
+		{
+			public const byte Timestamp = 253;
+			public const byte TimestampMs = 0;
+			public const byte SampleTimeOffset = 1;
+			public const byte AccelX = 2;
+			public const byte AccelY = 3;
+			public const byte AccelZ = 4;
+			public const byte CalibratedAccelX = 5;
+			public const byte CalibratedAccelY = 6;
+			public const byte CalibratedAccelZ = 7;
+			public const byte CompressedCalibratedAccelX = 8;
+			public const byte CompressedCalibratedAccelY = 9;
+			public const byte CompressedCalibratedAccelZ = 10;
+			public const byte Invalid = Fit.FieldNumInvalid;
+		}
 
-        #region Constructors
-        public AccelerometerDataMesg() : base(Profile.GetMesg(MesgNum.AccelerometerData))
-        {
-        }
+		#region Constructors
+		public AccelerometerDataMesg() : base(Profile.GetMesg(MesgNum.AccelerometerData))
+		{
+		}
 
-        public AccelerometerDataMesg(Mesg mesg) : base(mesg)
-        {
-        }
-        #endregion // Constructors
+		public AccelerometerDataMesg(Mesg mesg) : base(mesg)
+		{
+		}
+		#endregion // Constructors
 
-        #region Methods
-        ///<summary>
-        /// Retrieves the Timestamp field
-        /// Units: s
-        /// Comment: Whole second part of the timestamp</summary>
-        /// <returns>Returns DateTime representing the Timestamp field</returns>
-        public DateTime GetTimestamp()
-        {
-            Object val = GetFieldValue(253, 0, Fit.SubfieldIndexMainField);
-            if(val == null)
-            {
-                return null;
-            }
+		#region Methods
+		///<summary>
+		/// Retrieves the Timestamp field
+		/// Units: s
+		/// Comment: Whole second part of the timestamp</summary>
+		/// <returns>Returns DateTime representing the Timestamp field</returns>
+		public DateTime Timestamp
+		{
+			get
+			{
+				Object val = GetFieldValue(253, 0, Fit.SubfieldIndexMainField);
+				if (val == null)
+				{
+					return null;
+				}
 
-            return TimestampToDateTime(Convert.ToUInt32(val));
-            
-        }
+				return TimestampToDateTime(Convert.ToUInt32(val));
 
-        /// <summary>
-        /// Set Timestamp field
-        /// Units: s
-        /// Comment: Whole second part of the timestamp</summary>
-        /// <param name="timestamp_">Nullable field value to be set</param>
-        public void SetTimestamp(DateTime timestamp_)
-        {
-            SetFieldValue(253, 0, timestamp_.GetTimeStamp(), Fit.SubfieldIndexMainField);
-        }
-        
-        ///<summary>
-        /// Retrieves the TimestampMs field
-        /// Units: ms
-        /// Comment: Millisecond part of the timestamp.</summary>
-        /// <returns>Returns nullable ushort representing the TimestampMs field</returns>
-        public ushort? GetTimestampMs()
-        {
-            Object val = GetFieldValue(0, 0, Fit.SubfieldIndexMainField);
-            if(val == null)
-            {
-                return null;
-            }
+			}
+			set
+			{
+				SetFieldValue(253, 0, value.GetTimeStamp(), Fit.SubfieldIndexMainField);
+			}
+		}
 
-            return (Convert.ToUInt16(val));
-            
-        }
+		///<summary>
+		/// Retrieves the TimestampMs field
+		/// Units: ms
+		/// Comment: Millisecond part of the timestamp.</summary>
+		/// <returns>Returns nullable ushort representing the TimestampMs field</returns>
+		public ushort? TimestampMs
+		{
+			get
+			{
+				Object val = GetFieldValue(0, 0, Fit.SubfieldIndexMainField);
+				if (val == null)
+				{
+					return null;
+				}
 
-        /// <summary>
-        /// Set TimestampMs field
-        /// Units: ms
-        /// Comment: Millisecond part of the timestamp.</summary>
-        /// <param name="timestampMs_">Nullable field value to be set</param>
-        public void SetTimestampMs(ushort? timestampMs_)
-        {
-            SetFieldValue(0, 0, timestampMs_, Fit.SubfieldIndexMainField);
-        }
-        
-        
-        /// <summary>
-        ///
-        /// </summary>
-        /// <returns>returns number of elements in field SampleTimeOffset</returns>
-        public int GetNumSampleTimeOffset()
-        {
-            return GetNumFieldValues(1, Fit.SubfieldIndexMainField);
-        }
+				return (Convert.ToUInt16(val));
 
-        ///<summary>
-        /// Retrieves the SampleTimeOffset field
-        /// Units: ms
-        /// Comment: Each time in the array describes the time at which the accelerometer sample with the corrosponding index was taken. Limited to 30 samples in each message. The samples may span across seconds. Array size must match the number of samples in accel_x and accel_y and accel_z</summary>
-        /// <param name="index">0 based index of SampleTimeOffset element to retrieve</param>
-        /// <returns>Returns nullable ushort representing the SampleTimeOffset field</returns>
-        public ushort? GetSampleTimeOffset(int index)
-        {
-            Object val = GetFieldValue(1, index, Fit.SubfieldIndexMainField);
-            if(val == null)
-            {
-                return null;
-            }
+			}
+			set
+			{
+				SetFieldValue(0, 0, value, Fit.SubfieldIndexMainField);
+			}
+		}
 
-            return (Convert.ToUInt16(val));
-            
-        }
 
-        /// <summary>
-        /// Set SampleTimeOffset field
-        /// Units: ms
-        /// Comment: Each time in the array describes the time at which the accelerometer sample with the corrosponding index was taken. Limited to 30 samples in each message. The samples may span across seconds. Array size must match the number of samples in accel_x and accel_y and accel_z</summary>
-        /// <param name="index">0 based index of sample_time_offset</param>
-        /// <param name="sampleTimeOffset_">Nullable field value to be set</param>
-        public void SetSampleTimeOffset(int index, ushort? sampleTimeOffset_)
-        {
-            SetFieldValue(1, index, sampleTimeOffset_, Fit.SubfieldIndexMainField);
-        }
-        
-        
-        /// <summary>
-        ///
-        /// </summary>
-        /// <returns>returns number of elements in field AccelX</returns>
-        public int GetNumAccelX()
-        {
-            return GetNumFieldValues(2, Fit.SubfieldIndexMainField);
-        }
+		/// <summary>
+		///
+		/// </summary>
+		/// <returns>returns number of elements in field SampleTimeOffset</returns>
+		public int GetNumSampleTimeOffset()
+		{
+			return GetNumFieldValues(1, Fit.SubfieldIndexMainField);
+		}
 
-        ///<summary>
-        /// Retrieves the AccelX field
-        /// Units: counts
-        /// Comment: These are the raw ADC reading. Maximum number of samples is 30 in each message. The samples may span across seconds. A conversion will need to be done on this data once read.</summary>
-        /// <param name="index">0 based index of AccelX element to retrieve</param>
-        /// <returns>Returns nullable ushort representing the AccelX field</returns>
-        public ushort? GetAccelX(int index)
-        {
-            Object val = GetFieldValue(2, index, Fit.SubfieldIndexMainField);
-            if(val == null)
-            {
-                return null;
-            }
+		///<summary>
+		/// Retrieves the SampleTimeOffset field
+		/// Units: ms
+		/// Comment: Each time in the array describes the time at which the accelerometer sample with the corrosponding index was taken. Limited to 30 samples in each message. The samples may span across seconds. Array size must match the number of samples in accel_x and accel_y and accel_z</summary>
+		/// <param name="index">0 based index of SampleTimeOffset element to retrieve</param>
+		/// <returns>Returns nullable ushort representing the SampleTimeOffset field</returns>
+		public ushort? GetSampleTimeOffset(int index)
+		{
+			Object val = GetFieldValue(1, index, Fit.SubfieldIndexMainField);
+			if (val == null)
+			{
+				return null;
+			}
 
-            return (Convert.ToUInt16(val));
-            
-        }
+			return (Convert.ToUInt16(val));
 
-        /// <summary>
-        /// Set AccelX field
-        /// Units: counts
-        /// Comment: These are the raw ADC reading. Maximum number of samples is 30 in each message. The samples may span across seconds. A conversion will need to be done on this data once read.</summary>
-        /// <param name="index">0 based index of accel_x</param>
-        /// <param name="accelX_">Nullable field value to be set</param>
-        public void SetAccelX(int index, ushort? accelX_)
-        {
-            SetFieldValue(2, index, accelX_, Fit.SubfieldIndexMainField);
-        }
-        
-        
-        /// <summary>
-        ///
-        /// </summary>
-        /// <returns>returns number of elements in field AccelY</returns>
-        public int GetNumAccelY()
-        {
-            return GetNumFieldValues(3, Fit.SubfieldIndexMainField);
-        }
+		}
 
-        ///<summary>
-        /// Retrieves the AccelY field
-        /// Units: counts
-        /// Comment: These are the raw ADC reading. Maximum number of samples is 30 in each message. The samples may span across seconds. A conversion will need to be done on this data once read.</summary>
-        /// <param name="index">0 based index of AccelY element to retrieve</param>
-        /// <returns>Returns nullable ushort representing the AccelY field</returns>
-        public ushort? GetAccelY(int index)
-        {
-            Object val = GetFieldValue(3, index, Fit.SubfieldIndexMainField);
-            if(val == null)
-            {
-                return null;
-            }
+		/// <summary>
+		/// Set SampleTimeOffset field
+		/// Units: ms
+		/// Comment: Each time in the array describes the time at which the accelerometer sample with the corrosponding index was taken. Limited to 30 samples in each message. The samples may span across seconds. Array size must match the number of samples in accel_x and accel_y and accel_z</summary>
+		/// <param name="index">0 based index of sample_time_offset</param>
+		/// <param name="sampleTimeOffset_">Nullable field value to be set</param>
+		public void SetSampleTimeOffset(int index, ushort? sampleTimeOffset_)
+		{
+			SetFieldValue(1, index, sampleTimeOffset_, Fit.SubfieldIndexMainField);
+		}
 
-            return (Convert.ToUInt16(val));
-            
-        }
 
-        /// <summary>
-        /// Set AccelY field
-        /// Units: counts
-        /// Comment: These are the raw ADC reading. Maximum number of samples is 30 in each message. The samples may span across seconds. A conversion will need to be done on this data once read.</summary>
-        /// <param name="index">0 based index of accel_y</param>
-        /// <param name="accelY_">Nullable field value to be set</param>
-        public void SetAccelY(int index, ushort? accelY_)
-        {
-            SetFieldValue(3, index, accelY_, Fit.SubfieldIndexMainField);
-        }
-        
-        
-        /// <summary>
-        ///
-        /// </summary>
-        /// <returns>returns number of elements in field AccelZ</returns>
-        public int GetNumAccelZ()
-        {
-            return GetNumFieldValues(4, Fit.SubfieldIndexMainField);
-        }
+		/// <summary>
+		///
+		/// </summary>
+		/// <returns>returns number of elements in field AccelX</returns>
+		public int GetNumAccelX()
+		{
+			return GetNumFieldValues(2, Fit.SubfieldIndexMainField);
+		}
 
-        ///<summary>
-        /// Retrieves the AccelZ field
-        /// Units: counts
-        /// Comment: These are the raw ADC reading. Maximum number of samples is 30 in each message. The samples may span across seconds. A conversion will need to be done on this data once read.</summary>
-        /// <param name="index">0 based index of AccelZ element to retrieve</param>
-        /// <returns>Returns nullable ushort representing the AccelZ field</returns>
-        public ushort? GetAccelZ(int index)
-        {
-            Object val = GetFieldValue(4, index, Fit.SubfieldIndexMainField);
-            if(val == null)
-            {
-                return null;
-            }
+		///<summary>
+		/// Retrieves the AccelX field
+		/// Units: counts
+		/// Comment: These are the raw ADC reading. Maximum number of samples is 30 in each message. The samples may span across seconds. A conversion will need to be done on this data once read.</summary>
+		/// <param name="index">0 based index of AccelX element to retrieve</param>
+		/// <returns>Returns nullable ushort representing the AccelX field</returns>
+		public ushort? GetAccelX(int index)
+		{
+			Object val = GetFieldValue(2, index, Fit.SubfieldIndexMainField);
+			if (val == null)
+			{
+				return null;
+			}
 
-            return (Convert.ToUInt16(val));
-            
-        }
+			return (Convert.ToUInt16(val));
 
-        /// <summary>
-        /// Set AccelZ field
-        /// Units: counts
-        /// Comment: These are the raw ADC reading. Maximum number of samples is 30 in each message. The samples may span across seconds. A conversion will need to be done on this data once read.</summary>
-        /// <param name="index">0 based index of accel_z</param>
-        /// <param name="accelZ_">Nullable field value to be set</param>
-        public void SetAccelZ(int index, ushort? accelZ_)
-        {
-            SetFieldValue(4, index, accelZ_, Fit.SubfieldIndexMainField);
-        }
-        
-        
-        /// <summary>
-        ///
-        /// </summary>
-        /// <returns>returns number of elements in field CalibratedAccelX</returns>
-        public int GetNumCalibratedAccelX()
-        {
-            return GetNumFieldValues(5, Fit.SubfieldIndexMainField);
-        }
+		}
 
-        ///<summary>
-        /// Retrieves the CalibratedAccelX field
-        /// Units: g
-        /// Comment: Calibrated accel reading</summary>
-        /// <param name="index">0 based index of CalibratedAccelX element to retrieve</param>
-        /// <returns>Returns nullable float representing the CalibratedAccelX field</returns>
-        public float? GetCalibratedAccelX(int index)
-        {
-            Object val = GetFieldValue(5, index, Fit.SubfieldIndexMainField);
-            if(val == null)
-            {
-                return null;
-            }
+		/// <summary>
+		/// Set AccelX field
+		/// Units: counts
+		/// Comment: These are the raw ADC reading. Maximum number of samples is 30 in each message. The samples may span across seconds. A conversion will need to be done on this data once read.</summary>
+		/// <param name="index">0 based index of accel_x</param>
+		/// <param name="accelX_">Nullable field value to be set</param>
+		public void SetAccelX(int index, ushort? accelX_)
+		{
+			SetFieldValue(2, index, accelX_, Fit.SubfieldIndexMainField);
+		}
 
-            return (Convert.ToSingle(val));
-            
-        }
 
-        /// <summary>
-        /// Set CalibratedAccelX field
-        /// Units: g
-        /// Comment: Calibrated accel reading</summary>
-        /// <param name="index">0 based index of calibrated_accel_x</param>
-        /// <param name="calibratedAccelX_">Nullable field value to be set</param>
-        public void SetCalibratedAccelX(int index, float? calibratedAccelX_)
-        {
-            SetFieldValue(5, index, calibratedAccelX_, Fit.SubfieldIndexMainField);
-        }
-        
-        
-        /// <summary>
-        ///
-        /// </summary>
-        /// <returns>returns number of elements in field CalibratedAccelY</returns>
-        public int GetNumCalibratedAccelY()
-        {
-            return GetNumFieldValues(6, Fit.SubfieldIndexMainField);
-        }
+		/// <summary>
+		///
+		/// </summary>
+		/// <returns>returns number of elements in field AccelY</returns>
+		public int GetNumAccelY()
+		{
+			return GetNumFieldValues(3, Fit.SubfieldIndexMainField);
+		}
 
-        ///<summary>
-        /// Retrieves the CalibratedAccelY field
-        /// Units: g
-        /// Comment: Calibrated accel reading</summary>
-        /// <param name="index">0 based index of CalibratedAccelY element to retrieve</param>
-        /// <returns>Returns nullable float representing the CalibratedAccelY field</returns>
-        public float? GetCalibratedAccelY(int index)
-        {
-            Object val = GetFieldValue(6, index, Fit.SubfieldIndexMainField);
-            if(val == null)
-            {
-                return null;
-            }
+		///<summary>
+		/// Retrieves the AccelY field
+		/// Units: counts
+		/// Comment: These are the raw ADC reading. Maximum number of samples is 30 in each message. The samples may span across seconds. A conversion will need to be done on this data once read.</summary>
+		/// <param name="index">0 based index of AccelY element to retrieve</param>
+		/// <returns>Returns nullable ushort representing the AccelY field</returns>
+		public ushort? GetAccelY(int index)
+		{
+			Object val = GetFieldValue(3, index, Fit.SubfieldIndexMainField);
+			if (val == null)
+			{
+				return null;
+			}
 
-            return (Convert.ToSingle(val));
-            
-        }
+			return (Convert.ToUInt16(val));
 
-        /// <summary>
-        /// Set CalibratedAccelY field
-        /// Units: g
-        /// Comment: Calibrated accel reading</summary>
-        /// <param name="index">0 based index of calibrated_accel_y</param>
-        /// <param name="calibratedAccelY_">Nullable field value to be set</param>
-        public void SetCalibratedAccelY(int index, float? calibratedAccelY_)
-        {
-            SetFieldValue(6, index, calibratedAccelY_, Fit.SubfieldIndexMainField);
-        }
-        
-        
-        /// <summary>
-        ///
-        /// </summary>
-        /// <returns>returns number of elements in field CalibratedAccelZ</returns>
-        public int GetNumCalibratedAccelZ()
-        {
-            return GetNumFieldValues(7, Fit.SubfieldIndexMainField);
-        }
+		}
 
-        ///<summary>
-        /// Retrieves the CalibratedAccelZ field
-        /// Units: g
-        /// Comment: Calibrated accel reading</summary>
-        /// <param name="index">0 based index of CalibratedAccelZ element to retrieve</param>
-        /// <returns>Returns nullable float representing the CalibratedAccelZ field</returns>
-        public float? GetCalibratedAccelZ(int index)
-        {
-            Object val = GetFieldValue(7, index, Fit.SubfieldIndexMainField);
-            if(val == null)
-            {
-                return null;
-            }
+		/// <summary>
+		/// Set AccelY field
+		/// Units: counts
+		/// Comment: These are the raw ADC reading. Maximum number of samples is 30 in each message. The samples may span across seconds. A conversion will need to be done on this data once read.</summary>
+		/// <param name="index">0 based index of accel_y</param>
+		/// <param name="accelY_">Nullable field value to be set</param>
+		public void SetAccelY(int index, ushort? accelY_)
+		{
+			SetFieldValue(3, index, accelY_, Fit.SubfieldIndexMainField);
+		}
 
-            return (Convert.ToSingle(val));
-            
-        }
 
-        /// <summary>
-        /// Set CalibratedAccelZ field
-        /// Units: g
-        /// Comment: Calibrated accel reading</summary>
-        /// <param name="index">0 based index of calibrated_accel_z</param>
-        /// <param name="calibratedAccelZ_">Nullable field value to be set</param>
-        public void SetCalibratedAccelZ(int index, float? calibratedAccelZ_)
-        {
-            SetFieldValue(7, index, calibratedAccelZ_, Fit.SubfieldIndexMainField);
-        }
-        
-        
-        /// <summary>
-        ///
-        /// </summary>
-        /// <returns>returns number of elements in field CompressedCalibratedAccelX</returns>
-        public int GetNumCompressedCalibratedAccelX()
-        {
-            return GetNumFieldValues(8, Fit.SubfieldIndexMainField);
-        }
+		/// <summary>
+		///
+		/// </summary>
+		/// <returns>returns number of elements in field AccelZ</returns>
+		public int GetNumAccelZ()
+		{
+			return GetNumFieldValues(4, Fit.SubfieldIndexMainField);
+		}
 
-        ///<summary>
-        /// Retrieves the CompressedCalibratedAccelX field
-        /// Units: mG
-        /// Comment: Calibrated accel reading</summary>
-        /// <param name="index">0 based index of CompressedCalibratedAccelX element to retrieve</param>
-        /// <returns>Returns nullable short representing the CompressedCalibratedAccelX field</returns>
-        public short? GetCompressedCalibratedAccelX(int index)
-        {
-            Object val = GetFieldValue(8, index, Fit.SubfieldIndexMainField);
-            if(val == null)
-            {
-                return null;
-            }
+		///<summary>
+		/// Retrieves the AccelZ field
+		/// Units: counts
+		/// Comment: These are the raw ADC reading. Maximum number of samples is 30 in each message. The samples may span across seconds. A conversion will need to be done on this data once read.</summary>
+		/// <param name="index">0 based index of AccelZ element to retrieve</param>
+		/// <returns>Returns nullable ushort representing the AccelZ field</returns>
+		public ushort? GetAccelZ(int index)
+		{
+			Object val = GetFieldValue(4, index, Fit.SubfieldIndexMainField);
+			if (val == null)
+			{
+				return null;
+			}
 
-            return (Convert.ToInt16(val));
-            
-        }
+			return (Convert.ToUInt16(val));
 
-        /// <summary>
-        /// Set CompressedCalibratedAccelX field
-        /// Units: mG
-        /// Comment: Calibrated accel reading</summary>
-        /// <param name="index">0 based index of compressed_calibrated_accel_x</param>
-        /// <param name="compressedCalibratedAccelX_">Nullable field value to be set</param>
-        public void SetCompressedCalibratedAccelX(int index, short? compressedCalibratedAccelX_)
-        {
-            SetFieldValue(8, index, compressedCalibratedAccelX_, Fit.SubfieldIndexMainField);
-        }
-        
-        
-        /// <summary>
-        ///
-        /// </summary>
-        /// <returns>returns number of elements in field CompressedCalibratedAccelY</returns>
-        public int GetNumCompressedCalibratedAccelY()
-        {
-            return GetNumFieldValues(9, Fit.SubfieldIndexMainField);
-        }
+		}
 
-        ///<summary>
-        /// Retrieves the CompressedCalibratedAccelY field
-        /// Units: mG
-        /// Comment: Calibrated accel reading</summary>
-        /// <param name="index">0 based index of CompressedCalibratedAccelY element to retrieve</param>
-        /// <returns>Returns nullable short representing the CompressedCalibratedAccelY field</returns>
-        public short? GetCompressedCalibratedAccelY(int index)
-        {
-            Object val = GetFieldValue(9, index, Fit.SubfieldIndexMainField);
-            if(val == null)
-            {
-                return null;
-            }
+		/// <summary>
+		/// Set AccelZ field
+		/// Units: counts
+		/// Comment: These are the raw ADC reading. Maximum number of samples is 30 in each message. The samples may span across seconds. A conversion will need to be done on this data once read.</summary>
+		/// <param name="index">0 based index of accel_z</param>
+		/// <param name="accelZ_">Nullable field value to be set</param>
+		public void SetAccelZ(int index, ushort? accelZ_)
+		{
+			SetFieldValue(4, index, accelZ_, Fit.SubfieldIndexMainField);
+		}
 
-            return (Convert.ToInt16(val));
-            
-        }
 
-        /// <summary>
-        /// Set CompressedCalibratedAccelY field
-        /// Units: mG
-        /// Comment: Calibrated accel reading</summary>
-        /// <param name="index">0 based index of compressed_calibrated_accel_y</param>
-        /// <param name="compressedCalibratedAccelY_">Nullable field value to be set</param>
-        public void SetCompressedCalibratedAccelY(int index, short? compressedCalibratedAccelY_)
-        {
-            SetFieldValue(9, index, compressedCalibratedAccelY_, Fit.SubfieldIndexMainField);
-        }
-        
-        
-        /// <summary>
-        ///
-        /// </summary>
-        /// <returns>returns number of elements in field CompressedCalibratedAccelZ</returns>
-        public int GetNumCompressedCalibratedAccelZ()
-        {
-            return GetNumFieldValues(10, Fit.SubfieldIndexMainField);
-        }
+		/// <summary>
+		///
+		/// </summary>
+		/// <returns>returns number of elements in field CalibratedAccelX</returns>
+		public int GetNumCalibratedAccelX()
+		{
+			return GetNumFieldValues(5, Fit.SubfieldIndexMainField);
+		}
 
-        ///<summary>
-        /// Retrieves the CompressedCalibratedAccelZ field
-        /// Units: mG
-        /// Comment: Calibrated accel reading</summary>
-        /// <param name="index">0 based index of CompressedCalibratedAccelZ element to retrieve</param>
-        /// <returns>Returns nullable short representing the CompressedCalibratedAccelZ field</returns>
-        public short? GetCompressedCalibratedAccelZ(int index)
-        {
-            Object val = GetFieldValue(10, index, Fit.SubfieldIndexMainField);
-            if(val == null)
-            {
-                return null;
-            }
+		///<summary>
+		/// Retrieves the CalibratedAccelX field
+		/// Units: g
+		/// Comment: Calibrated accel reading</summary>
+		/// <param name="index">0 based index of CalibratedAccelX element to retrieve</param>
+		/// <returns>Returns nullable float representing the CalibratedAccelX field</returns>
+		public float? GetCalibratedAccelX(int index)
+		{
+			Object val = GetFieldValue(5, index, Fit.SubfieldIndexMainField);
+			if (val == null)
+			{
+				return null;
+			}
 
-            return (Convert.ToInt16(val));
-            
-        }
+			return (Convert.ToSingle(val));
 
-        /// <summary>
-        /// Set CompressedCalibratedAccelZ field
-        /// Units: mG
-        /// Comment: Calibrated accel reading</summary>
-        /// <param name="index">0 based index of compressed_calibrated_accel_z</param>
-        /// <param name="compressedCalibratedAccelZ_">Nullable field value to be set</param>
-        public void SetCompressedCalibratedAccelZ(int index, short? compressedCalibratedAccelZ_)
-        {
-            SetFieldValue(10, index, compressedCalibratedAccelZ_, Fit.SubfieldIndexMainField);
-        }
-        
-        #endregion // Methods
-    } // Class
+		}
+
+		/// <summary>
+		/// Set CalibratedAccelX field
+		/// Units: g
+		/// Comment: Calibrated accel reading</summary>
+		/// <param name="index">0 based index of calibrated_accel_x</param>
+		/// <param name="calibratedAccelX_">Nullable field value to be set</param>
+		public void SetCalibratedAccelX(int index, float? calibratedAccelX_)
+		{
+			SetFieldValue(5, index, calibratedAccelX_, Fit.SubfieldIndexMainField);
+		}
+
+
+		/// <summary>
+		///
+		/// </summary>
+		/// <returns>returns number of elements in field CalibratedAccelY</returns>
+		public int GetNumCalibratedAccelY()
+		{
+			return GetNumFieldValues(6, Fit.SubfieldIndexMainField);
+		}
+
+		///<summary>
+		/// Retrieves the CalibratedAccelY field
+		/// Units: g
+		/// Comment: Calibrated accel reading</summary>
+		/// <param name="index">0 based index of CalibratedAccelY element to retrieve</param>
+		/// <returns>Returns nullable float representing the CalibratedAccelY field</returns>
+		public float? GetCalibratedAccelY(int index)
+		{
+			Object val = GetFieldValue(6, index, Fit.SubfieldIndexMainField);
+			if (val == null)
+			{
+				return null;
+			}
+
+			return (Convert.ToSingle(val));
+
+		}
+
+		/// <summary>
+		/// Set CalibratedAccelY field
+		/// Units: g
+		/// Comment: Calibrated accel reading</summary>
+		/// <param name="index">0 based index of calibrated_accel_y</param>
+		/// <param name="calibratedAccelY_">Nullable field value to be set</param>
+		public void SetCalibratedAccelY(int index, float? calibratedAccelY_)
+		{
+			SetFieldValue(6, index, calibratedAccelY_, Fit.SubfieldIndexMainField);
+		}
+
+
+		/// <summary>
+		///
+		/// </summary>
+		/// <returns>returns number of elements in field CalibratedAccelZ</returns>
+		public int GetNumCalibratedAccelZ()
+		{
+			return GetNumFieldValues(7, Fit.SubfieldIndexMainField);
+		}
+
+		///<summary>
+		/// Retrieves the CalibratedAccelZ field
+		/// Units: g
+		/// Comment: Calibrated accel reading</summary>
+		/// <param name="index">0 based index of CalibratedAccelZ element to retrieve</param>
+		/// <returns>Returns nullable float representing the CalibratedAccelZ field</returns>
+		public float? GetCalibratedAccelZ(int index)
+		{
+			Object val = GetFieldValue(7, index, Fit.SubfieldIndexMainField);
+			if (val == null)
+			{
+				return null;
+			}
+
+			return (Convert.ToSingle(val));
+
+		}
+
+		/// <summary>
+		/// Set CalibratedAccelZ field
+		/// Units: g
+		/// Comment: Calibrated accel reading</summary>
+		/// <param name="index">0 based index of calibrated_accel_z</param>
+		/// <param name="calibratedAccelZ_">Nullable field value to be set</param>
+		public void SetCalibratedAccelZ(int index, float? calibratedAccelZ_)
+		{
+			SetFieldValue(7, index, calibratedAccelZ_, Fit.SubfieldIndexMainField);
+		}
+
+
+		/// <summary>
+		///
+		/// </summary>
+		/// <returns>returns number of elements in field CompressedCalibratedAccelX</returns>
+		public int GetNumCompressedCalibratedAccelX()
+		{
+			return GetNumFieldValues(8, Fit.SubfieldIndexMainField);
+		}
+
+		///<summary>
+		/// Retrieves the CompressedCalibratedAccelX field
+		/// Units: mG
+		/// Comment: Calibrated accel reading</summary>
+		/// <param name="index">0 based index of CompressedCalibratedAccelX element to retrieve</param>
+		/// <returns>Returns nullable short representing the CompressedCalibratedAccelX field</returns>
+		public short? GetCompressedCalibratedAccelX(int index)
+		{
+			Object val = GetFieldValue(8, index, Fit.SubfieldIndexMainField);
+			if (val == null)
+			{
+				return null;
+			}
+
+			return (Convert.ToInt16(val));
+
+		}
+
+		/// <summary>
+		/// Set CompressedCalibratedAccelX field
+		/// Units: mG
+		/// Comment: Calibrated accel reading</summary>
+		/// <param name="index">0 based index of compressed_calibrated_accel_x</param>
+		/// <param name="compressedCalibratedAccelX_">Nullable field value to be set</param>
+		public void SetCompressedCalibratedAccelX(int index, short? compressedCalibratedAccelX_)
+		{
+			SetFieldValue(8, index, compressedCalibratedAccelX_, Fit.SubfieldIndexMainField);
+		}
+
+
+		/// <summary>
+		///
+		/// </summary>
+		/// <returns>returns number of elements in field CompressedCalibratedAccelY</returns>
+		public int GetNumCompressedCalibratedAccelY()
+		{
+			return GetNumFieldValues(9, Fit.SubfieldIndexMainField);
+		}
+
+		///<summary>
+		/// Retrieves the CompressedCalibratedAccelY field
+		/// Units: mG
+		/// Comment: Calibrated accel reading</summary>
+		/// <param name="index">0 based index of CompressedCalibratedAccelY element to retrieve</param>
+		/// <returns>Returns nullable short representing the CompressedCalibratedAccelY field</returns>
+		public short? GetCompressedCalibratedAccelY(int index)
+		{
+			Object val = GetFieldValue(9, index, Fit.SubfieldIndexMainField);
+			if (val == null)
+			{
+				return null;
+			}
+
+			return (Convert.ToInt16(val));
+
+		}
+
+		/// <summary>
+		/// Set CompressedCalibratedAccelY field
+		/// Units: mG
+		/// Comment: Calibrated accel reading</summary>
+		/// <param name="index">0 based index of compressed_calibrated_accel_y</param>
+		/// <param name="compressedCalibratedAccelY_">Nullable field value to be set</param>
+		public void SetCompressedCalibratedAccelY(int index, short? compressedCalibratedAccelY_)
+		{
+			SetFieldValue(9, index, compressedCalibratedAccelY_, Fit.SubfieldIndexMainField);
+		}
+
+
+		/// <summary>
+		///
+		/// </summary>
+		/// <returns>returns number of elements in field CompressedCalibratedAccelZ</returns>
+		public int GetNumCompressedCalibratedAccelZ()
+		{
+			return GetNumFieldValues(10, Fit.SubfieldIndexMainField);
+		}
+
+		///<summary>
+		/// Retrieves the CompressedCalibratedAccelZ field
+		/// Units: mG
+		/// Comment: Calibrated accel reading</summary>
+		/// <param name="index">0 based index of CompressedCalibratedAccelZ element to retrieve</param>
+		/// <returns>Returns nullable short representing the CompressedCalibratedAccelZ field</returns>
+		public short? GetCompressedCalibratedAccelZ(int index)
+		{
+			Object val = GetFieldValue(10, index, Fit.SubfieldIndexMainField);
+			if (val == null)
+			{
+				return null;
+			}
+
+			return (Convert.ToInt16(val));
+
+		}
+
+		/// <summary>
+		/// Set CompressedCalibratedAccelZ field
+		/// Units: mG
+		/// Comment: Calibrated accel reading</summary>
+		/// <param name="index">0 based index of compressed_calibrated_accel_z</param>
+		/// <param name="compressedCalibratedAccelZ_">Nullable field value to be set</param>
+		public void SetCompressedCalibratedAccelZ(int index, short? compressedCalibratedAccelZ_)
+		{
+			SetFieldValue(10, index, compressedCalibratedAccelZ_, Fit.SubfieldIndexMainField);
+		}
+
+		#endregion // Methods
+	} // Class
 } // namespace

--- a/Dynastream/Fit/Profile/Mesgs/ActivityMesg.cs
+++ b/Dynastream/Fit/Profile/Mesgs/ActivityMesg.cs
@@ -21,216 +21,205 @@ using System.Linq;
 
 namespace Dynastream.Fit
 {
-    /// <summary>
-    /// Implements the Activity profile message.
-    /// </summary>
-    public class ActivityMesg : Mesg
-    {
-        #region Fields
-        #endregion
+	/// <summary>
+	/// Implements the Activity profile message.
+	/// </summary>
+	public class ActivityMesg : Mesg
+	{
+		#region Fields
+		#endregion
 
-        /// <summary>
-        /// Field Numbers for <see cref="ActivityMesg"/>
-        /// </summary>
-        public sealed class FieldDefNum
-        {
-            public const byte Timestamp = 253;
-            public const byte TotalTimerTime = 0;
-            public const byte NumSessions = 1;
-            public const byte Type = 2;
-            public const byte Event = 3;
-            public const byte EventType = 4;
-            public const byte LocalTimestamp = 5;
-            public const byte EventGroup = 6;
-            public const byte Invalid = Fit.FieldNumInvalid;
-        }
+		/// <summary>
+		/// Field Numbers for <see cref="ActivityMesg"/>
+		/// </summary>
+		public sealed class FieldDefNum
+		{
+			public const byte Timestamp = 253;
+			public const byte TotalTimerTime = 0;
+			public const byte NumSessions = 1;
+			public const byte Type = 2;
+			public const byte Event = 3;
+			public const byte EventType = 4;
+			public const byte LocalTimestamp = 5;
+			public const byte EventGroup = 6;
+			public const byte Invalid = Fit.FieldNumInvalid;
+		}
 
-        #region Constructors
-        public ActivityMesg() : base(Profile.GetMesg(MesgNum.Activity))
-        {
-        }
+		#region Constructors
+		public ActivityMesg() : base(Profile.GetMesg(MesgNum.Activity))
+		{
+		}
 
-        public ActivityMesg(Mesg mesg) : base(mesg)
-        {
-        }
-        #endregion // Constructors
+		public ActivityMesg(Mesg mesg) : base(mesg)
+		{
+		}
+		#endregion // Constructors
 
-        #region Methods
-        ///<summary>
-        /// Retrieves the Timestamp field</summary>
-        /// <returns>Returns DateTime representing the Timestamp field</returns>
-        public DateTime GetTimestamp()
-        {
-            Object val = GetFieldValue(253, 0, Fit.SubfieldIndexMainField);
-            if(val == null)
-            {
-                return null;
-            }
+		#region Methods
+		///<summary>
+		/// Retrieves the Timestamp field</summary>
+		/// <returns>Returns DateTime representing the Timestamp field</returns>
+		public DateTime Timestamp
+		{
+			get
+			{
+				Object val = GetFieldValue(253, 0, Fit.SubfieldIndexMainField);
+				if (val == null)
+				{
+					return null;
+				}
 
-            return TimestampToDateTime(Convert.ToUInt32(val));
-            
-        }
+				return TimestampToDateTime(Convert.ToUInt32(val));
 
-        /// <summary>
-        /// Set Timestamp field</summary>
-        /// <param name="timestamp_">Nullable field value to be set</param>
-        public void SetTimestamp(DateTime timestamp_)
-        {
-            SetFieldValue(253, 0, timestamp_.GetTimeStamp(), Fit.SubfieldIndexMainField);
-        }
-        
-        ///<summary>
-        /// Retrieves the TotalTimerTime field
-        /// Units: s
-        /// Comment: Exclude pauses</summary>
-        /// <returns>Returns nullable float representing the TotalTimerTime field</returns>
-        public float? GetTotalTimerTime()
-        {
-            Object val = GetFieldValue(0, 0, Fit.SubfieldIndexMainField);
-            if(val == null)
-            {
-                return null;
-            }
+			}
+			set
+			{
+				SetFieldValue(253, 0, value.GetTimeStamp(), Fit.SubfieldIndexMainField);
+			}
+		}
 
-            return (Convert.ToSingle(val));
-            
-        }
+		///<summary>
+		/// Retrieves the TotalTimerTime field
+		/// Units: s
+		/// Comment: Exclude pauses</summary>
+		/// <returns>Returns nullable float representing the TotalTimerTime field</returns>
+		public float? TotalTimerTime
+		{
+			get
+			{
+				Object val = GetFieldValue(0, 0, Fit.SubfieldIndexMainField);
+				if (val == null)
+				{
+					return null;
+				}
 
-        /// <summary>
-        /// Set TotalTimerTime field
-        /// Units: s
-        /// Comment: Exclude pauses</summary>
-        /// <param name="totalTimerTime_">Nullable field value to be set</param>
-        public void SetTotalTimerTime(float? totalTimerTime_)
-        {
-            SetFieldValue(0, 0, totalTimerTime_, Fit.SubfieldIndexMainField);
-        }
-        
-        ///<summary>
-        /// Retrieves the NumSessions field</summary>
-        /// <returns>Returns nullable ushort representing the NumSessions field</returns>
-        public ushort? GetNumSessions()
-        {
-            Object val = GetFieldValue(1, 0, Fit.SubfieldIndexMainField);
-            if(val == null)
-            {
-                return null;
-            }
+				return (Convert.ToSingle(val));
 
-            return (Convert.ToUInt16(val));
-            
-        }
+			}
+			set
+			{
+				SetFieldValue(0, 0, value, Fit.SubfieldIndexMainField);
+			}
+		}
 
-        /// <summary>
-        /// Set NumSessions field</summary>
-        /// <param name="numSessions_">Nullable field value to be set</param>
-        public void SetNumSessions(ushort? numSessions_)
-        {
-            SetFieldValue(1, 0, numSessions_, Fit.SubfieldIndexMainField);
-        }
-        
-        ///<summary>
-        /// Retrieves the Type field</summary>
-        /// <returns>Returns nullable Activity enum representing the Type field</returns>
-        new public Activity? GetType()
-        {
-            object obj = GetFieldValue(2, 0, Fit.SubfieldIndexMainField);
-            Activity? value = obj == null ? (Activity?)null : (Activity)obj;
-            return value;
-        }
+		///<summary>
+		/// Retrieves the NumSessions field</summary>
+		/// <returns>Returns nullable ushort representing the NumSessions field</returns>
+		public ushort? NumSessions
+		{
+			get
+			{
+				Object val = GetFieldValue(1, 0, Fit.SubfieldIndexMainField);
+				if (val == null)
+				{
+					return null;
+				}
 
-        /// <summary>
-        /// Set Type field</summary>
-        /// <param name="type_">Nullable field value to be set</param>
-        public void SetType(Activity? type_)
-        {
-            SetFieldValue(2, 0, type_, Fit.SubfieldIndexMainField);
-        }
-        
-        ///<summary>
-        /// Retrieves the Event field</summary>
-        /// <returns>Returns nullable Event enum representing the Event field</returns>
-        public Event? GetEvent()
-        {
-            object obj = GetFieldValue(3, 0, Fit.SubfieldIndexMainField);
-            Event? value = obj == null ? (Event?)null : (Event)obj;
-            return value;
-        }
+				return (Convert.ToUInt16(val));
 
-        /// <summary>
-        /// Set Event field</summary>
-        /// <param name="event_">Nullable field value to be set</param>
-        public void SetEvent(Event? event_)
-        {
-            SetFieldValue(3, 0, event_, Fit.SubfieldIndexMainField);
-        }
-        
-        ///<summary>
-        /// Retrieves the EventType field</summary>
-        /// <returns>Returns nullable EventType enum representing the EventType field</returns>
-        public EventType? GetEventType()
-        {
-            object obj = GetFieldValue(4, 0, Fit.SubfieldIndexMainField);
-            EventType? value = obj == null ? (EventType?)null : (EventType)obj;
-            return value;
-        }
+			}
+			set
+			{
+				SetFieldValue(1, 0, value, Fit.SubfieldIndexMainField);
+			}
+		}
 
-        /// <summary>
-        /// Set EventType field</summary>
-        /// <param name="eventType_">Nullable field value to be set</param>
-        public void SetEventType(EventType? eventType_)
-        {
-            SetFieldValue(4, 0, eventType_, Fit.SubfieldIndexMainField);
-        }
-        
-        ///<summary>
-        /// Retrieves the LocalTimestamp field
-        /// Comment: timestamp epoch expressed in local time, used to convert activity timestamps to local time</summary>
-        /// <returns>Returns nullable uint representing the LocalTimestamp field</returns>
-        public uint? GetLocalTimestamp()
-        {
-            Object val = GetFieldValue(5, 0, Fit.SubfieldIndexMainField);
-            if(val == null)
-            {
-                return null;
-            }
+		///<summary>
+		/// Retrieves the Type field</summary>
+		/// <returns>Returns nullable Activity enum representing the Type field</returns>
+		public Activity? Type
+		{
+			get
+			{
+				object obj = GetFieldValue(2, 0, Fit.SubfieldIndexMainField);
+				Activity? value = obj == null ? (Activity?)null : (Activity)obj;
+				return value;
+			}
+			set
+			{
+				SetFieldValue(2, 0, value, Fit.SubfieldIndexMainField);
+			}
+		}
 
-            return (Convert.ToUInt32(val));
-            
-        }
+		///<summary>
+		/// Retrieves the Event field</summary>
+		/// <returns>Returns nullable Event enum representing the Event field</returns>
+		public Event? Event
+		{
+			get
+			{
+				object obj = GetFieldValue(3, 0, Fit.SubfieldIndexMainField);
+				Event? value = obj == null ? (Event?)null : (Event)obj;
+				return value;
+			}
+			set
+			{
+				SetFieldValue(3, 0, value, Fit.SubfieldIndexMainField);
+			}
+		}
 
-        /// <summary>
-        /// Set LocalTimestamp field
-        /// Comment: timestamp epoch expressed in local time, used to convert activity timestamps to local time</summary>
-        /// <param name="localTimestamp_">Nullable field value to be set</param>
-        public void SetLocalTimestamp(uint? localTimestamp_)
-        {
-            SetFieldValue(5, 0, localTimestamp_, Fit.SubfieldIndexMainField);
-        }
-        
-        ///<summary>
-        /// Retrieves the EventGroup field</summary>
-        /// <returns>Returns nullable byte representing the EventGroup field</returns>
-        public byte? GetEventGroup()
-        {
-            Object val = GetFieldValue(6, 0, Fit.SubfieldIndexMainField);
-            if(val == null)
-            {
-                return null;
-            }
+		///<summary>
+		/// Retrieves the EventType field</summary>
+		/// <returns>Returns nullable EventType enum representing the EventType field</returns>
+		public EventType? EventType
+		{
+			get
+			{
+				object obj = GetFieldValue(4, 0, Fit.SubfieldIndexMainField);
+				EventType? value = obj == null ? (EventType?)null : (EventType)obj;
+				return value;
+			}
+			set
+			{
+				SetFieldValue(4, 0, value, Fit.SubfieldIndexMainField);
+			}
+		}
 
-            return (Convert.ToByte(val));
-            
-        }
+		///<summary>
+		/// Retrieves the LocalTimestamp field
+		/// Comment: timestamp epoch expressed in local time, used to convert activity timestamps to local time</summary>
+		/// <returns>Returns nullable uint representing the LocalTimestamp field</returns>
+		public uint? LocalTimestamp
+		{
+			get
+			{
+				Object val = GetFieldValue(5, 0, Fit.SubfieldIndexMainField);
+				if (val == null)
+				{
+					return null;
+				}
 
-        /// <summary>
-        /// Set EventGroup field</summary>
-        /// <param name="eventGroup_">Nullable field value to be set</param>
-        public void SetEventGroup(byte? eventGroup_)
-        {
-            SetFieldValue(6, 0, eventGroup_, Fit.SubfieldIndexMainField);
-        }
-        
-        #endregion // Methods
-    } // Class
+				return (Convert.ToUInt32(val));
+
+			}
+			set
+			{
+				SetFieldValue(5, 0, value, Fit.SubfieldIndexMainField);
+			}
+		}
+
+		///<summary>
+		/// Retrieves the EventGroup field</summary>
+		/// <returns>Returns nullable byte representing the EventGroup field</returns>
+		public byte? EventGroup
+		{
+			get
+			{
+				Object val = GetFieldValue(6, 0, Fit.SubfieldIndexMainField);
+				if (val == null)
+				{
+					return null;
+				}
+
+				return (Convert.ToByte(val));
+
+			}
+			set
+			{
+				SetFieldValue(6, 0, value, Fit.SubfieldIndexMainField);
+			}
+		}
+
+		#endregion // Methods
+	} // Class
 } // namespace

--- a/Dynastream/Fit/Profile/Mesgs/AntChannelIdMesg.cs
+++ b/Dynastream/Fit/Profile/Mesgs/AntChannelIdMesg.cs
@@ -21,153 +21,148 @@ using System.Linq;
 
 namespace Dynastream.Fit
 {
-    /// <summary>
-    /// Implements the AntChannelId profile message.
-    /// </summary>
-    public class AntChannelIdMesg : Mesg
-    {
-        #region Fields
-        #endregion
+	/// <summary>
+	/// Implements the AntChannelId profile message.
+	/// </summary>
+	public class AntChannelIdMesg : Mesg
+	{
+		#region Fields
+		#endregion
 
-        /// <summary>
-        /// Field Numbers for <see cref="AntChannelIdMesg"/>
-        /// </summary>
-        public sealed class FieldDefNum
-        {
-            public const byte ChannelNumber = 0;
-            public const byte DeviceType = 1;
-            public const byte DeviceNumber = 2;
-            public const byte TransmissionType = 3;
-            public const byte DeviceIndex = 4;
-            public const byte Invalid = Fit.FieldNumInvalid;
-        }
+		/// <summary>
+		/// Field Numbers for <see cref="AntChannelIdMesg"/>
+		/// </summary>
+		public sealed class FieldDefNum
+		{
+			public const byte ChannelNumber = 0;
+			public const byte DeviceType = 1;
+			public const byte DeviceNumber = 2;
+			public const byte TransmissionType = 3;
+			public const byte DeviceIndex = 4;
+			public const byte Invalid = Fit.FieldNumInvalid;
+		}
 
-        #region Constructors
-        public AntChannelIdMesg() : base(Profile.GetMesg(MesgNum.AntChannelId))
-        {
-        }
+		#region Constructors
+		public AntChannelIdMesg() : base(Profile.GetMesg(MesgNum.AntChannelId))
+		{
+		}
 
-        public AntChannelIdMesg(Mesg mesg) : base(mesg)
-        {
-        }
-        #endregion // Constructors
+		public AntChannelIdMesg(Mesg mesg) : base(mesg)
+		{
+		}
+		#endregion // Constructors
 
-        #region Methods
-        ///<summary>
-        /// Retrieves the ChannelNumber field</summary>
-        /// <returns>Returns nullable byte representing the ChannelNumber field</returns>
-        public byte? GetChannelNumber()
-        {
-            Object val = GetFieldValue(0, 0, Fit.SubfieldIndexMainField);
-            if(val == null)
-            {
-                return null;
-            }
+		#region Methods
+		///<summary>
+		/// Retrieves the ChannelNumber field</summary>
+		/// <returns>Returns nullable byte representing the ChannelNumber field</returns>
+		public byte? ChannelNumber
+		{
+			get
+			{
+				Object val = GetFieldValue(0, 0, Fit.SubfieldIndexMainField);
+				if (val == null)
+				{
+					return null;
+				}
 
-            return (Convert.ToByte(val));
-            
-        }
+				return (Convert.ToByte(val));
 
-        /// <summary>
-        /// Set ChannelNumber field</summary>
-        /// <param name="channelNumber_">Nullable field value to be set</param>
-        public void SetChannelNumber(byte? channelNumber_)
-        {
-            SetFieldValue(0, 0, channelNumber_, Fit.SubfieldIndexMainField);
-        }
-        
-        ///<summary>
-        /// Retrieves the DeviceType field</summary>
-        /// <returns>Returns nullable byte representing the DeviceType field</returns>
-        public byte? GetDeviceType()
-        {
-            Object val = GetFieldValue(1, 0, Fit.SubfieldIndexMainField);
-            if(val == null)
-            {
-                return null;
-            }
+			}
+			set
+			{
+				SetFieldValue(0, 0, value, Fit.SubfieldIndexMainField);
+			}
+		}
 
-            return (Convert.ToByte(val));
-            
-        }
+		///<summary>
+		/// Retrieves the DeviceType field</summary>
+		/// <returns>Returns nullable byte representing the DeviceType field</returns>
+		public byte? DeviceType
+		{
+			get
+			{
+				Object val = GetFieldValue(1, 0, Fit.SubfieldIndexMainField);
+				if (val == null)
+				{
+					return null;
+				}
 
-        /// <summary>
-        /// Set DeviceType field</summary>
-        /// <param name="deviceType_">Nullable field value to be set</param>
-        public void SetDeviceType(byte? deviceType_)
-        {
-            SetFieldValue(1, 0, deviceType_, Fit.SubfieldIndexMainField);
-        }
-        
-        ///<summary>
-        /// Retrieves the DeviceNumber field</summary>
-        /// <returns>Returns nullable ushort representing the DeviceNumber field</returns>
-        public ushort? GetDeviceNumber()
-        {
-            Object val = GetFieldValue(2, 0, Fit.SubfieldIndexMainField);
-            if(val == null)
-            {
-                return null;
-            }
+				return (Convert.ToByte(val));
 
-            return (Convert.ToUInt16(val));
-            
-        }
+			}
+			set
+			{
+				SetFieldValue(1, 0, value, Fit.SubfieldIndexMainField);
+			}
+		}
 
-        /// <summary>
-        /// Set DeviceNumber field</summary>
-        /// <param name="deviceNumber_">Nullable field value to be set</param>
-        public void SetDeviceNumber(ushort? deviceNumber_)
-        {
-            SetFieldValue(2, 0, deviceNumber_, Fit.SubfieldIndexMainField);
-        }
-        
-        ///<summary>
-        /// Retrieves the TransmissionType field</summary>
-        /// <returns>Returns nullable byte representing the TransmissionType field</returns>
-        public byte? GetTransmissionType()
-        {
-            Object val = GetFieldValue(3, 0, Fit.SubfieldIndexMainField);
-            if(val == null)
-            {
-                return null;
-            }
+		///<summary>
+		/// Retrieves the DeviceNumber field</summary>
+		/// <returns>Returns nullable ushort representing the DeviceNumber field</returns>
+		public ushort? DeviceNumber
+		{
+			get
+			{
+				Object val = GetFieldValue(2, 0, Fit.SubfieldIndexMainField);
+				if (val == null)
+				{
+					return null;
+				}
 
-            return (Convert.ToByte(val));
-            
-        }
+				return (Convert.ToUInt16(val));
 
-        /// <summary>
-        /// Set TransmissionType field</summary>
-        /// <param name="transmissionType_">Nullable field value to be set</param>
-        public void SetTransmissionType(byte? transmissionType_)
-        {
-            SetFieldValue(3, 0, transmissionType_, Fit.SubfieldIndexMainField);
-        }
-        
-        ///<summary>
-        /// Retrieves the DeviceIndex field</summary>
-        /// <returns>Returns nullable byte representing the DeviceIndex field</returns>
-        public byte? GetDeviceIndex()
-        {
-            Object val = GetFieldValue(4, 0, Fit.SubfieldIndexMainField);
-            if(val == null)
-            {
-                return null;
-            }
+			}
+			set
+			{
+				SetFieldValue(2, 0, value, Fit.SubfieldIndexMainField);
+			}
+		}
 
-            return (Convert.ToByte(val));
-            
-        }
+		///<summary>
+		/// Retrieves the TransmissionType field</summary>
+		/// <returns>Returns nullable byte representing the TransmissionType field</returns>
+		public byte? TransmissionType
+		{
+			get
+			{
+				Object val = GetFieldValue(3, 0, Fit.SubfieldIndexMainField);
+				if (val == null)
+				{
+					return null;
+				}
 
-        /// <summary>
-        /// Set DeviceIndex field</summary>
-        /// <param name="deviceIndex_">Nullable field value to be set</param>
-        public void SetDeviceIndex(byte? deviceIndex_)
-        {
-            SetFieldValue(4, 0, deviceIndex_, Fit.SubfieldIndexMainField);
-        }
-        
-        #endregion // Methods
-    } // Class
+				return (Convert.ToByte(val));
+
+			}
+			set
+			{
+				SetFieldValue(3, 0, value, Fit.SubfieldIndexMainField);
+			}
+		}
+
+		///<summary>
+		/// Retrieves the DeviceIndex field</summary>
+		/// <returns>Returns nullable byte representing the DeviceIndex field</returns>
+		public byte? DeviceIndex
+		{
+			get
+			{
+				Object val = GetFieldValue(4, 0, Fit.SubfieldIndexMainField);
+				if (val == null)
+				{
+					return null;
+				}
+
+				return (Convert.ToByte(val));
+
+			}
+			set
+			{
+				SetFieldValue(4, 0, value, Fit.SubfieldIndexMainField);
+			}
+		}
+
+		#endregion // Methods
+	} // Class
 } // namespace

--- a/Dynastream/Fit/Profile/Mesgs/AntRxMesg.cs
+++ b/Dynastream/Fit/Profile/Mesgs/AntRxMesg.cs
@@ -21,205 +21,199 @@ using System.Linq;
 
 namespace Dynastream.Fit
 {
-    /// <summary>
-    /// Implements the AntRx profile message.
-    /// </summary>
-    public class AntRxMesg : Mesg
-    {
-        #region Fields
-        #endregion
+	/// <summary>
+	/// Implements the AntRx profile message.
+	/// </summary>
+	public class AntRxMesg : Mesg
+	{
+		#region Fields
+		#endregion
 
-        /// <summary>
-        /// Field Numbers for <see cref="AntRxMesg"/>
-        /// </summary>
-        public sealed class FieldDefNum
-        {
-            public const byte Timestamp = 253;
-            public const byte FractionalTimestamp = 0;
-            public const byte MesgId = 1;
-            public const byte MesgData = 2;
-            public const byte ChannelNumber = 3;
-            public const byte Data = 4;
-            public const byte Invalid = Fit.FieldNumInvalid;
-        }
+		/// <summary>
+		/// Field Numbers for <see cref="AntRxMesg"/>
+		/// </summary>
+		public sealed class FieldDefNum
+		{
+			public const byte Timestamp = 253;
+			public const byte FractionalTimestamp = 0;
+			public const byte MesgId = 1;
+			public const byte MesgData = 2;
+			public const byte ChannelNumber = 3;
+			public const byte Data = 4;
+			public const byte Invalid = Fit.FieldNumInvalid;
+		}
 
-        #region Constructors
-        public AntRxMesg() : base(Profile.GetMesg(MesgNum.AntRx))
-        {
-        }
+		#region Constructors
+		public AntRxMesg() : base(Profile.GetMesg(MesgNum.AntRx))
+		{
+		}
 
-        public AntRxMesg(Mesg mesg) : base(mesg)
-        {
-        }
-        #endregion // Constructors
+		public AntRxMesg(Mesg mesg) : base(mesg)
+		{
+		}
+		#endregion // Constructors
 
-        #region Methods
-        ///<summary>
-        /// Retrieves the Timestamp field
-        /// Units: s</summary>
-        /// <returns>Returns DateTime representing the Timestamp field</returns>
-        public DateTime GetTimestamp()
-        {
-            Object val = GetFieldValue(253, 0, Fit.SubfieldIndexMainField);
-            if(val == null)
-            {
-                return null;
-            }
+		#region Methods
+		///<summary>
+		/// Retrieves the Timestamp field
+		/// Units: s</summary>
+		/// <returns>Returns DateTime representing the Timestamp field</returns>
+		public DateTime Timestamp
+		{
+			get
+			{
+				Object val = GetFieldValue(253, 0, Fit.SubfieldIndexMainField);
+				if (val == null)
+				{
+					return null;
+				}
 
-            return TimestampToDateTime(Convert.ToUInt32(val));
-            
-        }
+				return TimestampToDateTime(Convert.ToUInt32(val));
 
-        /// <summary>
-        /// Set Timestamp field
-        /// Units: s</summary>
-        /// <param name="timestamp_">Nullable field value to be set</param>
-        public void SetTimestamp(DateTime timestamp_)
-        {
-            SetFieldValue(253, 0, timestamp_.GetTimeStamp(), Fit.SubfieldIndexMainField);
-        }
-        
-        ///<summary>
-        /// Retrieves the FractionalTimestamp field
-        /// Units: s</summary>
-        /// <returns>Returns nullable float representing the FractionalTimestamp field</returns>
-        public float? GetFractionalTimestamp()
-        {
-            Object val = GetFieldValue(0, 0, Fit.SubfieldIndexMainField);
-            if(val == null)
-            {
-                return null;
-            }
+			}
+			set
+			{
+				SetFieldValue(253, 0, value.GetTimeStamp(), Fit.SubfieldIndexMainField);
+			}
+		}
 
-            return (Convert.ToSingle(val));
-            
-        }
+		///<summary>
+		/// Retrieves the FractionalTimestamp field
+		/// Units: s</summary>
+		/// <returns>Returns nullable float representing the FractionalTimestamp field</returns>
+		public float? FractionalTimestamp
+		{
+			get
+			{
+				Object val = GetFieldValue(0, 0, Fit.SubfieldIndexMainField);
+				if (val == null)
+				{
+					return null;
+				}
 
-        /// <summary>
-        /// Set FractionalTimestamp field
-        /// Units: s</summary>
-        /// <param name="fractionalTimestamp_">Nullable field value to be set</param>
-        public void SetFractionalTimestamp(float? fractionalTimestamp_)
-        {
-            SetFieldValue(0, 0, fractionalTimestamp_, Fit.SubfieldIndexMainField);
-        }
-        
-        ///<summary>
-        /// Retrieves the MesgId field</summary>
-        /// <returns>Returns nullable byte representing the MesgId field</returns>
-        public byte? GetMesgId()
-        {
-            Object val = GetFieldValue(1, 0, Fit.SubfieldIndexMainField);
-            if(val == null)
-            {
-                return null;
-            }
+				return (Convert.ToSingle(val));
 
-            return (Convert.ToByte(val));
-            
-        }
+			}
+			set
+			{
+				SetFieldValue(0, 0, value, Fit.SubfieldIndexMainField);
+			}
+		}
 
-        /// <summary>
-        /// Set MesgId field</summary>
-        /// <param name="mesgId_">Nullable field value to be set</param>
-        public void SetMesgId(byte? mesgId_)
-        {
-            SetFieldValue(1, 0, mesgId_, Fit.SubfieldIndexMainField);
-        }
-        
-        
-        /// <summary>
-        ///
-        /// </summary>
-        /// <returns>returns number of elements in field MesgData</returns>
-        public int GetNumMesgData()
-        {
-            return GetNumFieldValues(2, Fit.SubfieldIndexMainField);
-        }
+		///<summary>
+		/// Retrieves the MesgId field</summary>
+		/// <returns>Returns nullable byte representing the MesgId field</returns>
+		public byte? MesgId
+		{
+			get
+			{
+				Object val = GetFieldValue(1, 0, Fit.SubfieldIndexMainField);
+				if (val == null)
+				{
+					return null;
+				}
 
-        ///<summary>
-        /// Retrieves the MesgData field</summary>
-        /// <param name="index">0 based index of MesgData element to retrieve</param>
-        /// <returns>Returns nullable byte representing the MesgData field</returns>
-        public byte? GetMesgData(int index)
-        {
-            Object val = GetFieldValue(2, index, Fit.SubfieldIndexMainField);
-            if(val == null)
-            {
-                return null;
-            }
+				return (Convert.ToByte(val));
 
-            return (Convert.ToByte(val));
-            
-        }
+			}
+			set
+			{
+				SetFieldValue(1, 0, value, Fit.SubfieldIndexMainField);
+			}
+		}
 
-        /// <summary>
-        /// Set MesgData field</summary>
-        /// <param name="index">0 based index of mesg_data</param>
-        /// <param name="mesgData_">Nullable field value to be set</param>
-        public void SetMesgData(int index, byte? mesgData_)
-        {
-            SetFieldValue(2, index, mesgData_, Fit.SubfieldIndexMainField);
-        }
-        
-        ///<summary>
-        /// Retrieves the ChannelNumber field</summary>
-        /// <returns>Returns nullable byte representing the ChannelNumber field</returns>
-        public byte? GetChannelNumber()
-        {
-            Object val = GetFieldValue(3, 0, Fit.SubfieldIndexMainField);
-            if(val == null)
-            {
-                return null;
-            }
 
-            return (Convert.ToByte(val));
-            
-        }
+		/// <summary>
+		///
+		/// </summary>
+		/// <returns>returns number of elements in field MesgData</returns>
+		public int GetNumMesgData()
+		{
+			return GetNumFieldValues(2, Fit.SubfieldIndexMainField);
+		}
 
-        /// <summary>
-        /// Set ChannelNumber field</summary>
-        /// <param name="channelNumber_">Nullable field value to be set</param>
-        public void SetChannelNumber(byte? channelNumber_)
-        {
-            SetFieldValue(3, 0, channelNumber_, Fit.SubfieldIndexMainField);
-        }
-        
-        
-        /// <summary>
-        ///
-        /// </summary>
-        /// <returns>returns number of elements in field Data</returns>
-        public int GetNumData()
-        {
-            return GetNumFieldValues(4, Fit.SubfieldIndexMainField);
-        }
+		///<summary>
+		/// Retrieves the MesgData field</summary>
+		/// <param name="index">0 based index of MesgData element to retrieve</param>
+		/// <returns>Returns nullable byte representing the MesgData field</returns>
+		public byte? GetMesgData(int index)
+		{
+			Object val = GetFieldValue(2, index, Fit.SubfieldIndexMainField);
+			if (val == null)
+			{
+				return null;
+			}
 
-        ///<summary>
-        /// Retrieves the Data field</summary>
-        /// <param name="index">0 based index of Data element to retrieve</param>
-        /// <returns>Returns nullable byte representing the Data field</returns>
-        public byte? GetData(int index)
-        {
-            Object val = GetFieldValue(4, index, Fit.SubfieldIndexMainField);
-            if(val == null)
-            {
-                return null;
-            }
+			return (Convert.ToByte(val));
 
-            return (Convert.ToByte(val));
-            
-        }
+		}
 
-        /// <summary>
-        /// Set Data field</summary>
-        /// <param name="index">0 based index of data</param>
-        /// <param name="data_">Nullable field value to be set</param>
-        public void SetData(int index, byte? data_)
-        {
-            SetFieldValue(4, index, data_, Fit.SubfieldIndexMainField);
-        }
-        
-        #endregion // Methods
-    } // Class
+		/// <summary>
+		/// Set MesgData field</summary>
+		/// <param name="index">0 based index of mesg_data</param>
+		/// <param name="mesgData_">Nullable field value to be set</param>
+		public void SetMesgData(int index, byte? mesgData_)
+		{
+			SetFieldValue(2, index, mesgData_, Fit.SubfieldIndexMainField);
+		}
+
+		///<summary>
+		/// Retrieves the ChannelNumber field</summary>
+		/// <returns>Returns nullable byte representing the ChannelNumber field</returns>
+		public byte? ChannelNumber
+		{
+			get
+			{
+				Object val = GetFieldValue(3, 0, Fit.SubfieldIndexMainField);
+				if (val == null)
+				{
+					return null;
+				}
+
+				return (Convert.ToByte(val));
+
+			}
+			set
+			{
+				SetFieldValue(3, 0, value, Fit.SubfieldIndexMainField);
+			}
+		}
+
+
+		/// <summary>
+		///
+		/// </summary>
+		/// <returns>returns number of elements in field Data</returns>
+		public int GetNumData()
+		{
+			return GetNumFieldValues(4, Fit.SubfieldIndexMainField);
+		}
+
+		///<summary>
+		/// Retrieves the Data field</summary>
+		/// <param name="index">0 based index of Data element to retrieve</param>
+		/// <returns>Returns nullable byte representing the Data field</returns>
+		public byte? GetData(int index)
+		{
+			Object val = GetFieldValue(4, index, Fit.SubfieldIndexMainField);
+			if (val == null)
+			{
+				return null;
+			}
+
+			return (Convert.ToByte(val));
+
+		}
+
+		/// <summary>
+		/// Set Data field</summary>
+		/// <param name="index">0 based index of data</param>
+		/// <param name="data_">Nullable field value to be set</param>
+		public void SetData(int index, byte? data_)
+		{
+			SetFieldValue(4, index, data_, Fit.SubfieldIndexMainField);
+		}
+
+		#endregion // Methods
+	} // Class
 } // namespace

--- a/Dynastream/Fit/Profile/Mesgs/AntTxMesg.cs
+++ b/Dynastream/Fit/Profile/Mesgs/AntTxMesg.cs
@@ -21,205 +21,199 @@ using System.Linq;
 
 namespace Dynastream.Fit
 {
-    /// <summary>
-    /// Implements the AntTx profile message.
-    /// </summary>
-    public class AntTxMesg : Mesg
-    {
-        #region Fields
-        #endregion
+	/// <summary>
+	/// Implements the AntTx profile message.
+	/// </summary>
+	public class AntTxMesg : Mesg
+	{
+		#region Fields
+		#endregion
 
-        /// <summary>
-        /// Field Numbers for <see cref="AntTxMesg"/>
-        /// </summary>
-        public sealed class FieldDefNum
-        {
-            public const byte Timestamp = 253;
-            public const byte FractionalTimestamp = 0;
-            public const byte MesgId = 1;
-            public const byte MesgData = 2;
-            public const byte ChannelNumber = 3;
-            public const byte Data = 4;
-            public const byte Invalid = Fit.FieldNumInvalid;
-        }
+		/// <summary>
+		/// Field Numbers for <see cref="AntTxMesg"/>
+		/// </summary>
+		public sealed class FieldDefNum
+		{
+			public const byte Timestamp = 253;
+			public const byte FractionalTimestamp = 0;
+			public const byte MesgId = 1;
+			public const byte MesgData = 2;
+			public const byte ChannelNumber = 3;
+			public const byte Data = 4;
+			public const byte Invalid = Fit.FieldNumInvalid;
+		}
 
-        #region Constructors
-        public AntTxMesg() : base(Profile.GetMesg(MesgNum.AntTx))
-        {
-        }
+		#region Constructors
+		public AntTxMesg() : base(Profile.GetMesg(MesgNum.AntTx))
+		{
+		}
 
-        public AntTxMesg(Mesg mesg) : base(mesg)
-        {
-        }
-        #endregion // Constructors
+		public AntTxMesg(Mesg mesg) : base(mesg)
+		{
+		}
+		#endregion // Constructors
 
-        #region Methods
-        ///<summary>
-        /// Retrieves the Timestamp field
-        /// Units: s</summary>
-        /// <returns>Returns DateTime representing the Timestamp field</returns>
-        public DateTime GetTimestamp()
-        {
-            Object val = GetFieldValue(253, 0, Fit.SubfieldIndexMainField);
-            if(val == null)
-            {
-                return null;
-            }
+		#region Methods
+		///<summary>
+		/// Retrieves the Timestamp field
+		/// Units: s</summary>
+		/// <returns>Returns DateTime representing the Timestamp field</returns>
+		public DateTime Timestamp
+		{
+			get
+			{
+				Object val = GetFieldValue(253, 0, Fit.SubfieldIndexMainField);
+				if (val == null)
+				{
+					return null;
+				}
 
-            return TimestampToDateTime(Convert.ToUInt32(val));
-            
-        }
+				return TimestampToDateTime(Convert.ToUInt32(val));
 
-        /// <summary>
-        /// Set Timestamp field
-        /// Units: s</summary>
-        /// <param name="timestamp_">Nullable field value to be set</param>
-        public void SetTimestamp(DateTime timestamp_)
-        {
-            SetFieldValue(253, 0, timestamp_.GetTimeStamp(), Fit.SubfieldIndexMainField);
-        }
-        
-        ///<summary>
-        /// Retrieves the FractionalTimestamp field
-        /// Units: s</summary>
-        /// <returns>Returns nullable float representing the FractionalTimestamp field</returns>
-        public float? GetFractionalTimestamp()
-        {
-            Object val = GetFieldValue(0, 0, Fit.SubfieldIndexMainField);
-            if(val == null)
-            {
-                return null;
-            }
+			}
+			set
+			{
+				SetFieldValue(253, 0, value.GetTimeStamp(), Fit.SubfieldIndexMainField);
+			}
+		}
 
-            return (Convert.ToSingle(val));
-            
-        }
+		///<summary>
+		/// Retrieves the FractionalTimestamp field
+		/// Units: s</summary>
+		/// <returns>Returns nullable float representing the FractionalTimestamp field</returns>
+		public float? FractionalTimestamp
+		{
+			get
+			{
+				Object val = GetFieldValue(0, 0, Fit.SubfieldIndexMainField);
+				if (val == null)
+				{
+					return null;
+				}
 
-        /// <summary>
-        /// Set FractionalTimestamp field
-        /// Units: s</summary>
-        /// <param name="fractionalTimestamp_">Nullable field value to be set</param>
-        public void SetFractionalTimestamp(float? fractionalTimestamp_)
-        {
-            SetFieldValue(0, 0, fractionalTimestamp_, Fit.SubfieldIndexMainField);
-        }
-        
-        ///<summary>
-        /// Retrieves the MesgId field</summary>
-        /// <returns>Returns nullable byte representing the MesgId field</returns>
-        public byte? GetMesgId()
-        {
-            Object val = GetFieldValue(1, 0, Fit.SubfieldIndexMainField);
-            if(val == null)
-            {
-                return null;
-            }
+				return (Convert.ToSingle(val));
 
-            return (Convert.ToByte(val));
-            
-        }
+			}
+			set
+			{
+				SetFieldValue(0, 0, value, Fit.SubfieldIndexMainField);
+			}
+		}
 
-        /// <summary>
-        /// Set MesgId field</summary>
-        /// <param name="mesgId_">Nullable field value to be set</param>
-        public void SetMesgId(byte? mesgId_)
-        {
-            SetFieldValue(1, 0, mesgId_, Fit.SubfieldIndexMainField);
-        }
-        
-        
-        /// <summary>
-        ///
-        /// </summary>
-        /// <returns>returns number of elements in field MesgData</returns>
-        public int GetNumMesgData()
-        {
-            return GetNumFieldValues(2, Fit.SubfieldIndexMainField);
-        }
+		///<summary>
+		/// Retrieves the MesgId field</summary>
+		/// <returns>Returns nullable byte representing the MesgId field</returns>
+		public byte? MesgId
+		{
+			get
+			{
+				Object val = GetFieldValue(1, 0, Fit.SubfieldIndexMainField);
+				if (val == null)
+				{
+					return null;
+				}
 
-        ///<summary>
-        /// Retrieves the MesgData field</summary>
-        /// <param name="index">0 based index of MesgData element to retrieve</param>
-        /// <returns>Returns nullable byte representing the MesgData field</returns>
-        public byte? GetMesgData(int index)
-        {
-            Object val = GetFieldValue(2, index, Fit.SubfieldIndexMainField);
-            if(val == null)
-            {
-                return null;
-            }
+				return (Convert.ToByte(val));
 
-            return (Convert.ToByte(val));
-            
-        }
+			}
+			set
+			{
+				SetFieldValue(1, 0, value, Fit.SubfieldIndexMainField);
+			}
+		}
 
-        /// <summary>
-        /// Set MesgData field</summary>
-        /// <param name="index">0 based index of mesg_data</param>
-        /// <param name="mesgData_">Nullable field value to be set</param>
-        public void SetMesgData(int index, byte? mesgData_)
-        {
-            SetFieldValue(2, index, mesgData_, Fit.SubfieldIndexMainField);
-        }
-        
-        ///<summary>
-        /// Retrieves the ChannelNumber field</summary>
-        /// <returns>Returns nullable byte representing the ChannelNumber field</returns>
-        public byte? GetChannelNumber()
-        {
-            Object val = GetFieldValue(3, 0, Fit.SubfieldIndexMainField);
-            if(val == null)
-            {
-                return null;
-            }
 
-            return (Convert.ToByte(val));
-            
-        }
+		/// <summary>
+		///
+		/// </summary>
+		/// <returns>returns number of elements in field MesgData</returns>
+		public int GetNumMesgData()
+		{
+			return GetNumFieldValues(2, Fit.SubfieldIndexMainField);
+		}
 
-        /// <summary>
-        /// Set ChannelNumber field</summary>
-        /// <param name="channelNumber_">Nullable field value to be set</param>
-        public void SetChannelNumber(byte? channelNumber_)
-        {
-            SetFieldValue(3, 0, channelNumber_, Fit.SubfieldIndexMainField);
-        }
-        
-        
-        /// <summary>
-        ///
-        /// </summary>
-        /// <returns>returns number of elements in field Data</returns>
-        public int GetNumData()
-        {
-            return GetNumFieldValues(4, Fit.SubfieldIndexMainField);
-        }
+		///<summary>
+		/// Retrieves the MesgData field</summary>
+		/// <param name="index">0 based index of MesgData element to retrieve</param>
+		/// <returns>Returns nullable byte representing the MesgData field</returns>
+		public byte? GetMesgData(int index)
+		{
+			Object val = GetFieldValue(2, index, Fit.SubfieldIndexMainField);
+			if (val == null)
+			{
+				return null;
+			}
 
-        ///<summary>
-        /// Retrieves the Data field</summary>
-        /// <param name="index">0 based index of Data element to retrieve</param>
-        /// <returns>Returns nullable byte representing the Data field</returns>
-        public byte? GetData(int index)
-        {
-            Object val = GetFieldValue(4, index, Fit.SubfieldIndexMainField);
-            if(val == null)
-            {
-                return null;
-            }
+			return (Convert.ToByte(val));
 
-            return (Convert.ToByte(val));
-            
-        }
+		}
 
-        /// <summary>
-        /// Set Data field</summary>
-        /// <param name="index">0 based index of data</param>
-        /// <param name="data_">Nullable field value to be set</param>
-        public void SetData(int index, byte? data_)
-        {
-            SetFieldValue(4, index, data_, Fit.SubfieldIndexMainField);
-        }
-        
-        #endregion // Methods
-    } // Class
+		/// <summary>
+		/// Set MesgData field</summary>
+		/// <param name="index">0 based index of mesg_data</param>
+		/// <param name="mesgData_">Nullable field value to be set</param>
+		public void SetMesgData(int index, byte? mesgData_)
+		{
+			SetFieldValue(2, index, mesgData_, Fit.SubfieldIndexMainField);
+		}
+
+		///<summary>
+		/// Retrieves the ChannelNumber field</summary>
+		/// <returns>Returns nullable byte representing the ChannelNumber field</returns>
+		public byte? ChannelNumber
+		{
+			get
+			{
+				Object val = GetFieldValue(3, 0, Fit.SubfieldIndexMainField);
+				if (val == null)
+				{
+					return null;
+				}
+
+				return (Convert.ToByte(val));
+
+			}
+			set
+			{
+				SetFieldValue(3, 0, value, Fit.SubfieldIndexMainField);
+			}
+		}
+
+
+		/// <summary>
+		///
+		/// </summary>
+		/// <returns>returns number of elements in field Data</returns>
+		public int GetNumData()
+		{
+			return GetNumFieldValues(4, Fit.SubfieldIndexMainField);
+		}
+
+		///<summary>
+		/// Retrieves the Data field</summary>
+		/// <param name="index">0 based index of Data element to retrieve</param>
+		/// <returns>Returns nullable byte representing the Data field</returns>
+		public byte? GetData(int index)
+		{
+			Object val = GetFieldValue(4, index, Fit.SubfieldIndexMainField);
+			if (val == null)
+			{
+				return null;
+			}
+
+			return (Convert.ToByte(val));
+
+		}
+
+		/// <summary>
+		/// Set Data field</summary>
+		/// <param name="index">0 based index of data</param>
+		/// <param name="data_">Nullable field value to be set</param>
+		public void SetData(int index, byte? data_)
+		{
+			SetFieldValue(4, index, data_, Fit.SubfieldIndexMainField);
+		}
+
+		#endregion // Methods
+	} // Class
 } // namespace

--- a/Dynastream/Fit/Profile/Mesgs/AviationAttitudeMesg.cs
+++ b/Dynastream/Fit/Profile/Mesgs/AviationAttitudeMesg.cs
@@ -21,476 +21,470 @@ using System.Linq;
 
 namespace Dynastream.Fit
 {
-    /// <summary>
-    /// Implements the AviationAttitude profile message.
-    /// </summary>
-    public class AviationAttitudeMesg : Mesg
-    {
-        #region Fields
-        #endregion
+	/// <summary>
+	/// Implements the AviationAttitude profile message.
+	/// </summary>
+	public class AviationAttitudeMesg : Mesg
+	{
+		#region Fields
+		#endregion
 
-        /// <summary>
-        /// Field Numbers for <see cref="AviationAttitudeMesg"/>
-        /// </summary>
-        public sealed class FieldDefNum
-        {
-            public const byte Timestamp = 253;
-            public const byte TimestampMs = 0;
-            public const byte SystemTime = 1;
-            public const byte Pitch = 2;
-            public const byte Roll = 3;
-            public const byte AccelLateral = 4;
-            public const byte AccelNormal = 5;
-            public const byte TurnRate = 6;
-            public const byte Stage = 7;
-            public const byte AttitudeStageComplete = 8;
-            public const byte Track = 9;
-            public const byte Validity = 10;
-            public const byte Invalid = Fit.FieldNumInvalid;
-        }
+		/// <summary>
+		/// Field Numbers for <see cref="AviationAttitudeMesg"/>
+		/// </summary>
+		public sealed class FieldDefNum
+		{
+			public const byte Timestamp = 253;
+			public const byte TimestampMs = 0;
+			public const byte SystemTime = 1;
+			public const byte Pitch = 2;
+			public const byte Roll = 3;
+			public const byte AccelLateral = 4;
+			public const byte AccelNormal = 5;
+			public const byte TurnRate = 6;
+			public const byte Stage = 7;
+			public const byte AttitudeStageComplete = 8;
+			public const byte Track = 9;
+			public const byte Validity = 10;
+			public const byte Invalid = Fit.FieldNumInvalid;
+		}
 
-        #region Constructors
-        public AviationAttitudeMesg() : base(Profile.GetMesg(MesgNum.AviationAttitude))
-        {
-        }
+		#region Constructors
+		public AviationAttitudeMesg() : base(Profile.GetMesg(MesgNum.AviationAttitude))
+		{
+		}
 
-        public AviationAttitudeMesg(Mesg mesg) : base(mesg)
-        {
-        }
-        #endregion // Constructors
+		public AviationAttitudeMesg(Mesg mesg) : base(mesg)
+		{
+		}
+		#endregion // Constructors
 
-        #region Methods
-        ///<summary>
-        /// Retrieves the Timestamp field
-        /// Units: s
-        /// Comment: Timestamp message was output</summary>
-        /// <returns>Returns DateTime representing the Timestamp field</returns>
-        public DateTime GetTimestamp()
-        {
-            Object val = GetFieldValue(253, 0, Fit.SubfieldIndexMainField);
-            if(val == null)
-            {
-                return null;
-            }
+		#region Methods
+		///<summary>
+		/// Retrieves the Timestamp field
+		/// Units: s
+		/// Comment: Timestamp message was output</summary>
+		/// <returns>Returns DateTime representing the Timestamp field</returns>
+		public DateTime Timestamp
+		{
+			get
+			{
+				Object val = GetFieldValue(253, 0, Fit.SubfieldIndexMainField);
+				if (val == null)
+				{
+					return null;
+				}
 
-            return TimestampToDateTime(Convert.ToUInt32(val));
-            
-        }
+				return TimestampToDateTime(Convert.ToUInt32(val));
 
-        /// <summary>
-        /// Set Timestamp field
-        /// Units: s
-        /// Comment: Timestamp message was output</summary>
-        /// <param name="timestamp_">Nullable field value to be set</param>
-        public void SetTimestamp(DateTime timestamp_)
-        {
-            SetFieldValue(253, 0, timestamp_.GetTimeStamp(), Fit.SubfieldIndexMainField);
-        }
-        
-        ///<summary>
-        /// Retrieves the TimestampMs field
-        /// Units: ms
-        /// Comment: Fractional part of timestamp, added to timestamp</summary>
-        /// <returns>Returns nullable ushort representing the TimestampMs field</returns>
-        public ushort? GetTimestampMs()
-        {
-            Object val = GetFieldValue(0, 0, Fit.SubfieldIndexMainField);
-            if(val == null)
-            {
-                return null;
-            }
+			}
+			set
+			{
+				SetFieldValue(253, 0, value.GetTimeStamp(), Fit.SubfieldIndexMainField);
+			}
+		}
 
-            return (Convert.ToUInt16(val));
-            
-        }
+		///<summary>
+		/// Retrieves the TimestampMs field
+		/// Units: ms
+		/// Comment: Fractional part of timestamp, added to timestamp</summary>
+		/// <returns>Returns nullable ushort representing the TimestampMs field</returns>
+		public ushort? TimestampMs
+		{
+			get
+			{
+				Object val = GetFieldValue(0, 0, Fit.SubfieldIndexMainField);
+				if (val == null)
+				{
+					return null;
+				}
 
-        /// <summary>
-        /// Set TimestampMs field
-        /// Units: ms
-        /// Comment: Fractional part of timestamp, added to timestamp</summary>
-        /// <param name="timestampMs_">Nullable field value to be set</param>
-        public void SetTimestampMs(ushort? timestampMs_)
-        {
-            SetFieldValue(0, 0, timestampMs_, Fit.SubfieldIndexMainField);
-        }
-        
-        
-        /// <summary>
-        ///
-        /// </summary>
-        /// <returns>returns number of elements in field SystemTime</returns>
-        public int GetNumSystemTime()
-        {
-            return GetNumFieldValues(1, Fit.SubfieldIndexMainField);
-        }
+				return (Convert.ToUInt16(val));
 
-        ///<summary>
-        /// Retrieves the SystemTime field
-        /// Units: ms
-        /// Comment: System time associated with sample expressed in ms.</summary>
-        /// <param name="index">0 based index of SystemTime element to retrieve</param>
-        /// <returns>Returns nullable uint representing the SystemTime field</returns>
-        public uint? GetSystemTime(int index)
-        {
-            Object val = GetFieldValue(1, index, Fit.SubfieldIndexMainField);
-            if(val == null)
-            {
-                return null;
-            }
+			}
+			set
+			{
+				SetFieldValue(0, 0, value, Fit.SubfieldIndexMainField);
+			}
+		}
 
-            return (Convert.ToUInt32(val));
-            
-        }
 
-        /// <summary>
-        /// Set SystemTime field
-        /// Units: ms
-        /// Comment: System time associated with sample expressed in ms.</summary>
-        /// <param name="index">0 based index of system_time</param>
-        /// <param name="systemTime_">Nullable field value to be set</param>
-        public void SetSystemTime(int index, uint? systemTime_)
-        {
-            SetFieldValue(1, index, systemTime_, Fit.SubfieldIndexMainField);
-        }
-        
-        
-        /// <summary>
-        ///
-        /// </summary>
-        /// <returns>returns number of elements in field Pitch</returns>
-        public int GetNumPitch()
-        {
-            return GetNumFieldValues(2, Fit.SubfieldIndexMainField);
-        }
+		/// <summary>
+		///
+		/// </summary>
+		/// <returns>returns number of elements in field SystemTime</returns>
+		public int GetNumSystemTime()
+		{
+			return GetNumFieldValues(1, Fit.SubfieldIndexMainField);
+		}
 
-        ///<summary>
-        /// Retrieves the Pitch field
-        /// Units: radians
-        /// Comment: Range -PI/2 to +PI/2</summary>
-        /// <param name="index">0 based index of Pitch element to retrieve</param>
-        /// <returns>Returns nullable float representing the Pitch field</returns>
-        public float? GetPitch(int index)
-        {
-            Object val = GetFieldValue(2, index, Fit.SubfieldIndexMainField);
-            if(val == null)
-            {
-                return null;
-            }
+		///<summary>
+		/// Retrieves the SystemTime field
+		/// Units: ms
+		/// Comment: System time associated with sample expressed in ms.</summary>
+		/// <param name="index">0 based index of SystemTime element to retrieve</param>
+		/// <returns>Returns nullable uint representing the SystemTime field</returns>
+		public uint? GetSystemTime(int index)
+		{
+			Object val = GetFieldValue(1, index, Fit.SubfieldIndexMainField);
+			if (val == null)
+			{
+				return null;
+			}
 
-            return (Convert.ToSingle(val));
-            
-        }
+			return (Convert.ToUInt32(val));
 
-        /// <summary>
-        /// Set Pitch field
-        /// Units: radians
-        /// Comment: Range -PI/2 to +PI/2</summary>
-        /// <param name="index">0 based index of pitch</param>
-        /// <param name="pitch_">Nullable field value to be set</param>
-        public void SetPitch(int index, float? pitch_)
-        {
-            SetFieldValue(2, index, pitch_, Fit.SubfieldIndexMainField);
-        }
-        
-        
-        /// <summary>
-        ///
-        /// </summary>
-        /// <returns>returns number of elements in field Roll</returns>
-        public int GetNumRoll()
-        {
-            return GetNumFieldValues(3, Fit.SubfieldIndexMainField);
-        }
+		}
 
-        ///<summary>
-        /// Retrieves the Roll field
-        /// Units: radians
-        /// Comment: Range -PI to +PI</summary>
-        /// <param name="index">0 based index of Roll element to retrieve</param>
-        /// <returns>Returns nullable float representing the Roll field</returns>
-        public float? GetRoll(int index)
-        {
-            Object val = GetFieldValue(3, index, Fit.SubfieldIndexMainField);
-            if(val == null)
-            {
-                return null;
-            }
+		/// <summary>
+		/// Set SystemTime field
+		/// Units: ms
+		/// Comment: System time associated with sample expressed in ms.</summary>
+		/// <param name="index">0 based index of system_time</param>
+		/// <param name="systemTime_">Nullable field value to be set</param>
+		public void SetSystemTime(int index, uint? systemTime_)
+		{
+			SetFieldValue(1, index, systemTime_, Fit.SubfieldIndexMainField);
+		}
 
-            return (Convert.ToSingle(val));
-            
-        }
 
-        /// <summary>
-        /// Set Roll field
-        /// Units: radians
-        /// Comment: Range -PI to +PI</summary>
-        /// <param name="index">0 based index of roll</param>
-        /// <param name="roll_">Nullable field value to be set</param>
-        public void SetRoll(int index, float? roll_)
-        {
-            SetFieldValue(3, index, roll_, Fit.SubfieldIndexMainField);
-        }
-        
-        
-        /// <summary>
-        ///
-        /// </summary>
-        /// <returns>returns number of elements in field AccelLateral</returns>
-        public int GetNumAccelLateral()
-        {
-            return GetNumFieldValues(4, Fit.SubfieldIndexMainField);
-        }
+		/// <summary>
+		///
+		/// </summary>
+		/// <returns>returns number of elements in field Pitch</returns>
+		public int GetNumPitch()
+		{
+			return GetNumFieldValues(2, Fit.SubfieldIndexMainField);
+		}
 
-        ///<summary>
-        /// Retrieves the AccelLateral field
-        /// Units: m/s^2
-        /// Comment: Range -78.4 to +78.4 (-8 Gs to 8 Gs)</summary>
-        /// <param name="index">0 based index of AccelLateral element to retrieve</param>
-        /// <returns>Returns nullable float representing the AccelLateral field</returns>
-        public float? GetAccelLateral(int index)
-        {
-            Object val = GetFieldValue(4, index, Fit.SubfieldIndexMainField);
-            if(val == null)
-            {
-                return null;
-            }
+		///<summary>
+		/// Retrieves the Pitch field
+		/// Units: radians
+		/// Comment: Range -PI/2 to +PI/2</summary>
+		/// <param name="index">0 based index of Pitch element to retrieve</param>
+		/// <returns>Returns nullable float representing the Pitch field</returns>
+		public float? GetPitch(int index)
+		{
+			Object val = GetFieldValue(2, index, Fit.SubfieldIndexMainField);
+			if (val == null)
+			{
+				return null;
+			}
 
-            return (Convert.ToSingle(val));
-            
-        }
+			return (Convert.ToSingle(val));
 
-        /// <summary>
-        /// Set AccelLateral field
-        /// Units: m/s^2
-        /// Comment: Range -78.4 to +78.4 (-8 Gs to 8 Gs)</summary>
-        /// <param name="index">0 based index of accel_lateral</param>
-        /// <param name="accelLateral_">Nullable field value to be set</param>
-        public void SetAccelLateral(int index, float? accelLateral_)
-        {
-            SetFieldValue(4, index, accelLateral_, Fit.SubfieldIndexMainField);
-        }
-        
-        
-        /// <summary>
-        ///
-        /// </summary>
-        /// <returns>returns number of elements in field AccelNormal</returns>
-        public int GetNumAccelNormal()
-        {
-            return GetNumFieldValues(5, Fit.SubfieldIndexMainField);
-        }
+		}
 
-        ///<summary>
-        /// Retrieves the AccelNormal field
-        /// Units: m/s^2
-        /// Comment: Range -78.4 to +78.4 (-8 Gs to 8 Gs)</summary>
-        /// <param name="index">0 based index of AccelNormal element to retrieve</param>
-        /// <returns>Returns nullable float representing the AccelNormal field</returns>
-        public float? GetAccelNormal(int index)
-        {
-            Object val = GetFieldValue(5, index, Fit.SubfieldIndexMainField);
-            if(val == null)
-            {
-                return null;
-            }
+		/// <summary>
+		/// Set Pitch field
+		/// Units: radians
+		/// Comment: Range -PI/2 to +PI/2</summary>
+		/// <param name="index">0 based index of pitch</param>
+		/// <param name="pitch_">Nullable field value to be set</param>
+		public void SetPitch(int index, float? pitch_)
+		{
+			SetFieldValue(2, index, pitch_, Fit.SubfieldIndexMainField);
+		}
 
-            return (Convert.ToSingle(val));
-            
-        }
 
-        /// <summary>
-        /// Set AccelNormal field
-        /// Units: m/s^2
-        /// Comment: Range -78.4 to +78.4 (-8 Gs to 8 Gs)</summary>
-        /// <param name="index">0 based index of accel_normal</param>
-        /// <param name="accelNormal_">Nullable field value to be set</param>
-        public void SetAccelNormal(int index, float? accelNormal_)
-        {
-            SetFieldValue(5, index, accelNormal_, Fit.SubfieldIndexMainField);
-        }
-        
-        
-        /// <summary>
-        ///
-        /// </summary>
-        /// <returns>returns number of elements in field TurnRate</returns>
-        public int GetNumTurnRate()
-        {
-            return GetNumFieldValues(6, Fit.SubfieldIndexMainField);
-        }
+		/// <summary>
+		///
+		/// </summary>
+		/// <returns>returns number of elements in field Roll</returns>
+		public int GetNumRoll()
+		{
+			return GetNumFieldValues(3, Fit.SubfieldIndexMainField);
+		}
 
-        ///<summary>
-        /// Retrieves the TurnRate field
-        /// Units: radians/second
-        /// Comment: Range -8.727 to +8.727 (-500 degs/sec to +500 degs/sec)</summary>
-        /// <param name="index">0 based index of TurnRate element to retrieve</param>
-        /// <returns>Returns nullable float representing the TurnRate field</returns>
-        public float? GetTurnRate(int index)
-        {
-            Object val = GetFieldValue(6, index, Fit.SubfieldIndexMainField);
-            if(val == null)
-            {
-                return null;
-            }
+		///<summary>
+		/// Retrieves the Roll field
+		/// Units: radians
+		/// Comment: Range -PI to +PI</summary>
+		/// <param name="index">0 based index of Roll element to retrieve</param>
+		/// <returns>Returns nullable float representing the Roll field</returns>
+		public float? GetRoll(int index)
+		{
+			Object val = GetFieldValue(3, index, Fit.SubfieldIndexMainField);
+			if (val == null)
+			{
+				return null;
+			}
 
-            return (Convert.ToSingle(val));
-            
-        }
+			return (Convert.ToSingle(val));
 
-        /// <summary>
-        /// Set TurnRate field
-        /// Units: radians/second
-        /// Comment: Range -8.727 to +8.727 (-500 degs/sec to +500 degs/sec)</summary>
-        /// <param name="index">0 based index of turn_rate</param>
-        /// <param name="turnRate_">Nullable field value to be set</param>
-        public void SetTurnRate(int index, float? turnRate_)
-        {
-            SetFieldValue(6, index, turnRate_, Fit.SubfieldIndexMainField);
-        }
-        
-        
-        /// <summary>
-        ///
-        /// </summary>
-        /// <returns>returns number of elements in field Stage</returns>
-        public int GetNumStage()
-        {
-            return GetNumFieldValues(7, Fit.SubfieldIndexMainField);
-        }
+		}
 
-        ///<summary>
-        /// Retrieves the Stage field</summary>
-        /// <param name="index">0 based index of Stage element to retrieve</param>
-        /// <returns>Returns nullable AttitudeStage enum representing the Stage field</returns>
-        public AttitudeStage? GetStage(int index)
-        {
-            object obj = GetFieldValue(7, index, Fit.SubfieldIndexMainField);
-            AttitudeStage? value = obj == null ? (AttitudeStage?)null : (AttitudeStage)obj;
-            return value;
-        }
+		/// <summary>
+		/// Set Roll field
+		/// Units: radians
+		/// Comment: Range -PI to +PI</summary>
+		/// <param name="index">0 based index of roll</param>
+		/// <param name="roll_">Nullable field value to be set</param>
+		public void SetRoll(int index, float? roll_)
+		{
+			SetFieldValue(3, index, roll_, Fit.SubfieldIndexMainField);
+		}
 
-        /// <summary>
-        /// Set Stage field</summary>
-        /// <param name="index">0 based index of stage</param>
-        /// <param name="stage_">Nullable field value to be set</param>
-        public void SetStage(int index, AttitudeStage? stage_)
-        {
-            SetFieldValue(7, index, stage_, Fit.SubfieldIndexMainField);
-        }
-        
-        
-        /// <summary>
-        ///
-        /// </summary>
-        /// <returns>returns number of elements in field AttitudeStageComplete</returns>
-        public int GetNumAttitudeStageComplete()
-        {
-            return GetNumFieldValues(8, Fit.SubfieldIndexMainField);
-        }
 
-        ///<summary>
-        /// Retrieves the AttitudeStageComplete field
-        /// Units: %
-        /// Comment: The percent complete of the current attitude stage. Set to 0 for attitude stages 0, 1 and 2 and to 100 for attitude stage 3 by AHRS modules that do not support it. Range - 100</summary>
-        /// <param name="index">0 based index of AttitudeStageComplete element to retrieve</param>
-        /// <returns>Returns nullable byte representing the AttitudeStageComplete field</returns>
-        public byte? GetAttitudeStageComplete(int index)
-        {
-            Object val = GetFieldValue(8, index, Fit.SubfieldIndexMainField);
-            if(val == null)
-            {
-                return null;
-            }
+		/// <summary>
+		///
+		/// </summary>
+		/// <returns>returns number of elements in field AccelLateral</returns>
+		public int GetNumAccelLateral()
+		{
+			return GetNumFieldValues(4, Fit.SubfieldIndexMainField);
+		}
 
-            return (Convert.ToByte(val));
-            
-        }
+		///<summary>
+		/// Retrieves the AccelLateral field
+		/// Units: m/s^2
+		/// Comment: Range -78.4 to +78.4 (-8 Gs to 8 Gs)</summary>
+		/// <param name="index">0 based index of AccelLateral element to retrieve</param>
+		/// <returns>Returns nullable float representing the AccelLateral field</returns>
+		public float? GetAccelLateral(int index)
+		{
+			Object val = GetFieldValue(4, index, Fit.SubfieldIndexMainField);
+			if (val == null)
+			{
+				return null;
+			}
 
-        /// <summary>
-        /// Set AttitudeStageComplete field
-        /// Units: %
-        /// Comment: The percent complete of the current attitude stage. Set to 0 for attitude stages 0, 1 and 2 and to 100 for attitude stage 3 by AHRS modules that do not support it. Range - 100</summary>
-        /// <param name="index">0 based index of attitude_stage_complete</param>
-        /// <param name="attitudeStageComplete_">Nullable field value to be set</param>
-        public void SetAttitudeStageComplete(int index, byte? attitudeStageComplete_)
-        {
-            SetFieldValue(8, index, attitudeStageComplete_, Fit.SubfieldIndexMainField);
-        }
-        
-        
-        /// <summary>
-        ///
-        /// </summary>
-        /// <returns>returns number of elements in field Track</returns>
-        public int GetNumTrack()
-        {
-            return GetNumFieldValues(9, Fit.SubfieldIndexMainField);
-        }
+			return (Convert.ToSingle(val));
 
-        ///<summary>
-        /// Retrieves the Track field
-        /// Units: radians
-        /// Comment: Track Angle/Heading Range 0 - 2pi</summary>
-        /// <param name="index">0 based index of Track element to retrieve</param>
-        /// <returns>Returns nullable float representing the Track field</returns>
-        public float? GetTrack(int index)
-        {
-            Object val = GetFieldValue(9, index, Fit.SubfieldIndexMainField);
-            if(val == null)
-            {
-                return null;
-            }
+		}
 
-            return (Convert.ToSingle(val));
-            
-        }
+		/// <summary>
+		/// Set AccelLateral field
+		/// Units: m/s^2
+		/// Comment: Range -78.4 to +78.4 (-8 Gs to 8 Gs)</summary>
+		/// <param name="index">0 based index of accel_lateral</param>
+		/// <param name="accelLateral_">Nullable field value to be set</param>
+		public void SetAccelLateral(int index, float? accelLateral_)
+		{
+			SetFieldValue(4, index, accelLateral_, Fit.SubfieldIndexMainField);
+		}
 
-        /// <summary>
-        /// Set Track field
-        /// Units: radians
-        /// Comment: Track Angle/Heading Range 0 - 2pi</summary>
-        /// <param name="index">0 based index of track</param>
-        /// <param name="track_">Nullable field value to be set</param>
-        public void SetTrack(int index, float? track_)
-        {
-            SetFieldValue(9, index, track_, Fit.SubfieldIndexMainField);
-        }
-        
-        
-        /// <summary>
-        ///
-        /// </summary>
-        /// <returns>returns number of elements in field Validity</returns>
-        public int GetNumValidity()
-        {
-            return GetNumFieldValues(10, Fit.SubfieldIndexMainField);
-        }
 
-        ///<summary>
-        /// Retrieves the Validity field</summary>
-        /// <param name="index">0 based index of Validity element to retrieve</param>
-        /// <returns>Returns nullable ushort representing the Validity field</returns>
-        public ushort? GetValidity(int index)
-        {
-            Object val = GetFieldValue(10, index, Fit.SubfieldIndexMainField);
-            if(val == null)
-            {
-                return null;
-            }
+		/// <summary>
+		///
+		/// </summary>
+		/// <returns>returns number of elements in field AccelNormal</returns>
+		public int GetNumAccelNormal()
+		{
+			return GetNumFieldValues(5, Fit.SubfieldIndexMainField);
+		}
 
-            return (Convert.ToUInt16(val));
-            
-        }
+		///<summary>
+		/// Retrieves the AccelNormal field
+		/// Units: m/s^2
+		/// Comment: Range -78.4 to +78.4 (-8 Gs to 8 Gs)</summary>
+		/// <param name="index">0 based index of AccelNormal element to retrieve</param>
+		/// <returns>Returns nullable float representing the AccelNormal field</returns>
+		public float? GetAccelNormal(int index)
+		{
+			Object val = GetFieldValue(5, index, Fit.SubfieldIndexMainField);
+			if (val == null)
+			{
+				return null;
+			}
 
-        /// <summary>
-        /// Set Validity field</summary>
-        /// <param name="index">0 based index of validity</param>
-        /// <param name="validity_">Nullable field value to be set</param>
-        public void SetValidity(int index, ushort? validity_)
-        {
-            SetFieldValue(10, index, validity_, Fit.SubfieldIndexMainField);
-        }
-        
-        #endregion // Methods
-    } // Class
+			return (Convert.ToSingle(val));
+
+		}
+
+		/// <summary>
+		/// Set AccelNormal field
+		/// Units: m/s^2
+		/// Comment: Range -78.4 to +78.4 (-8 Gs to 8 Gs)</summary>
+		/// <param name="index">0 based index of accel_normal</param>
+		/// <param name="accelNormal_">Nullable field value to be set</param>
+		public void SetAccelNormal(int index, float? accelNormal_)
+		{
+			SetFieldValue(5, index, accelNormal_, Fit.SubfieldIndexMainField);
+		}
+
+
+		/// <summary>
+		///
+		/// </summary>
+		/// <returns>returns number of elements in field TurnRate</returns>
+		public int GetNumTurnRate()
+		{
+			return GetNumFieldValues(6, Fit.SubfieldIndexMainField);
+		}
+
+		///<summary>
+		/// Retrieves the TurnRate field
+		/// Units: radians/second
+		/// Comment: Range -8.727 to +8.727 (-500 degs/sec to +500 degs/sec)</summary>
+		/// <param name="index">0 based index of TurnRate element to retrieve</param>
+		/// <returns>Returns nullable float representing the TurnRate field</returns>
+		public float? GetTurnRate(int index)
+		{
+			Object val = GetFieldValue(6, index, Fit.SubfieldIndexMainField);
+			if (val == null)
+			{
+				return null;
+			}
+
+			return (Convert.ToSingle(val));
+
+		}
+
+		/// <summary>
+		/// Set TurnRate field
+		/// Units: radians/second
+		/// Comment: Range -8.727 to +8.727 (-500 degs/sec to +500 degs/sec)</summary>
+		/// <param name="index">0 based index of turn_rate</param>
+		/// <param name="turnRate_">Nullable field value to be set</param>
+		public void SetTurnRate(int index, float? turnRate_)
+		{
+			SetFieldValue(6, index, turnRate_, Fit.SubfieldIndexMainField);
+		}
+
+
+		/// <summary>
+		///
+		/// </summary>
+		/// <returns>returns number of elements in field Stage</returns>
+		public int GetNumStage()
+		{
+			return GetNumFieldValues(7, Fit.SubfieldIndexMainField);
+		}
+
+		///<summary>
+		/// Retrieves the Stage field</summary>
+		/// <param name="index">0 based index of Stage element to retrieve</param>
+		/// <returns>Returns nullable AttitudeStage enum representing the Stage field</returns>
+		public AttitudeStage? GetStage(int index)
+		{
+			object obj = GetFieldValue(7, index, Fit.SubfieldIndexMainField);
+			AttitudeStage? value = obj == null ? (AttitudeStage?)null : (AttitudeStage)obj;
+			return value;
+		}
+
+		/// <summary>
+		/// Set Stage field</summary>
+		/// <param name="index">0 based index of stage</param>
+		/// <param name="stage_">Nullable field value to be set</param>
+		public void SetStage(int index, AttitudeStage? stage_)
+		{
+			SetFieldValue(7, index, stage_, Fit.SubfieldIndexMainField);
+		}
+
+
+		/// <summary>
+		///
+		/// </summary>
+		/// <returns>returns number of elements in field AttitudeStageComplete</returns>
+		public int GetNumAttitudeStageComplete()
+		{
+			return GetNumFieldValues(8, Fit.SubfieldIndexMainField);
+		}
+
+		///<summary>
+		/// Retrieves the AttitudeStageComplete field
+		/// Units: %
+		/// Comment: The percent complete of the current attitude stage. Set to 0 for attitude stages 0, 1 and 2 and to 100 for attitude stage 3 by AHRS modules that do not support it. Range - 100</summary>
+		/// <param name="index">0 based index of AttitudeStageComplete element to retrieve</param>
+		/// <returns>Returns nullable byte representing the AttitudeStageComplete field</returns>
+		public byte? GetAttitudeStageComplete(int index)
+		{
+			Object val = GetFieldValue(8, index, Fit.SubfieldIndexMainField);
+			if (val == null)
+			{
+				return null;
+			}
+
+			return (Convert.ToByte(val));
+
+		}
+
+		/// <summary>
+		/// Set AttitudeStageComplete field
+		/// Units: %
+		/// Comment: The percent complete of the current attitude stage. Set to 0 for attitude stages 0, 1 and 2 and to 100 for attitude stage 3 by AHRS modules that do not support it. Range - 100</summary>
+		/// <param name="index">0 based index of attitude_stage_complete</param>
+		/// <param name="attitudeStageComplete_">Nullable field value to be set</param>
+		public void SetAttitudeStageComplete(int index, byte? attitudeStageComplete_)
+		{
+			SetFieldValue(8, index, attitudeStageComplete_, Fit.SubfieldIndexMainField);
+		}
+
+
+		/// <summary>
+		///
+		/// </summary>
+		/// <returns>returns number of elements in field Track</returns>
+		public int GetNumTrack()
+		{
+			return GetNumFieldValues(9, Fit.SubfieldIndexMainField);
+		}
+
+		///<summary>
+		/// Retrieves the Track field
+		/// Units: radians
+		/// Comment: Track Angle/Heading Range 0 - 2pi</summary>
+		/// <param name="index">0 based index of Track element to retrieve</param>
+		/// <returns>Returns nullable float representing the Track field</returns>
+		public float? GetTrack(int index)
+		{
+			Object val = GetFieldValue(9, index, Fit.SubfieldIndexMainField);
+			if (val == null)
+			{
+				return null;
+			}
+
+			return (Convert.ToSingle(val));
+
+		}
+
+		/// <summary>
+		/// Set Track field
+		/// Units: radians
+		/// Comment: Track Angle/Heading Range 0 - 2pi</summary>
+		/// <param name="index">0 based index of track</param>
+		/// <param name="track_">Nullable field value to be set</param>
+		public void SetTrack(int index, float? track_)
+		{
+			SetFieldValue(9, index, track_, Fit.SubfieldIndexMainField);
+		}
+
+
+		/// <summary>
+		///
+		/// </summary>
+		/// <returns>returns number of elements in field Validity</returns>
+		public int GetNumValidity()
+		{
+			return GetNumFieldValues(10, Fit.SubfieldIndexMainField);
+		}
+
+		///<summary>
+		/// Retrieves the Validity field</summary>
+		/// <param name="index">0 based index of Validity element to retrieve</param>
+		/// <returns>Returns nullable ushort representing the Validity field</returns>
+		public ushort? GetValidity(int index)
+		{
+			Object val = GetFieldValue(10, index, Fit.SubfieldIndexMainField);
+			if (val == null)
+			{
+				return null;
+			}
+
+			return (Convert.ToUInt16(val));
+
+		}
+
+		/// <summary>
+		/// Set Validity field</summary>
+		/// <param name="index">0 based index of validity</param>
+		/// <param name="validity_">Nullable field value to be set</param>
+		public void SetValidity(int index, ushort? validity_)
+		{
+			SetFieldValue(10, index, validity_, Fit.SubfieldIndexMainField);
+		}
+
+		#endregion // Methods
+	} // Class
 } // namespace

--- a/Dynastream/Fit/Profile/Mesgs/BarometerDataMesg.cs
+++ b/Dynastream/Fit/Profile/Mesgs/BarometerDataMesg.cs
@@ -21,169 +21,163 @@ using System.Linq;
 
 namespace Dynastream.Fit
 {
-    /// <summary>
-    /// Implements the BarometerData profile message.
-    /// </summary>
-    public class BarometerDataMesg : Mesg
-    {
-        #region Fields
-        #endregion
+	/// <summary>
+	/// Implements the BarometerData profile message.
+	/// </summary>
+	public class BarometerDataMesg : Mesg
+	{
+		#region Fields
+		#endregion
 
-        /// <summary>
-        /// Field Numbers for <see cref="BarometerDataMesg"/>
-        /// </summary>
-        public sealed class FieldDefNum
-        {
-            public const byte Timestamp = 253;
-            public const byte TimestampMs = 0;
-            public const byte SampleTimeOffset = 1;
-            public const byte BaroPres = 2;
-            public const byte Invalid = Fit.FieldNumInvalid;
-        }
+		/// <summary>
+		/// Field Numbers for <see cref="BarometerDataMesg"/>
+		/// </summary>
+		public sealed class FieldDefNum
+		{
+			public const byte Timestamp = 253;
+			public const byte TimestampMs = 0;
+			public const byte SampleTimeOffset = 1;
+			public const byte BaroPres = 2;
+			public const byte Invalid = Fit.FieldNumInvalid;
+		}
 
-        #region Constructors
-        public BarometerDataMesg() : base(Profile.GetMesg(MesgNum.BarometerData))
-        {
-        }
+		#region Constructors
+		public BarometerDataMesg() : base(Profile.GetMesg(MesgNum.BarometerData))
+		{
+		}
 
-        public BarometerDataMesg(Mesg mesg) : base(mesg)
-        {
-        }
-        #endregion // Constructors
+		public BarometerDataMesg(Mesg mesg) : base(mesg)
+		{
+		}
+		#endregion // Constructors
 
-        #region Methods
-        ///<summary>
-        /// Retrieves the Timestamp field
-        /// Units: s
-        /// Comment: Whole second part of the timestamp</summary>
-        /// <returns>Returns DateTime representing the Timestamp field</returns>
-        public DateTime GetTimestamp()
-        {
-            Object val = GetFieldValue(253, 0, Fit.SubfieldIndexMainField);
-            if(val == null)
-            {
-                return null;
-            }
+		#region Methods
+		///<summary>
+		/// Retrieves the Timestamp field
+		/// Units: s
+		/// Comment: Whole second part of the timestamp</summary>
+		/// <returns>Returns DateTime representing the Timestamp field</returns>
+		public DateTime Timestamp
+		{
+			get
+			{
+				Object val = GetFieldValue(253, 0, Fit.SubfieldIndexMainField);
+				if (val == null)
+				{
+					return null;
+				}
 
-            return TimestampToDateTime(Convert.ToUInt32(val));
-            
-        }
+				return TimestampToDateTime(Convert.ToUInt32(val));
 
-        /// <summary>
-        /// Set Timestamp field
-        /// Units: s
-        /// Comment: Whole second part of the timestamp</summary>
-        /// <param name="timestamp_">Nullable field value to be set</param>
-        public void SetTimestamp(DateTime timestamp_)
-        {
-            SetFieldValue(253, 0, timestamp_.GetTimeStamp(), Fit.SubfieldIndexMainField);
-        }
-        
-        ///<summary>
-        /// Retrieves the TimestampMs field
-        /// Units: ms
-        /// Comment: Millisecond part of the timestamp.</summary>
-        /// <returns>Returns nullable ushort representing the TimestampMs field</returns>
-        public ushort? GetTimestampMs()
-        {
-            Object val = GetFieldValue(0, 0, Fit.SubfieldIndexMainField);
-            if(val == null)
-            {
-                return null;
-            }
+			}
+			set
+			{
+				SetFieldValue(253, 0, value.GetTimeStamp(), Fit.SubfieldIndexMainField);
+			}
+		}
 
-            return (Convert.ToUInt16(val));
-            
-        }
+		///<summary>
+		/// Retrieves the TimestampMs field
+		/// Units: ms
+		/// Comment: Millisecond part of the timestamp.</summary>
+		/// <returns>Returns nullable ushort representing the TimestampMs field</returns>
+		public ushort? TimestampMs
+		{
+			get
+			{
+				Object val = GetFieldValue(0, 0, Fit.SubfieldIndexMainField);
+				if (val == null)
+				{
+					return null;
+				}
 
-        /// <summary>
-        /// Set TimestampMs field
-        /// Units: ms
-        /// Comment: Millisecond part of the timestamp.</summary>
-        /// <param name="timestampMs_">Nullable field value to be set</param>
-        public void SetTimestampMs(ushort? timestampMs_)
-        {
-            SetFieldValue(0, 0, timestampMs_, Fit.SubfieldIndexMainField);
-        }
-        
-        
-        /// <summary>
-        ///
-        /// </summary>
-        /// <returns>returns number of elements in field SampleTimeOffset</returns>
-        public int GetNumSampleTimeOffset()
-        {
-            return GetNumFieldValues(1, Fit.SubfieldIndexMainField);
-        }
+				return (Convert.ToUInt16(val));
 
-        ///<summary>
-        /// Retrieves the SampleTimeOffset field
-        /// Units: ms
-        /// Comment: Each time in the array describes the time at which the barometer sample with the corrosponding index was taken. The samples may span across seconds. Array size must match the number of samples in baro_cal</summary>
-        /// <param name="index">0 based index of SampleTimeOffset element to retrieve</param>
-        /// <returns>Returns nullable ushort representing the SampleTimeOffset field</returns>
-        public ushort? GetSampleTimeOffset(int index)
-        {
-            Object val = GetFieldValue(1, index, Fit.SubfieldIndexMainField);
-            if(val == null)
-            {
-                return null;
-            }
+			}
+			set
+			{
+				SetFieldValue(0, 0, value, Fit.SubfieldIndexMainField);
+			}
+		}
 
-            return (Convert.ToUInt16(val));
-            
-        }
 
-        /// <summary>
-        /// Set SampleTimeOffset field
-        /// Units: ms
-        /// Comment: Each time in the array describes the time at which the barometer sample with the corrosponding index was taken. The samples may span across seconds. Array size must match the number of samples in baro_cal</summary>
-        /// <param name="index">0 based index of sample_time_offset</param>
-        /// <param name="sampleTimeOffset_">Nullable field value to be set</param>
-        public void SetSampleTimeOffset(int index, ushort? sampleTimeOffset_)
-        {
-            SetFieldValue(1, index, sampleTimeOffset_, Fit.SubfieldIndexMainField);
-        }
-        
-        
-        /// <summary>
-        ///
-        /// </summary>
-        /// <returns>returns number of elements in field BaroPres</returns>
-        public int GetNumBaroPres()
-        {
-            return GetNumFieldValues(2, Fit.SubfieldIndexMainField);
-        }
+		/// <summary>
+		///
+		/// </summary>
+		/// <returns>returns number of elements in field SampleTimeOffset</returns>
+		public int GetNumSampleTimeOffset()
+		{
+			return GetNumFieldValues(1, Fit.SubfieldIndexMainField);
+		}
 
-        ///<summary>
-        /// Retrieves the BaroPres field
-        /// Units: Pa
-        /// Comment: These are the raw ADC reading. The samples may span across seconds. A conversion will need to be done on this data once read.</summary>
-        /// <param name="index">0 based index of BaroPres element to retrieve</param>
-        /// <returns>Returns nullable uint representing the BaroPres field</returns>
-        public uint? GetBaroPres(int index)
-        {
-            Object val = GetFieldValue(2, index, Fit.SubfieldIndexMainField);
-            if(val == null)
-            {
-                return null;
-            }
+		///<summary>
+		/// Retrieves the SampleTimeOffset field
+		/// Units: ms
+		/// Comment: Each time in the array describes the time at which the barometer sample with the corrosponding index was taken. The samples may span across seconds. Array size must match the number of samples in baro_cal</summary>
+		/// <param name="index">0 based index of SampleTimeOffset element to retrieve</param>
+		/// <returns>Returns nullable ushort representing the SampleTimeOffset field</returns>
+		public ushort? GetSampleTimeOffset(int index)
+		{
+			Object val = GetFieldValue(1, index, Fit.SubfieldIndexMainField);
+			if (val == null)
+			{
+				return null;
+			}
 
-            return (Convert.ToUInt32(val));
-            
-        }
+			return (Convert.ToUInt16(val));
 
-        /// <summary>
-        /// Set BaroPres field
-        /// Units: Pa
-        /// Comment: These are the raw ADC reading. The samples may span across seconds. A conversion will need to be done on this data once read.</summary>
-        /// <param name="index">0 based index of baro_pres</param>
-        /// <param name="baroPres_">Nullable field value to be set</param>
-        public void SetBaroPres(int index, uint? baroPres_)
-        {
-            SetFieldValue(2, index, baroPres_, Fit.SubfieldIndexMainField);
-        }
-        
-        #endregion // Methods
-    } // Class
+		}
+
+		/// <summary>
+		/// Set SampleTimeOffset field
+		/// Units: ms
+		/// Comment: Each time in the array describes the time at which the barometer sample with the corrosponding index was taken. The samples may span across seconds. Array size must match the number of samples in baro_cal</summary>
+		/// <param name="index">0 based index of sample_time_offset</param>
+		/// <param name="sampleTimeOffset_">Nullable field value to be set</param>
+		public void SetSampleTimeOffset(int index, ushort? sampleTimeOffset_)
+		{
+			SetFieldValue(1, index, sampleTimeOffset_, Fit.SubfieldIndexMainField);
+		}
+
+
+		/// <summary>
+		///
+		/// </summary>
+		/// <returns>returns number of elements in field BaroPres</returns>
+		public int GetNumBaroPres()
+		{
+			return GetNumFieldValues(2, Fit.SubfieldIndexMainField);
+		}
+
+		///<summary>
+		/// Retrieves the BaroPres field
+		/// Units: Pa
+		/// Comment: These are the raw ADC reading. The samples may span across seconds. A conversion will need to be done on this data once read.</summary>
+		/// <param name="index">0 based index of BaroPres element to retrieve</param>
+		/// <returns>Returns nullable uint representing the BaroPres field</returns>
+		public uint? GetBaroPres(int index)
+		{
+			Object val = GetFieldValue(2, index, Fit.SubfieldIndexMainField);
+			if (val == null)
+			{
+				return null;
+			}
+
+			return (Convert.ToUInt32(val));
+
+		}
+
+		/// <summary>
+		/// Set BaroPres field
+		/// Units: Pa
+		/// Comment: These are the raw ADC reading. The samples may span across seconds. A conversion will need to be done on this data once read.</summary>
+		/// <param name="index">0 based index of baro_pres</param>
+		/// <param name="baroPres_">Nullable field value to be set</param>
+		public void SetBaroPres(int index, uint? baroPres_)
+		{
+			SetFieldValue(2, index, baroPres_, Fit.SubfieldIndexMainField);
+		}
+
+		#endregion // Methods
+	} // Class
 } // namespace

--- a/Dynastream/Fit/Profile/Mesgs/BeatIntervalsMesg.cs
+++ b/Dynastream/Fit/Profile/Mesgs/BeatIntervalsMesg.cs
@@ -21,125 +21,121 @@ using System.Linq;
 
 namespace Dynastream.Fit
 {
-    /// <summary>
-    /// Implements the BeatIntervals profile message.
-    /// </summary>
-    public class BeatIntervalsMesg : Mesg
-    {
-        #region Fields
-        #endregion
+	/// <summary>
+	/// Implements the BeatIntervals profile message.
+	/// </summary>
+	public class BeatIntervalsMesg : Mesg
+	{
+		#region Fields
+		#endregion
 
-        /// <summary>
-        /// Field Numbers for <see cref="BeatIntervalsMesg"/>
-        /// </summary>
-        public sealed class FieldDefNum
-        {
-            public const byte Timestamp = 253;
-            public const byte TimestampMs = 0;
-            public const byte Time = 1;
-            public const byte Invalid = Fit.FieldNumInvalid;
-        }
+		/// <summary>
+		/// Field Numbers for <see cref="BeatIntervalsMesg"/>
+		/// </summary>
+		public sealed class FieldDefNum
+		{
+			public const byte Timestamp = 253;
+			public const byte TimestampMs = 0;
+			public const byte Time = 1;
+			public const byte Invalid = Fit.FieldNumInvalid;
+		}
 
-        #region Constructors
-        public BeatIntervalsMesg() : base(Profile.GetMesg(MesgNum.BeatIntervals))
-        {
-        }
+		#region Constructors
+		public BeatIntervalsMesg() : base(Profile.GetMesg(MesgNum.BeatIntervals))
+		{
+		}
 
-        public BeatIntervalsMesg(Mesg mesg) : base(mesg)
-        {
-        }
-        #endregion // Constructors
+		public BeatIntervalsMesg(Mesg mesg) : base(mesg)
+		{
+		}
+		#endregion // Constructors
 
-        #region Methods
-        ///<summary>
-        /// Retrieves the Timestamp field</summary>
-        /// <returns>Returns DateTime representing the Timestamp field</returns>
-        public DateTime GetTimestamp()
-        {
-            Object val = GetFieldValue(253, 0, Fit.SubfieldIndexMainField);
-            if(val == null)
-            {
-                return null;
-            }
+		#region Methods
+		///<summary>
+		/// Retrieves the Timestamp field</summary>
+		/// <returns>Returns DateTime representing the Timestamp field</returns>
+		public DateTime Timestamp
+		{
+			get
+			{
+				Object val = GetFieldValue(253, 0, Fit.SubfieldIndexMainField);
+				if (val == null)
+				{
+					return null;
+				}
 
-            return TimestampToDateTime(Convert.ToUInt32(val));
-            
-        }
+				return TimestampToDateTime(Convert.ToUInt32(val));
 
-        /// <summary>
-        /// Set Timestamp field</summary>
-        /// <param name="timestamp_">Nullable field value to be set</param>
-        public void SetTimestamp(DateTime timestamp_)
-        {
-            SetFieldValue(253, 0, timestamp_.GetTimeStamp(), Fit.SubfieldIndexMainField);
-        }
-        
-        ///<summary>
-        /// Retrieves the TimestampMs field
-        /// Units: ms
-        /// Comment: Milliseconds past date_time</summary>
-        /// <returns>Returns nullable ushort representing the TimestampMs field</returns>
-        public ushort? GetTimestampMs()
-        {
-            Object val = GetFieldValue(0, 0, Fit.SubfieldIndexMainField);
-            if(val == null)
-            {
-                return null;
-            }
+			}
+			set
+			{
+				SetFieldValue(253, 0, value.GetTimeStamp(), Fit.SubfieldIndexMainField);
+			}
+		}
 
-            return (Convert.ToUInt16(val));
-            
-        }
+		///<summary>
+		/// Retrieves the TimestampMs field
+		/// Units: ms
+		/// Comment: Milliseconds past date_time</summary>
+		/// <returns>Returns nullable ushort representing the TimestampMs field</returns>
+		public ushort? TimestampMs
+		{
+			get
+			{
+				Object val = GetFieldValue(0, 0, Fit.SubfieldIndexMainField);
+				if (val == null)
+				{
+					return null;
+				}
 
-        /// <summary>
-        /// Set TimestampMs field
-        /// Units: ms
-        /// Comment: Milliseconds past date_time</summary>
-        /// <param name="timestampMs_">Nullable field value to be set</param>
-        public void SetTimestampMs(ushort? timestampMs_)
-        {
-            SetFieldValue(0, 0, timestampMs_, Fit.SubfieldIndexMainField);
-        }
-        
-        
-        /// <summary>
-        ///
-        /// </summary>
-        /// <returns>returns number of elements in field Time</returns>
-        public int GetNumTime()
-        {
-            return GetNumFieldValues(1, Fit.SubfieldIndexMainField);
-        }
+				return (Convert.ToUInt16(val));
 
-        ///<summary>
-        /// Retrieves the Time field
-        /// Units: ms
-        /// Comment: Array of millisecond times between beats</summary>
-        /// <param name="index">0 based index of Time element to retrieve</param>
-        /// <returns>Returns nullable ushort representing the Time field</returns>
-        public ushort? GetTime(int index)
-        {
-            Object val = GetFieldValue(1, index, Fit.SubfieldIndexMainField);
-            if(val == null)
-            {
-                return null;
-            }
+			}
+			set
+			{
+				SetFieldValue(0, 0, value, Fit.SubfieldIndexMainField);
+			}
+		}
 
-            return (Convert.ToUInt16(val));
-            
-        }
 
-        /// <summary>
-        /// Set Time field
-        /// Units: ms
-        /// Comment: Array of millisecond times between beats</summary>
-        /// <param name="index">0 based index of time</param>
-        /// <param name="time_">Nullable field value to be set</param>
-        public void SetTime(int index, ushort? time_)
-        {
-            SetFieldValue(1, index, time_, Fit.SubfieldIndexMainField);
-        }
-        
-        #endregion // Methods
-    } // Class
+		/// <summary>
+		///
+		/// </summary>
+		/// <returns>returns number of elements in field Time</returns>
+		public int GetNumTime()
+		{
+			return GetNumFieldValues(1, Fit.SubfieldIndexMainField);
+		}
+
+		///<summary>
+		/// Retrieves the Time field
+		/// Units: ms
+		/// Comment: Array of millisecond times between beats</summary>
+		/// <param name="index">0 based index of Time element to retrieve</param>
+		/// <returns>Returns nullable ushort representing the Time field</returns>
+		public ushort? GetTime(int index)
+		{
+			Object val = GetFieldValue(1, index, Fit.SubfieldIndexMainField);
+			if (val == null)
+			{
+				return null;
+			}
+
+			return (Convert.ToUInt16(val));
+
+		}
+
+		/// <summary>
+		/// Set Time field
+		/// Units: ms
+		/// Comment: Array of millisecond times between beats</summary>
+		/// <param name="index">0 based index of time</param>
+		/// <param name="time_">Nullable field value to be set</param>
+		public void SetTime(int index, ushort? time_)
+		{
+			SetFieldValue(1, index, time_, Fit.SubfieldIndexMainField);
+		}
+
+		#endregion // Methods
+	} // Class
 } // namespace

--- a/Dynastream/Fit/Profile/Mesgs/BikeProfileMesg.cs
+++ b/Dynastream/Fit/Profile/Mesgs/BikeProfileMesg.cs
@@ -21,812 +21,772 @@ using System.Linq;
 
 namespace Dynastream.Fit
 {
-    /// <summary>
-    /// Implements the BikeProfile profile message.
-    /// </summary>
-    public class BikeProfileMesg : Mesg
-    {
-        #region Fields
-        #endregion
+	/// <summary>
+	/// Implements the BikeProfile profile message.
+	/// </summary>
+	public class BikeProfileMesg : Mesg
+	{
+		#region Fields
+		#endregion
 
-        /// <summary>
-        /// Field Numbers for <see cref="BikeProfileMesg"/>
-        /// </summary>
-        public sealed class FieldDefNum
-        {
-            public const byte MessageIndex = 254;
-            public const byte Name = 0;
-            public const byte Sport = 1;
-            public const byte SubSport = 2;
-            public const byte Odometer = 3;
-            public const byte BikeSpdAntId = 4;
-            public const byte BikeCadAntId = 5;
-            public const byte BikeSpdcadAntId = 6;
-            public const byte BikePowerAntId = 7;
-            public const byte CustomWheelsize = 8;
-            public const byte AutoWheelsize = 9;
-            public const byte BikeWeight = 10;
-            public const byte PowerCalFactor = 11;
-            public const byte AutoWheelCal = 12;
-            public const byte AutoPowerZero = 13;
-            public const byte Id = 14;
-            public const byte SpdEnabled = 15;
-            public const byte CadEnabled = 16;
-            public const byte SpdcadEnabled = 17;
-            public const byte PowerEnabled = 18;
-            public const byte CrankLength = 19;
-            public const byte Enabled = 20;
-            public const byte BikeSpdAntIdTransType = 21;
-            public const byte BikeCadAntIdTransType = 22;
-            public const byte BikeSpdcadAntIdTransType = 23;
-            public const byte BikePowerAntIdTransType = 24;
-            public const byte OdometerRollover = 37;
-            public const byte FrontGearNum = 38;
-            public const byte FrontGear = 39;
-            public const byte RearGearNum = 40;
-            public const byte RearGear = 41;
-            public const byte ShimanoDi2Enabled = 44;
-            public const byte Invalid = Fit.FieldNumInvalid;
-        }
+		/// <summary>
+		/// Field Numbers for <see cref="BikeProfileMesg"/>
+		/// </summary>
+		public sealed class FieldDefNum
+		{
+			public const byte MessageIndex = 254;
+			public const byte Name = 0;
+			public const byte Sport = 1;
+			public const byte SubSport = 2;
+			public const byte Odometer = 3;
+			public const byte BikeSpdAntId = 4;
+			public const byte BikeCadAntId = 5;
+			public const byte BikeSpdcadAntId = 6;
+			public const byte BikePowerAntId = 7;
+			public const byte CustomWheelsize = 8;
+			public const byte AutoWheelsize = 9;
+			public const byte BikeWeight = 10;
+			public const byte PowerCalFactor = 11;
+			public const byte AutoWheelCal = 12;
+			public const byte AutoPowerZero = 13;
+			public const byte Id = 14;
+			public const byte SpdEnabled = 15;
+			public const byte CadEnabled = 16;
+			public const byte SpdcadEnabled = 17;
+			public const byte PowerEnabled = 18;
+			public const byte CrankLength = 19;
+			public const byte Enabled = 20;
+			public const byte BikeSpdAntIdTransType = 21;
+			public const byte BikeCadAntIdTransType = 22;
+			public const byte BikeSpdcadAntIdTransType = 23;
+			public const byte BikePowerAntIdTransType = 24;
+			public const byte OdometerRollover = 37;
+			public const byte FrontGearNum = 38;
+			public const byte FrontGear = 39;
+			public const byte RearGearNum = 40;
+			public const byte RearGear = 41;
+			public const byte ShimanoDi2Enabled = 44;
+			public const byte Invalid = Fit.FieldNumInvalid;
+		}
 
-        #region Constructors
-        public BikeProfileMesg() : base(Profile.GetMesg(MesgNum.BikeProfile))
-        {
-        }
+		#region Constructors
+		public BikeProfileMesg() : base(Profile.GetMesg(MesgNum.BikeProfile))
+		{
+		}
 
-        public BikeProfileMesg(Mesg mesg) : base(mesg)
-        {
-        }
-        #endregion // Constructors
+		public BikeProfileMesg(Mesg mesg) : base(mesg)
+		{
+		}
+		#endregion // Constructors
 
-        #region Methods
-        ///<summary>
-        /// Retrieves the MessageIndex field</summary>
-        /// <returns>Returns nullable ushort representing the MessageIndex field</returns>
-        public ushort? GetMessageIndex()
-        {
-            Object val = GetFieldValue(254, 0, Fit.SubfieldIndexMainField);
-            if(val == null)
-            {
-                return null;
-            }
+		#region Methods
+		///<summary>
+		/// Retrieves the MessageIndex field</summary>
+		/// <returns>Returns nullable ushort representing the MessageIndex field</returns>
+		public ushort? MessageIndex
+		{
+			get
+			{
+				Object val = GetFieldValue(254, 0, Fit.SubfieldIndexMainField);
+				if (val == null)
+				{
+					return null;
+				}
 
-            return (Convert.ToUInt16(val));
-            
-        }
+				return (Convert.ToUInt16(val));
 
-        /// <summary>
-        /// Set MessageIndex field</summary>
-        /// <param name="messageIndex_">Nullable field value to be set</param>
-        public void SetMessageIndex(ushort? messageIndex_)
-        {
-            SetFieldValue(254, 0, messageIndex_, Fit.SubfieldIndexMainField);
-        }
-        
-        ///<summary>
-        /// Retrieves the Name field</summary>
-        /// <returns>Returns byte[] representing the Name field</returns>
-        public byte[] GetName()
-        {
-            byte[] data = (byte[])GetFieldValue(0, 0, Fit.SubfieldIndexMainField);
-            return data.Take(data.Length - 1).ToArray();
-        }
+			}
+			set
+			{
+				SetFieldValue(254, 0, value, Fit.SubfieldIndexMainField);
+			}
+		}
 
-        ///<summary>
-        /// Retrieves the Name field</summary>
-        /// <returns>Returns String representing the Name field</returns>
-        public String GetNameAsString()
-        {
-            byte[] data = (byte[])GetFieldValue(0, 0, Fit.SubfieldIndexMainField);
-            return data != null ? Encoding.UTF8.GetString(data, 0, data.Length - 1) : null;
-        }
+		///<summary>
+		/// Retrieves the Name field</summary>
+		/// <returns>Returns byte[] representing the Name field</returns>
+		public byte[] Name
+		{
+			get
+			{
+				byte[] data = (byte[])GetFieldValue(0, 0, Fit.SubfieldIndexMainField);
+				return data.Take(data.Length - 1).ToArray();
+			}
+			set
+			{
+				SetFieldValue(0, 0, value, Fit.SubfieldIndexMainField);
+			}
+		}
 
-        ///<summary>
-        /// Set Name field</summary>
-        /// <param name="name_"> field value to be set</param>
-        public void SetName(String name_)
-        {
-            byte[] data = Encoding.UTF8.GetBytes(name_);
-            byte[] zdata = new byte[data.Length + 1];
-            data.CopyTo(zdata, 0);
-            SetFieldValue(0, 0, zdata, Fit.SubfieldIndexMainField);
-        }
+		///<summary>
+		/// Retrieves the Name field</summary>
+		/// <returns>Returns String representing the Name field</returns>
+		public String GetNameAsString()
+		{
+			byte[] data = (byte[])GetFieldValue(0, 0, Fit.SubfieldIndexMainField);
+			return data != null ? Encoding.UTF8.GetString(data, 0, data.Length - 1) : null;
+		}
 
-        
-        /// <summary>
-        /// Set Name field</summary>
-        /// <param name="name_">field value to be set</param>
-        public void SetName(byte[] name_)
-        {
-            SetFieldValue(0, 0, name_, Fit.SubfieldIndexMainField);
-        }
-        
-        ///<summary>
-        /// Retrieves the Sport field</summary>
-        /// <returns>Returns nullable Sport enum representing the Sport field</returns>
-        public Sport? GetSport()
-        {
-            object obj = GetFieldValue(1, 0, Fit.SubfieldIndexMainField);
-            Sport? value = obj == null ? (Sport?)null : (Sport)obj;
-            return value;
-        }
+		///<summary>
+		/// Set Name field</summary>
+		/// <param name="name_"> field value to be set</param>
+		public void SetName(String name_)
+		{
+			byte[] data = Encoding.UTF8.GetBytes(name_);
+			byte[] zdata = new byte[data.Length + 1];
+			data.CopyTo(zdata, 0);
+			SetFieldValue(0, 0, zdata, Fit.SubfieldIndexMainField);
+		}
 
-        /// <summary>
-        /// Set Sport field</summary>
-        /// <param name="sport_">Nullable field value to be set</param>
-        public void SetSport(Sport? sport_)
-        {
-            SetFieldValue(1, 0, sport_, Fit.SubfieldIndexMainField);
-        }
-        
-        ///<summary>
-        /// Retrieves the SubSport field</summary>
-        /// <returns>Returns nullable SubSport enum representing the SubSport field</returns>
-        public SubSport? GetSubSport()
-        {
-            object obj = GetFieldValue(2, 0, Fit.SubfieldIndexMainField);
-            SubSport? value = obj == null ? (SubSport?)null : (SubSport)obj;
-            return value;
-        }
+		///<summary>
+		/// Retrieves the Sport field</summary>
+		/// <returns>Returns nullable Sport enum representing the Sport field</returns>
+		public Sport? Sport
+		{
+			get
+			{
+				object obj = GetFieldValue(1, 0, Fit.SubfieldIndexMainField);
+				Sport? value = obj == null ? (Sport?)null : (Sport)obj;
+				return value;
+			}
+			set
+			{
+				SetFieldValue(1, 0, value, Fit.SubfieldIndexMainField);
+			}
+		}
 
-        /// <summary>
-        /// Set SubSport field</summary>
-        /// <param name="subSport_">Nullable field value to be set</param>
-        public void SetSubSport(SubSport? subSport_)
-        {
-            SetFieldValue(2, 0, subSport_, Fit.SubfieldIndexMainField);
-        }
-        
-        ///<summary>
-        /// Retrieves the Odometer field
-        /// Units: m</summary>
-        /// <returns>Returns nullable float representing the Odometer field</returns>
-        public float? GetOdometer()
-        {
-            Object val = GetFieldValue(3, 0, Fit.SubfieldIndexMainField);
-            if(val == null)
-            {
-                return null;
-            }
+		///<summary>
+		/// Retrieves the SubSport field</summary>
+		/// <returns>Returns nullable SubSport enum representing the SubSport field</returns>
+		public SubSport? SubSport
+		{
+			get
+			{
+				object obj = GetFieldValue(2, 0, Fit.SubfieldIndexMainField);
+				SubSport? value = obj == null ? (SubSport?)null : (SubSport)obj;
+				return value;
+			}
+			set
+			{
+				SetFieldValue(2, 0, value, Fit.SubfieldIndexMainField);
+			}
+		}
 
-            return (Convert.ToSingle(val));
-            
-        }
+		///<summary>
+		/// Retrieves the Odometer field
+		/// Units: m</summary>
+		/// <returns>Returns nullable float representing the Odometer field</returns>
+		public float? Odometer
+		{
+			get
+			{
+				Object val = GetFieldValue(3, 0, Fit.SubfieldIndexMainField);
+				if (val == null)
+				{
+					return null;
+				}
 
-        /// <summary>
-        /// Set Odometer field
-        /// Units: m</summary>
-        /// <param name="odometer_">Nullable field value to be set</param>
-        public void SetOdometer(float? odometer_)
-        {
-            SetFieldValue(3, 0, odometer_, Fit.SubfieldIndexMainField);
-        }
-        
-        ///<summary>
-        /// Retrieves the BikeSpdAntId field</summary>
-        /// <returns>Returns nullable ushort representing the BikeSpdAntId field</returns>
-        public ushort? GetBikeSpdAntId()
-        {
-            Object val = GetFieldValue(4, 0, Fit.SubfieldIndexMainField);
-            if(val == null)
-            {
-                return null;
-            }
+				return (Convert.ToSingle(val));
 
-            return (Convert.ToUInt16(val));
-            
-        }
+			}
+			set
+			{
+				SetFieldValue(3, 0, value, Fit.SubfieldIndexMainField);
+			}
+		}
 
-        /// <summary>
-        /// Set BikeSpdAntId field</summary>
-        /// <param name="bikeSpdAntId_">Nullable field value to be set</param>
-        public void SetBikeSpdAntId(ushort? bikeSpdAntId_)
-        {
-            SetFieldValue(4, 0, bikeSpdAntId_, Fit.SubfieldIndexMainField);
-        }
-        
-        ///<summary>
-        /// Retrieves the BikeCadAntId field</summary>
-        /// <returns>Returns nullable ushort representing the BikeCadAntId field</returns>
-        public ushort? GetBikeCadAntId()
-        {
-            Object val = GetFieldValue(5, 0, Fit.SubfieldIndexMainField);
-            if(val == null)
-            {
-                return null;
-            }
+		///<summary>
+		/// Retrieves the BikeSpdAntId field</summary>
+		/// <returns>Returns nullable ushort representing the BikeSpdAntId field</returns>
+		public ushort? BikeSpdAntId
+		{
+			get
+			{
+				Object val = GetFieldValue(4, 0, Fit.SubfieldIndexMainField);
+				if (val == null)
+				{
+					return null;
+				}
 
-            return (Convert.ToUInt16(val));
-            
-        }
+				return (Convert.ToUInt16(val));
 
-        /// <summary>
-        /// Set BikeCadAntId field</summary>
-        /// <param name="bikeCadAntId_">Nullable field value to be set</param>
-        public void SetBikeCadAntId(ushort? bikeCadAntId_)
-        {
-            SetFieldValue(5, 0, bikeCadAntId_, Fit.SubfieldIndexMainField);
-        }
-        
-        ///<summary>
-        /// Retrieves the BikeSpdcadAntId field</summary>
-        /// <returns>Returns nullable ushort representing the BikeSpdcadAntId field</returns>
-        public ushort? GetBikeSpdcadAntId()
-        {
-            Object val = GetFieldValue(6, 0, Fit.SubfieldIndexMainField);
-            if(val == null)
-            {
-                return null;
-            }
+			}
+			set
+			{
+				SetFieldValue(4, 0, value, Fit.SubfieldIndexMainField);
+			}
+		}
 
-            return (Convert.ToUInt16(val));
-            
-        }
+		///<summary>
+		/// Retrieves the BikeCadAntId field</summary>
+		/// <returns>Returns nullable ushort representing the BikeCadAntId field</returns>
+		public ushort? BikeCadAntId
+		{
+			get
+			{
+				Object val = GetFieldValue(5, 0, Fit.SubfieldIndexMainField);
+				if (val == null)
+				{
+					return null;
+				}
 
-        /// <summary>
-        /// Set BikeSpdcadAntId field</summary>
-        /// <param name="bikeSpdcadAntId_">Nullable field value to be set</param>
-        public void SetBikeSpdcadAntId(ushort? bikeSpdcadAntId_)
-        {
-            SetFieldValue(6, 0, bikeSpdcadAntId_, Fit.SubfieldIndexMainField);
-        }
-        
-        ///<summary>
-        /// Retrieves the BikePowerAntId field</summary>
-        /// <returns>Returns nullable ushort representing the BikePowerAntId field</returns>
-        public ushort? GetBikePowerAntId()
-        {
-            Object val = GetFieldValue(7, 0, Fit.SubfieldIndexMainField);
-            if(val == null)
-            {
-                return null;
-            }
+				return (Convert.ToUInt16(val));
 
-            return (Convert.ToUInt16(val));
-            
-        }
+			}
+			set
+			{
+				SetFieldValue(5, 0, value, Fit.SubfieldIndexMainField);
+			}
+		}
 
-        /// <summary>
-        /// Set BikePowerAntId field</summary>
-        /// <param name="bikePowerAntId_">Nullable field value to be set</param>
-        public void SetBikePowerAntId(ushort? bikePowerAntId_)
-        {
-            SetFieldValue(7, 0, bikePowerAntId_, Fit.SubfieldIndexMainField);
-        }
-        
-        ///<summary>
-        /// Retrieves the CustomWheelsize field
-        /// Units: m</summary>
-        /// <returns>Returns nullable float representing the CustomWheelsize field</returns>
-        public float? GetCustomWheelsize()
-        {
-            Object val = GetFieldValue(8, 0, Fit.SubfieldIndexMainField);
-            if(val == null)
-            {
-                return null;
-            }
+		///<summary>
+		/// Retrieves the BikeSpdcadAntId field</summary>
+		/// <returns>Returns nullable ushort representing the BikeSpdcadAntId field</returns>
+		public ushort? BikeSpdcadAntId
+		{
+			get
+			{
+				Object val = GetFieldValue(6, 0, Fit.SubfieldIndexMainField);
+				if (val == null)
+				{
+					return null;
+				}
 
-            return (Convert.ToSingle(val));
-            
-        }
+				return (Convert.ToUInt16(val));
 
-        /// <summary>
-        /// Set CustomWheelsize field
-        /// Units: m</summary>
-        /// <param name="customWheelsize_">Nullable field value to be set</param>
-        public void SetCustomWheelsize(float? customWheelsize_)
-        {
-            SetFieldValue(8, 0, customWheelsize_, Fit.SubfieldIndexMainField);
-        }
-        
-        ///<summary>
-        /// Retrieves the AutoWheelsize field
-        /// Units: m</summary>
-        /// <returns>Returns nullable float representing the AutoWheelsize field</returns>
-        public float? GetAutoWheelsize()
-        {
-            Object val = GetFieldValue(9, 0, Fit.SubfieldIndexMainField);
-            if(val == null)
-            {
-                return null;
-            }
+			}
+			set
+			{
+				SetFieldValue(6, 0, value, Fit.SubfieldIndexMainField);
+			}
+		}
 
-            return (Convert.ToSingle(val));
-            
-        }
+		///<summary>
+		/// Retrieves the BikePowerAntId field</summary>
+		/// <returns>Returns nullable ushort representing the BikePowerAntId field</returns>
+		public ushort? BikePowerAntId
+		{
+			get
+			{
+				Object val = GetFieldValue(7, 0, Fit.SubfieldIndexMainField);
+				if (val == null)
+				{
+					return null;
+				}
 
-        /// <summary>
-        /// Set AutoWheelsize field
-        /// Units: m</summary>
-        /// <param name="autoWheelsize_">Nullable field value to be set</param>
-        public void SetAutoWheelsize(float? autoWheelsize_)
-        {
-            SetFieldValue(9, 0, autoWheelsize_, Fit.SubfieldIndexMainField);
-        }
-        
-        ///<summary>
-        /// Retrieves the BikeWeight field
-        /// Units: kg</summary>
-        /// <returns>Returns nullable float representing the BikeWeight field</returns>
-        public float? GetBikeWeight()
-        {
-            Object val = GetFieldValue(10, 0, Fit.SubfieldIndexMainField);
-            if(val == null)
-            {
-                return null;
-            }
+				return (Convert.ToUInt16(val));
 
-            return (Convert.ToSingle(val));
-            
-        }
+			}
+			set
+			{
+				SetFieldValue(7, 0, value, Fit.SubfieldIndexMainField);
+			}
+		}
 
-        /// <summary>
-        /// Set BikeWeight field
-        /// Units: kg</summary>
-        /// <param name="bikeWeight_">Nullable field value to be set</param>
-        public void SetBikeWeight(float? bikeWeight_)
-        {
-            SetFieldValue(10, 0, bikeWeight_, Fit.SubfieldIndexMainField);
-        }
-        
-        ///<summary>
-        /// Retrieves the PowerCalFactor field
-        /// Units: %</summary>
-        /// <returns>Returns nullable float representing the PowerCalFactor field</returns>
-        public float? GetPowerCalFactor()
-        {
-            Object val = GetFieldValue(11, 0, Fit.SubfieldIndexMainField);
-            if(val == null)
-            {
-                return null;
-            }
+		///<summary>
+		/// Retrieves the CustomWheelsize field
+		/// Units: m</summary>
+		/// <returns>Returns nullable float representing the CustomWheelsize field</returns>
+		public float? CustomWheelsize
+		{
+			get
+			{
+				Object val = GetFieldValue(8, 0, Fit.SubfieldIndexMainField);
+				if (val == null)
+				{
+					return null;
+				}
 
-            return (Convert.ToSingle(val));
-            
-        }
+				return (Convert.ToSingle(val));
 
-        /// <summary>
-        /// Set PowerCalFactor field
-        /// Units: %</summary>
-        /// <param name="powerCalFactor_">Nullable field value to be set</param>
-        public void SetPowerCalFactor(float? powerCalFactor_)
-        {
-            SetFieldValue(11, 0, powerCalFactor_, Fit.SubfieldIndexMainField);
-        }
-        
-        ///<summary>
-        /// Retrieves the AutoWheelCal field</summary>
-        /// <returns>Returns nullable Bool enum representing the AutoWheelCal field</returns>
-        public Bool? GetAutoWheelCal()
-        {
-            object obj = GetFieldValue(12, 0, Fit.SubfieldIndexMainField);
-            Bool? value = obj == null ? (Bool?)null : (Bool)obj;
-            return value;
-        }
+			}
+			set
+			{
+				SetFieldValue(8, 0, value, Fit.SubfieldIndexMainField);
+			}
+		}
 
-        /// <summary>
-        /// Set AutoWheelCal field</summary>
-        /// <param name="autoWheelCal_">Nullable field value to be set</param>
-        public void SetAutoWheelCal(Bool? autoWheelCal_)
-        {
-            SetFieldValue(12, 0, autoWheelCal_, Fit.SubfieldIndexMainField);
-        }
-        
-        ///<summary>
-        /// Retrieves the AutoPowerZero field</summary>
-        /// <returns>Returns nullable Bool enum representing the AutoPowerZero field</returns>
-        public Bool? GetAutoPowerZero()
-        {
-            object obj = GetFieldValue(13, 0, Fit.SubfieldIndexMainField);
-            Bool? value = obj == null ? (Bool?)null : (Bool)obj;
-            return value;
-        }
+		///<summary>
+		/// Retrieves the AutoWheelsize field
+		/// Units: m</summary>
+		/// <returns>Returns nullable float representing the AutoWheelsize field</returns>
+		public float? AutoWheelsize
+		{
+			get
+			{
+				Object val = GetFieldValue(9, 0, Fit.SubfieldIndexMainField);
+				if (val == null)
+				{
+					return null;
+				}
 
-        /// <summary>
-        /// Set AutoPowerZero field</summary>
-        /// <param name="autoPowerZero_">Nullable field value to be set</param>
-        public void SetAutoPowerZero(Bool? autoPowerZero_)
-        {
-            SetFieldValue(13, 0, autoPowerZero_, Fit.SubfieldIndexMainField);
-        }
-        
-        ///<summary>
-        /// Retrieves the Id field</summary>
-        /// <returns>Returns nullable byte representing the Id field</returns>
-        public byte? GetId()
-        {
-            Object val = GetFieldValue(14, 0, Fit.SubfieldIndexMainField);
-            if(val == null)
-            {
-                return null;
-            }
+				return (Convert.ToSingle(val));
 
-            return (Convert.ToByte(val));
-            
-        }
+			}
+			set
+			{
+				SetFieldValue(9, 0, value, Fit.SubfieldIndexMainField);
+			}
+		}
 
-        /// <summary>
-        /// Set Id field</summary>
-        /// <param name="id_">Nullable field value to be set</param>
-        public void SetId(byte? id_)
-        {
-            SetFieldValue(14, 0, id_, Fit.SubfieldIndexMainField);
-        }
-        
-        ///<summary>
-        /// Retrieves the SpdEnabled field</summary>
-        /// <returns>Returns nullable Bool enum representing the SpdEnabled field</returns>
-        public Bool? GetSpdEnabled()
-        {
-            object obj = GetFieldValue(15, 0, Fit.SubfieldIndexMainField);
-            Bool? value = obj == null ? (Bool?)null : (Bool)obj;
-            return value;
-        }
+		///<summary>
+		/// Retrieves the BikeWeight field
+		/// Units: kg</summary>
+		/// <returns>Returns nullable float representing the BikeWeight field</returns>
+		public float? BikeWeight
+		{
+			get
+			{
+				Object val = GetFieldValue(10, 0, Fit.SubfieldIndexMainField);
+				if (val == null)
+				{
+					return null;
+				}
 
-        /// <summary>
-        /// Set SpdEnabled field</summary>
-        /// <param name="spdEnabled_">Nullable field value to be set</param>
-        public void SetSpdEnabled(Bool? spdEnabled_)
-        {
-            SetFieldValue(15, 0, spdEnabled_, Fit.SubfieldIndexMainField);
-        }
-        
-        ///<summary>
-        /// Retrieves the CadEnabled field</summary>
-        /// <returns>Returns nullable Bool enum representing the CadEnabled field</returns>
-        public Bool? GetCadEnabled()
-        {
-            object obj = GetFieldValue(16, 0, Fit.SubfieldIndexMainField);
-            Bool? value = obj == null ? (Bool?)null : (Bool)obj;
-            return value;
-        }
+				return (Convert.ToSingle(val));
 
-        /// <summary>
-        /// Set CadEnabled field</summary>
-        /// <param name="cadEnabled_">Nullable field value to be set</param>
-        public void SetCadEnabled(Bool? cadEnabled_)
-        {
-            SetFieldValue(16, 0, cadEnabled_, Fit.SubfieldIndexMainField);
-        }
-        
-        ///<summary>
-        /// Retrieves the SpdcadEnabled field</summary>
-        /// <returns>Returns nullable Bool enum representing the SpdcadEnabled field</returns>
-        public Bool? GetSpdcadEnabled()
-        {
-            object obj = GetFieldValue(17, 0, Fit.SubfieldIndexMainField);
-            Bool? value = obj == null ? (Bool?)null : (Bool)obj;
-            return value;
-        }
+			}
+			set
+			{
+				SetFieldValue(10, 0, value, Fit.SubfieldIndexMainField);
+			}
+		}
 
-        /// <summary>
-        /// Set SpdcadEnabled field</summary>
-        /// <param name="spdcadEnabled_">Nullable field value to be set</param>
-        public void SetSpdcadEnabled(Bool? spdcadEnabled_)
-        {
-            SetFieldValue(17, 0, spdcadEnabled_, Fit.SubfieldIndexMainField);
-        }
-        
-        ///<summary>
-        /// Retrieves the PowerEnabled field</summary>
-        /// <returns>Returns nullable Bool enum representing the PowerEnabled field</returns>
-        public Bool? GetPowerEnabled()
-        {
-            object obj = GetFieldValue(18, 0, Fit.SubfieldIndexMainField);
-            Bool? value = obj == null ? (Bool?)null : (Bool)obj;
-            return value;
-        }
+		///<summary>
+		/// Retrieves the PowerCalFactor field
+		/// Units: %</summary>
+		/// <returns>Returns nullable float representing the PowerCalFactor field</returns>
+		public float? PowerCalFactor
+		{
+			get
+			{
+				Object val = GetFieldValue(11, 0, Fit.SubfieldIndexMainField);
+				if (val == null)
+				{
+					return null;
+				}
 
-        /// <summary>
-        /// Set PowerEnabled field</summary>
-        /// <param name="powerEnabled_">Nullable field value to be set</param>
-        public void SetPowerEnabled(Bool? powerEnabled_)
-        {
-            SetFieldValue(18, 0, powerEnabled_, Fit.SubfieldIndexMainField);
-        }
-        
-        ///<summary>
-        /// Retrieves the CrankLength field
-        /// Units: mm</summary>
-        /// <returns>Returns nullable float representing the CrankLength field</returns>
-        public float? GetCrankLength()
-        {
-            Object val = GetFieldValue(19, 0, Fit.SubfieldIndexMainField);
-            if(val == null)
-            {
-                return null;
-            }
+				return (Convert.ToSingle(val));
 
-            return (Convert.ToSingle(val));
-            
-        }
+			}
+			set
+			{
+				SetFieldValue(11, 0, value, Fit.SubfieldIndexMainField);
+			}
+		}
 
-        /// <summary>
-        /// Set CrankLength field
-        /// Units: mm</summary>
-        /// <param name="crankLength_">Nullable field value to be set</param>
-        public void SetCrankLength(float? crankLength_)
-        {
-            SetFieldValue(19, 0, crankLength_, Fit.SubfieldIndexMainField);
-        }
-        
-        ///<summary>
-        /// Retrieves the Enabled field</summary>
-        /// <returns>Returns nullable Bool enum representing the Enabled field</returns>
-        public Bool? GetEnabled()
-        {
-            object obj = GetFieldValue(20, 0, Fit.SubfieldIndexMainField);
-            Bool? value = obj == null ? (Bool?)null : (Bool)obj;
-            return value;
-        }
+		///<summary>
+		/// Retrieves the AutoWheelCal field</summary>
+		/// <returns>Returns nullable Bool enum representing the AutoWheelCal field</returns>
+		public Bool? AutoWheelCal
+		{
+			get
+			{
+				object obj = GetFieldValue(12, 0, Fit.SubfieldIndexMainField);
+				Bool? value = obj == null ? (Bool?)null : (Bool)obj;
+				return value;
+			}
+			set
+			{
+				SetFieldValue(12, 0, value, Fit.SubfieldIndexMainField);
+			}
+		}
 
-        /// <summary>
-        /// Set Enabled field</summary>
-        /// <param name="enabled_">Nullable field value to be set</param>
-        public void SetEnabled(Bool? enabled_)
-        {
-            SetFieldValue(20, 0, enabled_, Fit.SubfieldIndexMainField);
-        }
-        
-        ///<summary>
-        /// Retrieves the BikeSpdAntIdTransType field</summary>
-        /// <returns>Returns nullable byte representing the BikeSpdAntIdTransType field</returns>
-        public byte? GetBikeSpdAntIdTransType()
-        {
-            Object val = GetFieldValue(21, 0, Fit.SubfieldIndexMainField);
-            if(val == null)
-            {
-                return null;
-            }
+		///<summary>
+		/// Retrieves the AutoPowerZero field</summary>
+		/// <returns>Returns nullable Bool enum representing the AutoPowerZero field</returns>
+		public Bool? AutoPowerZero
+		{
+			get
+			{
+				object obj = GetFieldValue(13, 0, Fit.SubfieldIndexMainField);
+				Bool? value = obj == null ? (Bool?)null : (Bool)obj;
+				return value;
+			}
+			set
+			{
+				SetFieldValue(13, 0, value, Fit.SubfieldIndexMainField);
+			}
+		}
 
-            return (Convert.ToByte(val));
-            
-        }
+		///<summary>
+		/// Retrieves the Id field</summary>
+		/// <returns>Returns nullable byte representing the Id field</returns>
+		public byte? Id
+		{
+			get
+			{
+				Object val = GetFieldValue(14, 0, Fit.SubfieldIndexMainField);
+				if (val == null)
+				{
+					return null;
+				}
 
-        /// <summary>
-        /// Set BikeSpdAntIdTransType field</summary>
-        /// <param name="bikeSpdAntIdTransType_">Nullable field value to be set</param>
-        public void SetBikeSpdAntIdTransType(byte? bikeSpdAntIdTransType_)
-        {
-            SetFieldValue(21, 0, bikeSpdAntIdTransType_, Fit.SubfieldIndexMainField);
-        }
-        
-        ///<summary>
-        /// Retrieves the BikeCadAntIdTransType field</summary>
-        /// <returns>Returns nullable byte representing the BikeCadAntIdTransType field</returns>
-        public byte? GetBikeCadAntIdTransType()
-        {
-            Object val = GetFieldValue(22, 0, Fit.SubfieldIndexMainField);
-            if(val == null)
-            {
-                return null;
-            }
+				return (Convert.ToByte(val));
 
-            return (Convert.ToByte(val));
-            
-        }
+			}
+			set
+			{
+				SetFieldValue(14, 0, value, Fit.SubfieldIndexMainField);
+			}
+		}
 
-        /// <summary>
-        /// Set BikeCadAntIdTransType field</summary>
-        /// <param name="bikeCadAntIdTransType_">Nullable field value to be set</param>
-        public void SetBikeCadAntIdTransType(byte? bikeCadAntIdTransType_)
-        {
-            SetFieldValue(22, 0, bikeCadAntIdTransType_, Fit.SubfieldIndexMainField);
-        }
-        
-        ///<summary>
-        /// Retrieves the BikeSpdcadAntIdTransType field</summary>
-        /// <returns>Returns nullable byte representing the BikeSpdcadAntIdTransType field</returns>
-        public byte? GetBikeSpdcadAntIdTransType()
-        {
-            Object val = GetFieldValue(23, 0, Fit.SubfieldIndexMainField);
-            if(val == null)
-            {
-                return null;
-            }
+		///<summary>
+		/// Retrieves the SpdEnabled field</summary>
+		/// <returns>Returns nullable Bool enum representing the SpdEnabled field</returns>
+		public Bool? SpdEnabled
+		{
+			get
+			{
+				object obj = GetFieldValue(15, 0, Fit.SubfieldIndexMainField);
+				Bool? value = obj == null ? (Bool?)null : (Bool)obj;
+				return value;
+			}
+			set
+			{
+				SetFieldValue(15, 0, value, Fit.SubfieldIndexMainField);
+			}
+		}
 
-            return (Convert.ToByte(val));
-            
-        }
+		///<summary>
+		/// Retrieves the CadEnabled field</summary>
+		/// <returns>Returns nullable Bool enum representing the CadEnabled field</returns>
+		public Bool? CadEnabled
+		{
+			get
+			{
+				object obj = GetFieldValue(16, 0, Fit.SubfieldIndexMainField);
+				Bool? value = obj == null ? (Bool?)null : (Bool)obj;
+				return value;
+			}
+			set
+			{
+				SetFieldValue(16, 0, value, Fit.SubfieldIndexMainField);
+			}
+		}
 
-        /// <summary>
-        /// Set BikeSpdcadAntIdTransType field</summary>
-        /// <param name="bikeSpdcadAntIdTransType_">Nullable field value to be set</param>
-        public void SetBikeSpdcadAntIdTransType(byte? bikeSpdcadAntIdTransType_)
-        {
-            SetFieldValue(23, 0, bikeSpdcadAntIdTransType_, Fit.SubfieldIndexMainField);
-        }
-        
-        ///<summary>
-        /// Retrieves the BikePowerAntIdTransType field</summary>
-        /// <returns>Returns nullable byte representing the BikePowerAntIdTransType field</returns>
-        public byte? GetBikePowerAntIdTransType()
-        {
-            Object val = GetFieldValue(24, 0, Fit.SubfieldIndexMainField);
-            if(val == null)
-            {
-                return null;
-            }
+		///<summary>
+		/// Retrieves the SpdcadEnabled field</summary>
+		/// <returns>Returns nullable Bool enum representing the SpdcadEnabled field</returns>
+		public Bool? SpdcadEnabled
+		{
+			get
+			{
+				object obj = GetFieldValue(17, 0, Fit.SubfieldIndexMainField);
+				Bool? value = obj == null ? (Bool?)null : (Bool)obj;
+				return value;
+			}
+			set
+			{
+				SetFieldValue(17, 0, value, Fit.SubfieldIndexMainField);
+			}
+		}
 
-            return (Convert.ToByte(val));
-            
-        }
+		///<summary>
+		/// Retrieves the PowerEnabled field</summary>
+		/// <returns>Returns nullable Bool enum representing the PowerEnabled field</returns>
+		public Bool? PowerEnabled
+		{
+			get
+			{
+				object obj = GetFieldValue(18, 0, Fit.SubfieldIndexMainField);
+				Bool? value = obj == null ? (Bool?)null : (Bool)obj;
+				return value;
+			}
+			set
+			{
+				SetFieldValue(18, 0, value, Fit.SubfieldIndexMainField);
+			}
+		}
 
-        /// <summary>
-        /// Set BikePowerAntIdTransType field</summary>
-        /// <param name="bikePowerAntIdTransType_">Nullable field value to be set</param>
-        public void SetBikePowerAntIdTransType(byte? bikePowerAntIdTransType_)
-        {
-            SetFieldValue(24, 0, bikePowerAntIdTransType_, Fit.SubfieldIndexMainField);
-        }
-        
-        ///<summary>
-        /// Retrieves the OdometerRollover field
-        /// Comment: Rollover counter that can be used to extend the odometer</summary>
-        /// <returns>Returns nullable byte representing the OdometerRollover field</returns>
-        public byte? GetOdometerRollover()
-        {
-            Object val = GetFieldValue(37, 0, Fit.SubfieldIndexMainField);
-            if(val == null)
-            {
-                return null;
-            }
+		///<summary>
+		/// Retrieves the CrankLength field
+		/// Units: mm</summary>
+		/// <returns>Returns nullable float representing the CrankLength field</returns>
+		public float? CrankLength
+		{
+			get
+			{
+				Object val = GetFieldValue(19, 0, Fit.SubfieldIndexMainField);
+				if (val == null)
+				{
+					return null;
+				}
 
-            return (Convert.ToByte(val));
-            
-        }
+				return (Convert.ToSingle(val));
 
-        /// <summary>
-        /// Set OdometerRollover field
-        /// Comment: Rollover counter that can be used to extend the odometer</summary>
-        /// <param name="odometerRollover_">Nullable field value to be set</param>
-        public void SetOdometerRollover(byte? odometerRollover_)
-        {
-            SetFieldValue(37, 0, odometerRollover_, Fit.SubfieldIndexMainField);
-        }
-        
-        ///<summary>
-        /// Retrieves the FrontGearNum field
-        /// Comment: Number of front gears</summary>
-        /// <returns>Returns nullable byte representing the FrontGearNum field</returns>
-        public byte? GetFrontGearNum()
-        {
-            Object val = GetFieldValue(38, 0, Fit.SubfieldIndexMainField);
-            if(val == null)
-            {
-                return null;
-            }
+			}
+			set
+			{
+				SetFieldValue(19, 0, value, Fit.SubfieldIndexMainField);
+			}
+		}
 
-            return (Convert.ToByte(val));
-            
-        }
+		///<summary>
+		/// Retrieves the Enabled field</summary>
+		/// <returns>Returns nullable Bool enum representing the Enabled field</returns>
+		public Bool? Enabled
+		{
+			get
+			{
+				object obj = GetFieldValue(20, 0, Fit.SubfieldIndexMainField);
+				Bool? value = obj == null ? (Bool?)null : (Bool)obj;
+				return value;
+			}
+			set
+			{
+				SetFieldValue(20, 0, value, Fit.SubfieldIndexMainField);
+			}
+		}
 
-        /// <summary>
-        /// Set FrontGearNum field
-        /// Comment: Number of front gears</summary>
-        /// <param name="frontGearNum_">Nullable field value to be set</param>
-        public void SetFrontGearNum(byte? frontGearNum_)
-        {
-            SetFieldValue(38, 0, frontGearNum_, Fit.SubfieldIndexMainField);
-        }
-        
-        
-        /// <summary>
-        ///
-        /// </summary>
-        /// <returns>returns number of elements in field FrontGear</returns>
-        public int GetNumFrontGear()
-        {
-            return GetNumFieldValues(39, Fit.SubfieldIndexMainField);
-        }
+		///<summary>
+		/// Retrieves the BikeSpdAntIdTransType field</summary>
+		/// <returns>Returns nullable byte representing the BikeSpdAntIdTransType field</returns>
+		public byte? BikeSpdAntIdTransType
+		{
+			get
+			{
+				Object val = GetFieldValue(21, 0, Fit.SubfieldIndexMainField);
+				if (val == null)
+				{
+					return null;
+				}
 
-        ///<summary>
-        /// Retrieves the FrontGear field
-        /// Comment: Number of teeth on each gear 0 is innermost</summary>
-        /// <param name="index">0 based index of FrontGear element to retrieve</param>
-        /// <returns>Returns nullable byte representing the FrontGear field</returns>
-        public byte? GetFrontGear(int index)
-        {
-            Object val = GetFieldValue(39, index, Fit.SubfieldIndexMainField);
-            if(val == null)
-            {
-                return null;
-            }
+				return (Convert.ToByte(val));
 
-            return (Convert.ToByte(val));
-            
-        }
+			}
+			set
+			{
+				SetFieldValue(21, 0, value, Fit.SubfieldIndexMainField);
+			}
+		}
 
-        /// <summary>
-        /// Set FrontGear field
-        /// Comment: Number of teeth on each gear 0 is innermost</summary>
-        /// <param name="index">0 based index of front_gear</param>
-        /// <param name="frontGear_">Nullable field value to be set</param>
-        public void SetFrontGear(int index, byte? frontGear_)
-        {
-            SetFieldValue(39, index, frontGear_, Fit.SubfieldIndexMainField);
-        }
-        
-        ///<summary>
-        /// Retrieves the RearGearNum field
-        /// Comment: Number of rear gears</summary>
-        /// <returns>Returns nullable byte representing the RearGearNum field</returns>
-        public byte? GetRearGearNum()
-        {
-            Object val = GetFieldValue(40, 0, Fit.SubfieldIndexMainField);
-            if(val == null)
-            {
-                return null;
-            }
+		///<summary>
+		/// Retrieves the BikeCadAntIdTransType field</summary>
+		/// <returns>Returns nullable byte representing the BikeCadAntIdTransType field</returns>
+		public byte? BikeCadAntIdTransType
+		{
+			get
+			{
+				Object val = GetFieldValue(22, 0, Fit.SubfieldIndexMainField);
+				if (val == null)
+				{
+					return null;
+				}
 
-            return (Convert.ToByte(val));
-            
-        }
+				return (Convert.ToByte(val));
 
-        /// <summary>
-        /// Set RearGearNum field
-        /// Comment: Number of rear gears</summary>
-        /// <param name="rearGearNum_">Nullable field value to be set</param>
-        public void SetRearGearNum(byte? rearGearNum_)
-        {
-            SetFieldValue(40, 0, rearGearNum_, Fit.SubfieldIndexMainField);
-        }
-        
-        
-        /// <summary>
-        ///
-        /// </summary>
-        /// <returns>returns number of elements in field RearGear</returns>
-        public int GetNumRearGear()
-        {
-            return GetNumFieldValues(41, Fit.SubfieldIndexMainField);
-        }
+			}
+			set
+			{
+				SetFieldValue(22, 0, value, Fit.SubfieldIndexMainField);
+			}
+		}
 
-        ///<summary>
-        /// Retrieves the RearGear field
-        /// Comment: Number of teeth on each gear 0 is innermost</summary>
-        /// <param name="index">0 based index of RearGear element to retrieve</param>
-        /// <returns>Returns nullable byte representing the RearGear field</returns>
-        public byte? GetRearGear(int index)
-        {
-            Object val = GetFieldValue(41, index, Fit.SubfieldIndexMainField);
-            if(val == null)
-            {
-                return null;
-            }
+		///<summary>
+		/// Retrieves the BikeSpdcadAntIdTransType field</summary>
+		/// <returns>Returns nullable byte representing the BikeSpdcadAntIdTransType field</returns>
+		public byte? BikeSpdcadAntIdTransType
+		{
+			get
+			{
+				Object val = GetFieldValue(23, 0, Fit.SubfieldIndexMainField);
+				if (val == null)
+				{
+					return null;
+				}
 
-            return (Convert.ToByte(val));
-            
-        }
+				return (Convert.ToByte(val));
 
-        /// <summary>
-        /// Set RearGear field
-        /// Comment: Number of teeth on each gear 0 is innermost</summary>
-        /// <param name="index">0 based index of rear_gear</param>
-        /// <param name="rearGear_">Nullable field value to be set</param>
-        public void SetRearGear(int index, byte? rearGear_)
-        {
-            SetFieldValue(41, index, rearGear_, Fit.SubfieldIndexMainField);
-        }
-        
-        ///<summary>
-        /// Retrieves the ShimanoDi2Enabled field</summary>
-        /// <returns>Returns nullable Bool enum representing the ShimanoDi2Enabled field</returns>
-        public Bool? GetShimanoDi2Enabled()
-        {
-            object obj = GetFieldValue(44, 0, Fit.SubfieldIndexMainField);
-            Bool? value = obj == null ? (Bool?)null : (Bool)obj;
-            return value;
-        }
+			}
+			set
+			{
+				SetFieldValue(23, 0, value, Fit.SubfieldIndexMainField);
+			}
+		}
 
-        /// <summary>
-        /// Set ShimanoDi2Enabled field</summary>
-        /// <param name="shimanoDi2Enabled_">Nullable field value to be set</param>
-        public void SetShimanoDi2Enabled(Bool? shimanoDi2Enabled_)
-        {
-            SetFieldValue(44, 0, shimanoDi2Enabled_, Fit.SubfieldIndexMainField);
-        }
-        
-        #endregion // Methods
-    } // Class
+		///<summary>
+		/// Retrieves the BikePowerAntIdTransType field</summary>
+		/// <returns>Returns nullable byte representing the BikePowerAntIdTransType field</returns>
+		public byte? BikePowerAntIdTransType
+		{
+			get
+			{
+				Object val = GetFieldValue(24, 0, Fit.SubfieldIndexMainField);
+				if (val == null)
+				{
+					return null;
+				}
+
+				return (Convert.ToByte(val));
+
+			}
+			set
+			{
+				SetFieldValue(24, 0, value, Fit.SubfieldIndexMainField);
+			}
+		}
+
+		///<summary>
+		/// Retrieves the OdometerRollover field
+		/// Comment: Rollover counter that can be used to extend the odometer</summary>
+		/// <returns>Returns nullable byte representing the OdometerRollover field</returns>
+		public byte? OdometerRollover
+		{
+			get
+			{
+				Object val = GetFieldValue(37, 0, Fit.SubfieldIndexMainField);
+				if (val == null)
+				{
+					return null;
+				}
+
+				return (Convert.ToByte(val));
+
+			}
+			set
+			{
+				SetFieldValue(37, 0, value, Fit.SubfieldIndexMainField);
+			}
+		}
+
+		///<summary>
+		/// Retrieves the FrontGearNum field
+		/// Comment: Number of front gears</summary>
+		/// <returns>Returns nullable byte representing the FrontGearNum field</returns>
+		public byte? FrontGearNum
+		{
+			get
+			{
+				Object val = GetFieldValue(38, 0, Fit.SubfieldIndexMainField);
+				if (val == null)
+				{
+					return null;
+				}
+
+				return (Convert.ToByte(val));
+
+			}
+			set
+			{
+				SetFieldValue(38, 0, value, Fit.SubfieldIndexMainField);
+			}
+		}
+
+
+		/// <summary>
+		///
+		/// </summary>
+		/// <returns>returns number of elements in field FrontGear</returns>
+		public int GetNumFrontGear()
+		{
+			return GetNumFieldValues(39, Fit.SubfieldIndexMainField);
+		}
+
+		///<summary>
+		/// Retrieves the FrontGear field
+		/// Comment: Number of teeth on each gear 0 is innermost</summary>
+		/// <param name="index">0 based index of FrontGear element to retrieve</param>
+		/// <returns>Returns nullable byte representing the FrontGear field</returns>
+		public byte? GetFrontGear(int index)
+		{
+			Object val = GetFieldValue(39, index, Fit.SubfieldIndexMainField);
+			if (val == null)
+			{
+				return null;
+			}
+
+			return (Convert.ToByte(val));
+
+		}
+
+		/// <summary>
+		/// Set FrontGear field
+		/// Comment: Number of teeth on each gear 0 is innermost</summary>
+		/// <param name="index">0 based index of front_gear</param>
+		/// <param name="frontGear_">Nullable field value to be set</param>
+		public void SetFrontGear(int index, byte? frontGear_)
+		{
+			SetFieldValue(39, index, frontGear_, Fit.SubfieldIndexMainField);
+		}
+
+		///<summary>
+		/// Retrieves the RearGearNum field
+		/// Comment: Number of rear gears</summary>
+		/// <returns>Returns nullable byte representing the RearGearNum field</returns>
+		public byte? RearGearNum
+		{
+			get
+			{
+				Object val = GetFieldValue(40, 0, Fit.SubfieldIndexMainField);
+				if (val == null)
+				{
+					return null;
+				}
+
+				return (Convert.ToByte(val));
+
+			}
+			set
+			{
+				SetFieldValue(40, 0, value, Fit.SubfieldIndexMainField);
+			}
+		}
+
+
+		/// <summary>
+		///
+		/// </summary>
+		/// <returns>returns number of elements in field RearGear</returns>
+		public int GetNumRearGear()
+		{
+			return GetNumFieldValues(41, Fit.SubfieldIndexMainField);
+		}
+
+		///<summary>
+		/// Retrieves the RearGear field
+		/// Comment: Number of teeth on each gear 0 is innermost</summary>
+		/// <param name="index">0 based index of RearGear element to retrieve</param>
+		/// <returns>Returns nullable byte representing the RearGear field</returns>
+		public byte? GetRearGear(int index)
+		{
+			Object val = GetFieldValue(41, index, Fit.SubfieldIndexMainField);
+			if (val == null)
+			{
+				return null;
+			}
+
+			return (Convert.ToByte(val));
+
+		}
+
+		/// <summary>
+		/// Set RearGear field
+		/// Comment: Number of teeth on each gear 0 is innermost</summary>
+		/// <param name="index">0 based index of rear_gear</param>
+		/// <param name="rearGear_">Nullable field value to be set</param>
+		public void SetRearGear(int index, byte? rearGear_)
+		{
+			SetFieldValue(41, index, rearGear_, Fit.SubfieldIndexMainField);
+		}
+
+		///<summary>
+		/// Retrieves the ShimanoDi2Enabled field</summary>
+		/// <returns>Returns nullable Bool enum representing the ShimanoDi2Enabled field</returns>
+		public Bool? ShimanoDi2Enabled
+		{
+			get
+			{
+				object obj = GetFieldValue(44, 0, Fit.SubfieldIndexMainField);
+				Bool? value = obj == null ? (Bool?)null : (Bool)obj;
+				return value;
+			}
+			set
+			{
+				SetFieldValue(44, 0, value, Fit.SubfieldIndexMainField);
+			}
+		}
+
+		#endregion // Methods
+	} // Class
 } // namespace

--- a/Dynastream/Fit/Profile/Mesgs/BloodPressureMesg.cs
+++ b/Dynastream/Fit/Profile/Mesgs/BloodPressureMesg.cs
@@ -21,305 +21,285 @@ using System.Linq;
 
 namespace Dynastream.Fit
 {
-    /// <summary>
-    /// Implements the BloodPressure profile message.
-    /// </summary>
-    public class BloodPressureMesg : Mesg
-    {
-        #region Fields
-        #endregion
+	/// <summary>
+	/// Implements the BloodPressure profile message.
+	/// </summary>
+	public class BloodPressureMesg : Mesg
+	{
+		#region Fields
+		#endregion
 
-        /// <summary>
-        /// Field Numbers for <see cref="BloodPressureMesg"/>
-        /// </summary>
-        public sealed class FieldDefNum
-        {
-            public const byte Timestamp = 253;
-            public const byte SystolicPressure = 0;
-            public const byte DiastolicPressure = 1;
-            public const byte MeanArterialPressure = 2;
-            public const byte Map3SampleMean = 3;
-            public const byte MapMorningValues = 4;
-            public const byte MapEveningValues = 5;
-            public const byte HeartRate = 6;
-            public const byte HeartRateType = 7;
-            public const byte Status = 8;
-            public const byte UserProfileIndex = 9;
-            public const byte Invalid = Fit.FieldNumInvalid;
-        }
+		/// <summary>
+		/// Field Numbers for <see cref="BloodPressureMesg"/>
+		/// </summary>
+		public sealed class FieldDefNum
+		{
+			public const byte Timestamp = 253;
+			public const byte SystolicPressure = 0;
+			public const byte DiastolicPressure = 1;
+			public const byte MeanArterialPressure = 2;
+			public const byte Map3SampleMean = 3;
+			public const byte MapMorningValues = 4;
+			public const byte MapEveningValues = 5;
+			public const byte HeartRate = 6;
+			public const byte HeartRateType = 7;
+			public const byte Status = 8;
+			public const byte UserProfileIndex = 9;
+			public const byte Invalid = Fit.FieldNumInvalid;
+		}
 
-        #region Constructors
-        public BloodPressureMesg() : base(Profile.GetMesg(MesgNum.BloodPressure))
-        {
-        }
+		#region Constructors
+		public BloodPressureMesg() : base(Profile.GetMesg(MesgNum.BloodPressure))
+		{
+		}
 
-        public BloodPressureMesg(Mesg mesg) : base(mesg)
-        {
-        }
-        #endregion // Constructors
+		public BloodPressureMesg(Mesg mesg) : base(mesg)
+		{
+		}
+		#endregion // Constructors
 
-        #region Methods
-        ///<summary>
-        /// Retrieves the Timestamp field
-        /// Units: s</summary>
-        /// <returns>Returns DateTime representing the Timestamp field</returns>
-        public DateTime GetTimestamp()
-        {
-            Object val = GetFieldValue(253, 0, Fit.SubfieldIndexMainField);
-            if(val == null)
-            {
-                return null;
-            }
+		#region Methods
+		///<summary>
+		/// Retrieves the Timestamp field
+		/// Units: s</summary>
+		/// <returns>Returns DateTime representing the Timestamp field</returns>
+		public DateTime Timestamp
+		{
+			get
+			{
+				Object val = GetFieldValue(253, 0, Fit.SubfieldIndexMainField);
+				if (val == null)
+				{
+					return null;
+				}
 
-            return TimestampToDateTime(Convert.ToUInt32(val));
-            
-        }
+				return TimestampToDateTime(Convert.ToUInt32(val));
 
-        /// <summary>
-        /// Set Timestamp field
-        /// Units: s</summary>
-        /// <param name="timestamp_">Nullable field value to be set</param>
-        public void SetTimestamp(DateTime timestamp_)
-        {
-            SetFieldValue(253, 0, timestamp_.GetTimeStamp(), Fit.SubfieldIndexMainField);
-        }
-        
-        ///<summary>
-        /// Retrieves the SystolicPressure field
-        /// Units: mmHg</summary>
-        /// <returns>Returns nullable ushort representing the SystolicPressure field</returns>
-        public ushort? GetSystolicPressure()
-        {
-            Object val = GetFieldValue(0, 0, Fit.SubfieldIndexMainField);
-            if(val == null)
-            {
-                return null;
-            }
+			}
+			set
+			{
+				SetFieldValue(253, 0, value.GetTimeStamp(), Fit.SubfieldIndexMainField);
+			}
+		}
 
-            return (Convert.ToUInt16(val));
-            
-        }
+		///<summary>
+		/// Retrieves the SystolicPressure field
+		/// Units: mmHg</summary>
+		/// <returns>Returns nullable ushort representing the SystolicPressure field</returns>
+		public ushort? SystolicPressure
+		{
+			get
+			{
+				Object val = GetFieldValue(0, 0, Fit.SubfieldIndexMainField);
+				if (val == null)
+				{
+					return null;
+				}
 
-        /// <summary>
-        /// Set SystolicPressure field
-        /// Units: mmHg</summary>
-        /// <param name="systolicPressure_">Nullable field value to be set</param>
-        public void SetSystolicPressure(ushort? systolicPressure_)
-        {
-            SetFieldValue(0, 0, systolicPressure_, Fit.SubfieldIndexMainField);
-        }
-        
-        ///<summary>
-        /// Retrieves the DiastolicPressure field
-        /// Units: mmHg</summary>
-        /// <returns>Returns nullable ushort representing the DiastolicPressure field</returns>
-        public ushort? GetDiastolicPressure()
-        {
-            Object val = GetFieldValue(1, 0, Fit.SubfieldIndexMainField);
-            if(val == null)
-            {
-                return null;
-            }
+				return (Convert.ToUInt16(val));
 
-            return (Convert.ToUInt16(val));
-            
-        }
+			}
+			set
+			{
+				SetFieldValue(0, 0, value, Fit.SubfieldIndexMainField);
+			}
+		}
 
-        /// <summary>
-        /// Set DiastolicPressure field
-        /// Units: mmHg</summary>
-        /// <param name="diastolicPressure_">Nullable field value to be set</param>
-        public void SetDiastolicPressure(ushort? diastolicPressure_)
-        {
-            SetFieldValue(1, 0, diastolicPressure_, Fit.SubfieldIndexMainField);
-        }
-        
-        ///<summary>
-        /// Retrieves the MeanArterialPressure field
-        /// Units: mmHg</summary>
-        /// <returns>Returns nullable ushort representing the MeanArterialPressure field</returns>
-        public ushort? GetMeanArterialPressure()
-        {
-            Object val = GetFieldValue(2, 0, Fit.SubfieldIndexMainField);
-            if(val == null)
-            {
-                return null;
-            }
+		///<summary>
+		/// Retrieves the DiastolicPressure field
+		/// Units: mmHg</summary>
+		/// <returns>Returns nullable ushort representing the DiastolicPressure field</returns>
+		public ushort? DiastolicPressure
+		{
+			get
+			{
+				Object val = GetFieldValue(1, 0, Fit.SubfieldIndexMainField);
+				if (val == null)
+				{
+					return null;
+				}
 
-            return (Convert.ToUInt16(val));
-            
-        }
+				return (Convert.ToUInt16(val));
 
-        /// <summary>
-        /// Set MeanArterialPressure field
-        /// Units: mmHg</summary>
-        /// <param name="meanArterialPressure_">Nullable field value to be set</param>
-        public void SetMeanArterialPressure(ushort? meanArterialPressure_)
-        {
-            SetFieldValue(2, 0, meanArterialPressure_, Fit.SubfieldIndexMainField);
-        }
-        
-        ///<summary>
-        /// Retrieves the Map3SampleMean field
-        /// Units: mmHg</summary>
-        /// <returns>Returns nullable ushort representing the Map3SampleMean field</returns>
-        public ushort? GetMap3SampleMean()
-        {
-            Object val = GetFieldValue(3, 0, Fit.SubfieldIndexMainField);
-            if(val == null)
-            {
-                return null;
-            }
+			}
+			set
+			{
+				SetFieldValue(1, 0, value, Fit.SubfieldIndexMainField);
+			}
+		}
 
-            return (Convert.ToUInt16(val));
-            
-        }
+		///<summary>
+		/// Retrieves the MeanArterialPressure field
+		/// Units: mmHg</summary>
+		/// <returns>Returns nullable ushort representing the MeanArterialPressure field</returns>
+		public ushort? MeanArterialPressure
+		{
+			get
+			{
+				Object val = GetFieldValue(2, 0, Fit.SubfieldIndexMainField);
+				if (val == null)
+				{
+					return null;
+				}
 
-        /// <summary>
-        /// Set Map3SampleMean field
-        /// Units: mmHg</summary>
-        /// <param name="map3SampleMean_">Nullable field value to be set</param>
-        public void SetMap3SampleMean(ushort? map3SampleMean_)
-        {
-            SetFieldValue(3, 0, map3SampleMean_, Fit.SubfieldIndexMainField);
-        }
-        
-        ///<summary>
-        /// Retrieves the MapMorningValues field
-        /// Units: mmHg</summary>
-        /// <returns>Returns nullable ushort representing the MapMorningValues field</returns>
-        public ushort? GetMapMorningValues()
-        {
-            Object val = GetFieldValue(4, 0, Fit.SubfieldIndexMainField);
-            if(val == null)
-            {
-                return null;
-            }
+				return (Convert.ToUInt16(val));
 
-            return (Convert.ToUInt16(val));
-            
-        }
+			}
+			set
+			{
+				SetFieldValue(2, 0, value, Fit.SubfieldIndexMainField);
+			}
+		}
 
-        /// <summary>
-        /// Set MapMorningValues field
-        /// Units: mmHg</summary>
-        /// <param name="mapMorningValues_">Nullable field value to be set</param>
-        public void SetMapMorningValues(ushort? mapMorningValues_)
-        {
-            SetFieldValue(4, 0, mapMorningValues_, Fit.SubfieldIndexMainField);
-        }
-        
-        ///<summary>
-        /// Retrieves the MapEveningValues field
-        /// Units: mmHg</summary>
-        /// <returns>Returns nullable ushort representing the MapEveningValues field</returns>
-        public ushort? GetMapEveningValues()
-        {
-            Object val = GetFieldValue(5, 0, Fit.SubfieldIndexMainField);
-            if(val == null)
-            {
-                return null;
-            }
+		///<summary>
+		/// Retrieves the Map3SampleMean field
+		/// Units: mmHg</summary>
+		/// <returns>Returns nullable ushort representing the Map3SampleMean field</returns>
+		public ushort? Map3SampleMean
+		{
+			get
+			{
+				Object val = GetFieldValue(3, 0, Fit.SubfieldIndexMainField);
+				if (val == null)
+				{
+					return null;
+				}
 
-            return (Convert.ToUInt16(val));
-            
-        }
+				return (Convert.ToUInt16(val));
 
-        /// <summary>
-        /// Set MapEveningValues field
-        /// Units: mmHg</summary>
-        /// <param name="mapEveningValues_">Nullable field value to be set</param>
-        public void SetMapEveningValues(ushort? mapEveningValues_)
-        {
-            SetFieldValue(5, 0, mapEveningValues_, Fit.SubfieldIndexMainField);
-        }
-        
-        ///<summary>
-        /// Retrieves the HeartRate field
-        /// Units: bpm</summary>
-        /// <returns>Returns nullable byte representing the HeartRate field</returns>
-        public byte? GetHeartRate()
-        {
-            Object val = GetFieldValue(6, 0, Fit.SubfieldIndexMainField);
-            if(val == null)
-            {
-                return null;
-            }
+			}
+			set
+			{
+				SetFieldValue(3, 0, value, Fit.SubfieldIndexMainField);
+			}
+		}
 
-            return (Convert.ToByte(val));
-            
-        }
+		///<summary>
+		/// Retrieves the MapMorningValues field
+		/// Units: mmHg</summary>
+		/// <returns>Returns nullable ushort representing the MapMorningValues field</returns>
+		public ushort? MapMorningValues
+		{
+			get
+			{
+				Object val = GetFieldValue(4, 0, Fit.SubfieldIndexMainField);
+				if (val == null)
+				{
+					return null;
+				}
 
-        /// <summary>
-        /// Set HeartRate field
-        /// Units: bpm</summary>
-        /// <param name="heartRate_">Nullable field value to be set</param>
-        public void SetHeartRate(byte? heartRate_)
-        {
-            SetFieldValue(6, 0, heartRate_, Fit.SubfieldIndexMainField);
-        }
-        
-        ///<summary>
-        /// Retrieves the HeartRateType field</summary>
-        /// <returns>Returns nullable HrType enum representing the HeartRateType field</returns>
-        public HrType? GetHeartRateType()
-        {
-            object obj = GetFieldValue(7, 0, Fit.SubfieldIndexMainField);
-            HrType? value = obj == null ? (HrType?)null : (HrType)obj;
-            return value;
-        }
+				return (Convert.ToUInt16(val));
 
-        /// <summary>
-        /// Set HeartRateType field</summary>
-        /// <param name="heartRateType_">Nullable field value to be set</param>
-        public void SetHeartRateType(HrType? heartRateType_)
-        {
-            SetFieldValue(7, 0, heartRateType_, Fit.SubfieldIndexMainField);
-        }
-        
-        ///<summary>
-        /// Retrieves the Status field</summary>
-        /// <returns>Returns nullable BpStatus enum representing the Status field</returns>
-        public BpStatus? GetStatus()
-        {
-            object obj = GetFieldValue(8, 0, Fit.SubfieldIndexMainField);
-            BpStatus? value = obj == null ? (BpStatus?)null : (BpStatus)obj;
-            return value;
-        }
+			}
+			set
+			{
+				SetFieldValue(4, 0, value, Fit.SubfieldIndexMainField);
+			}
+		}
 
-        /// <summary>
-        /// Set Status field</summary>
-        /// <param name="status_">Nullable field value to be set</param>
-        public void SetStatus(BpStatus? status_)
-        {
-            SetFieldValue(8, 0, status_, Fit.SubfieldIndexMainField);
-        }
-        
-        ///<summary>
-        /// Retrieves the UserProfileIndex field
-        /// Comment: Associates this blood pressure message to a user. This corresponds to the index of the user profile message in the blood pressure file.</summary>
-        /// <returns>Returns nullable ushort representing the UserProfileIndex field</returns>
-        public ushort? GetUserProfileIndex()
-        {
-            Object val = GetFieldValue(9, 0, Fit.SubfieldIndexMainField);
-            if(val == null)
-            {
-                return null;
-            }
+		///<summary>
+		/// Retrieves the MapEveningValues field
+		/// Units: mmHg</summary>
+		/// <returns>Returns nullable ushort representing the MapEveningValues field</returns>
+		public ushort? MapEveningValues
+		{
+			get
+			{
+				Object val = GetFieldValue(5, 0, Fit.SubfieldIndexMainField);
+				if (val == null)
+				{
+					return null;
+				}
 
-            return (Convert.ToUInt16(val));
-            
-        }
+				return (Convert.ToUInt16(val));
 
-        /// <summary>
-        /// Set UserProfileIndex field
-        /// Comment: Associates this blood pressure message to a user. This corresponds to the index of the user profile message in the blood pressure file.</summary>
-        /// <param name="userProfileIndex_">Nullable field value to be set</param>
-        public void SetUserProfileIndex(ushort? userProfileIndex_)
-        {
-            SetFieldValue(9, 0, userProfileIndex_, Fit.SubfieldIndexMainField);
-        }
-        
-        #endregion // Methods
-    } // Class
+			}
+			set
+			{
+				SetFieldValue(5, 0, value, Fit.SubfieldIndexMainField);
+			}
+		}
+
+		///<summary>
+		/// Retrieves the HeartRate field
+		/// Units: bpm</summary>
+		/// <returns>Returns nullable byte representing the HeartRate field</returns>
+		public byte? HeartRate
+		{
+			get
+			{
+				Object val = GetFieldValue(6, 0, Fit.SubfieldIndexMainField);
+				if (val == null)
+				{
+					return null;
+				}
+
+				return (Convert.ToByte(val));
+
+			}
+			set
+			{
+				SetFieldValue(6, 0, value, Fit.SubfieldIndexMainField);
+			}
+		}
+
+		///<summary>
+		/// Retrieves the HeartRateType field</summary>
+		/// <returns>Returns nullable HrType enum representing the HeartRateType field</returns>
+		public HrType? HeartRateType
+		{
+			get
+			{
+				object obj = GetFieldValue(7, 0, Fit.SubfieldIndexMainField);
+				HrType? value = obj == null ? (HrType?)null : (HrType)obj;
+				return value;
+			}
+			set
+			{
+				SetFieldValue(7, 0, value, Fit.SubfieldIndexMainField);
+			}
+		}
+
+		///<summary>
+		/// Retrieves the Status field</summary>
+		/// <returns>Returns nullable BpStatus enum representing the Status field</returns>
+		public BpStatus? Status
+		{
+			get
+			{
+				object obj = GetFieldValue(8, 0, Fit.SubfieldIndexMainField);
+				BpStatus? value = obj == null ? (BpStatus?)null : (BpStatus)obj;
+				return value;
+			}
+			set
+			{
+				SetFieldValue(8, 0, value, Fit.SubfieldIndexMainField);
+			}
+		}
+
+		///<summary>
+		/// Retrieves the UserProfileIndex field
+		/// Comment: Associates this blood pressure message to a user. This corresponds to the index of the user profile message in the blood pressure file.</summary>
+		/// <returns>Returns nullable ushort representing the UserProfileIndex field</returns>
+		public ushort? UserProfileIndex
+		{
+			get
+			{
+				Object val = GetFieldValue(9, 0, Fit.SubfieldIndexMainField);
+				if (val == null)
+				{
+					return null;
+				}
+
+				return (Convert.ToUInt16(val));
+
+			}
+			set
+			{
+				SetFieldValue(9, 0, value, Fit.SubfieldIndexMainField);
+			}
+		}
+
+		#endregion // Methods
+	} // Class
 } // namespace

--- a/Dynastream/Fit/Profile/Mesgs/CadenceZoneMesg.cs
+++ b/Dynastream/Fit/Profile/Mesgs/CadenceZoneMesg.cs
@@ -21,122 +21,117 @@ using System.Linq;
 
 namespace Dynastream.Fit
 {
-    /// <summary>
-    /// Implements the CadenceZone profile message.
-    /// </summary>
-    public class CadenceZoneMesg : Mesg
-    {
-        #region Fields
-        #endregion
+	/// <summary>
+	/// Implements the CadenceZone profile message.
+	/// </summary>
+	public class CadenceZoneMesg : Mesg
+	{
+		#region Fields
+		#endregion
 
-        /// <summary>
-        /// Field Numbers for <see cref="CadenceZoneMesg"/>
-        /// </summary>
-        public sealed class FieldDefNum
-        {
-            public const byte MessageIndex = 254;
-            public const byte HighValue = 0;
-            public const byte Name = 1;
-            public const byte Invalid = Fit.FieldNumInvalid;
-        }
+		/// <summary>
+		/// Field Numbers for <see cref="CadenceZoneMesg"/>
+		/// </summary>
+		public sealed class FieldDefNum
+		{
+			public const byte MessageIndex = 254;
+			public const byte HighValue = 0;
+			public const byte Name = 1;
+			public const byte Invalid = Fit.FieldNumInvalid;
+		}
 
-        #region Constructors
-        public CadenceZoneMesg() : base(Profile.GetMesg(MesgNum.CadenceZone))
-        {
-        }
+		#region Constructors
+		public CadenceZoneMesg() : base(Profile.GetMesg(MesgNum.CadenceZone))
+		{
+		}
 
-        public CadenceZoneMesg(Mesg mesg) : base(mesg)
-        {
-        }
-        #endregion // Constructors
+		public CadenceZoneMesg(Mesg mesg) : base(mesg)
+		{
+		}
+		#endregion // Constructors
 
-        #region Methods
-        ///<summary>
-        /// Retrieves the MessageIndex field</summary>
-        /// <returns>Returns nullable ushort representing the MessageIndex field</returns>
-        public ushort? GetMessageIndex()
-        {
-            Object val = GetFieldValue(254, 0, Fit.SubfieldIndexMainField);
-            if(val == null)
-            {
-                return null;
-            }
+		#region Methods
+		///<summary>
+		/// Retrieves the MessageIndex field</summary>
+		/// <returns>Returns nullable ushort representing the MessageIndex field</returns>
+		public ushort? MessageIndex
+		{
+			get
+			{
+				Object val = GetFieldValue(254, 0, Fit.SubfieldIndexMainField);
+				if (val == null)
+				{
+					return null;
+				}
 
-            return (Convert.ToUInt16(val));
-            
-        }
+				return (Convert.ToUInt16(val));
 
-        /// <summary>
-        /// Set MessageIndex field</summary>
-        /// <param name="messageIndex_">Nullable field value to be set</param>
-        public void SetMessageIndex(ushort? messageIndex_)
-        {
-            SetFieldValue(254, 0, messageIndex_, Fit.SubfieldIndexMainField);
-        }
-        
-        ///<summary>
-        /// Retrieves the HighValue field
-        /// Units: rpm</summary>
-        /// <returns>Returns nullable byte representing the HighValue field</returns>
-        public byte? GetHighValue()
-        {
-            Object val = GetFieldValue(0, 0, Fit.SubfieldIndexMainField);
-            if(val == null)
-            {
-                return null;
-            }
+			}
+			set
+			{
+				SetFieldValue(254, 0, value, Fit.SubfieldIndexMainField);
+			}
+		}
 
-            return (Convert.ToByte(val));
-            
-        }
+		///<summary>
+		/// Retrieves the HighValue field
+		/// Units: rpm</summary>
+		/// <returns>Returns nullable byte representing the HighValue field</returns>
+		public byte? HighValue
+		{
+			get
+			{
+				Object val = GetFieldValue(0, 0, Fit.SubfieldIndexMainField);
+				if (val == null)
+				{
+					return null;
+				}
 
-        /// <summary>
-        /// Set HighValue field
-        /// Units: rpm</summary>
-        /// <param name="highValue_">Nullable field value to be set</param>
-        public void SetHighValue(byte? highValue_)
-        {
-            SetFieldValue(0, 0, highValue_, Fit.SubfieldIndexMainField);
-        }
-        
-        ///<summary>
-        /// Retrieves the Name field</summary>
-        /// <returns>Returns byte[] representing the Name field</returns>
-        public byte[] GetName()
-        {
-            byte[] data = (byte[])GetFieldValue(1, 0, Fit.SubfieldIndexMainField);
-            return data.Take(data.Length - 1).ToArray();
-        }
+				return (Convert.ToByte(val));
 
-        ///<summary>
-        /// Retrieves the Name field</summary>
-        /// <returns>Returns String representing the Name field</returns>
-        public String GetNameAsString()
-        {
-            byte[] data = (byte[])GetFieldValue(1, 0, Fit.SubfieldIndexMainField);
-            return data != null ? Encoding.UTF8.GetString(data, 0, data.Length - 1) : null;
-        }
+			}
+			set
+			{
+				SetFieldValue(0, 0, value, Fit.SubfieldIndexMainField);
+			}
+		}
 
-        ///<summary>
-        /// Set Name field</summary>
-        /// <param name="name_"> field value to be set</param>
-        public void SetName(String name_)
-        {
-            byte[] data = Encoding.UTF8.GetBytes(name_);
-            byte[] zdata = new byte[data.Length + 1];
-            data.CopyTo(zdata, 0);
-            SetFieldValue(1, 0, zdata, Fit.SubfieldIndexMainField);
-        }
+		///<summary>
+		/// Retrieves the Name field</summary>
+		/// <returns>Returns byte[] representing the Name field</returns>
+		public byte[] Name
+		{
+			get
+			{
+				byte[] data = (byte[])GetFieldValue(1, 0, Fit.SubfieldIndexMainField);
+				return data.Take(data.Length - 1).ToArray();
+			}
+			set
+			{
+				SetFieldValue(1, 0, value, Fit.SubfieldIndexMainField);
+			}
+		}
 
-        
-        /// <summary>
-        /// Set Name field</summary>
-        /// <param name="name_">field value to be set</param>
-        public void SetName(byte[] name_)
-        {
-            SetFieldValue(1, 0, name_, Fit.SubfieldIndexMainField);
-        }
-        
-        #endregion // Methods
-    } // Class
+		///<summary>
+		/// Retrieves the Name field</summary>
+		/// <returns>Returns String representing the Name field</returns>
+		public String GetNameAsString()
+		{
+			byte[] data = (byte[])GetFieldValue(1, 0, Fit.SubfieldIndexMainField);
+			return data != null ? Encoding.UTF8.GetString(data, 0, data.Length - 1) : null;
+		}
+
+		///<summary>
+		/// Set Name field</summary>
+		/// <param name="name_"> field value to be set</param>
+		public void SetName(String name_)
+		{
+			byte[] data = Encoding.UTF8.GetBytes(name_);
+			byte[] zdata = new byte[data.Length + 1];
+			data.CopyTo(zdata, 0);
+			SetFieldValue(1, 0, zdata, Fit.SubfieldIndexMainField);
+		}
+
+		#endregion // Methods
+	} // Class
 } // namespace

--- a/Dynastream/Fit/Profile/Mesgs/CameraEventMesg.cs
+++ b/Dynastream/Fit/Profile/Mesgs/CameraEventMesg.cs
@@ -21,166 +21,156 @@ using System.Linq;
 
 namespace Dynastream.Fit
 {
-    /// <summary>
-    /// Implements the CameraEvent profile message.
-    /// </summary>
-    public class CameraEventMesg : Mesg
-    {
-        #region Fields
-        #endregion
+	/// <summary>
+	/// Implements the CameraEvent profile message.
+	/// </summary>
+	public class CameraEventMesg : Mesg
+	{
+		#region Fields
+		#endregion
 
-        /// <summary>
-        /// Field Numbers for <see cref="CameraEventMesg"/>
-        /// </summary>
-        public sealed class FieldDefNum
-        {
-            public const byte Timestamp = 253;
-            public const byte TimestampMs = 0;
-            public const byte CameraEventType = 1;
-            public const byte CameraFileUuid = 2;
-            public const byte CameraOrientation = 3;
-            public const byte Invalid = Fit.FieldNumInvalid;
-        }
+		/// <summary>
+		/// Field Numbers for <see cref="CameraEventMesg"/>
+		/// </summary>
+		public sealed class FieldDefNum
+		{
+			public const byte Timestamp = 253;
+			public const byte TimestampMs = 0;
+			public const byte CameraEventType = 1;
+			public const byte CameraFileUuid = 2;
+			public const byte CameraOrientation = 3;
+			public const byte Invalid = Fit.FieldNumInvalid;
+		}
 
-        #region Constructors
-        public CameraEventMesg() : base(Profile.GetMesg(MesgNum.CameraEvent))
-        {
-        }
+		#region Constructors
+		public CameraEventMesg() : base(Profile.GetMesg(MesgNum.CameraEvent))
+		{
+		}
 
-        public CameraEventMesg(Mesg mesg) : base(mesg)
-        {
-        }
-        #endregion // Constructors
+		public CameraEventMesg(Mesg mesg) : base(mesg)
+		{
+		}
+		#endregion // Constructors
 
-        #region Methods
-        ///<summary>
-        /// Retrieves the Timestamp field
-        /// Units: s
-        /// Comment: Whole second part of the timestamp.</summary>
-        /// <returns>Returns DateTime representing the Timestamp field</returns>
-        public DateTime GetTimestamp()
-        {
-            Object val = GetFieldValue(253, 0, Fit.SubfieldIndexMainField);
-            if(val == null)
-            {
-                return null;
-            }
+		#region Methods
+		///<summary>
+		/// Retrieves the Timestamp field
+		/// Units: s
+		/// Comment: Whole second part of the timestamp.</summary>
+		/// <returns>Returns DateTime representing the Timestamp field</returns>
+		public DateTime Timestamp
+		{
+			get
+			{
+				Object val = GetFieldValue(253, 0, Fit.SubfieldIndexMainField);
+				if (val == null)
+				{
+					return null;
+				}
 
-            return TimestampToDateTime(Convert.ToUInt32(val));
-            
-        }
+				return TimestampToDateTime(Convert.ToUInt32(val));
 
-        /// <summary>
-        /// Set Timestamp field
-        /// Units: s
-        /// Comment: Whole second part of the timestamp.</summary>
-        /// <param name="timestamp_">Nullable field value to be set</param>
-        public void SetTimestamp(DateTime timestamp_)
-        {
-            SetFieldValue(253, 0, timestamp_.GetTimeStamp(), Fit.SubfieldIndexMainField);
-        }
-        
-        ///<summary>
-        /// Retrieves the TimestampMs field
-        /// Units: ms
-        /// Comment: Millisecond part of the timestamp.</summary>
-        /// <returns>Returns nullable ushort representing the TimestampMs field</returns>
-        public ushort? GetTimestampMs()
-        {
-            Object val = GetFieldValue(0, 0, Fit.SubfieldIndexMainField);
-            if(val == null)
-            {
-                return null;
-            }
+			}
+			set
+			{
+				SetFieldValue(253, 0, value.GetTimeStamp(), Fit.SubfieldIndexMainField);
+			}
+		}
 
-            return (Convert.ToUInt16(val));
-            
-        }
+		///<summary>
+		/// Retrieves the TimestampMs field
+		/// Units: ms
+		/// Comment: Millisecond part of the timestamp.</summary>
+		/// <returns>Returns nullable ushort representing the TimestampMs field</returns>
+		public ushort? TimestampMs
+		{
+			get
+			{
+				Object val = GetFieldValue(0, 0, Fit.SubfieldIndexMainField);
+				if (val == null)
+				{
+					return null;
+				}
 
-        /// <summary>
-        /// Set TimestampMs field
-        /// Units: ms
-        /// Comment: Millisecond part of the timestamp.</summary>
-        /// <param name="timestampMs_">Nullable field value to be set</param>
-        public void SetTimestampMs(ushort? timestampMs_)
-        {
-            SetFieldValue(0, 0, timestampMs_, Fit.SubfieldIndexMainField);
-        }
-        
-        ///<summary>
-        /// Retrieves the CameraEventType field</summary>
-        /// <returns>Returns nullable CameraEventType enum representing the CameraEventType field</returns>
-        public CameraEventType? GetCameraEventType()
-        {
-            object obj = GetFieldValue(1, 0, Fit.SubfieldIndexMainField);
-            CameraEventType? value = obj == null ? (CameraEventType?)null : (CameraEventType)obj;
-            return value;
-        }
+				return (Convert.ToUInt16(val));
 
-        /// <summary>
-        /// Set CameraEventType field</summary>
-        /// <param name="cameraEventType_">Nullable field value to be set</param>
-        public void SetCameraEventType(CameraEventType? cameraEventType_)
-        {
-            SetFieldValue(1, 0, cameraEventType_, Fit.SubfieldIndexMainField);
-        }
-        
-        ///<summary>
-        /// Retrieves the CameraFileUuid field</summary>
-        /// <returns>Returns byte[] representing the CameraFileUuid field</returns>
-        public byte[] GetCameraFileUuid()
-        {
-            byte[] data = (byte[])GetFieldValue(2, 0, Fit.SubfieldIndexMainField);
-            return data.Take(data.Length - 1).ToArray();
-        }
+			}
+			set
+			{
+				SetFieldValue(0, 0, value, Fit.SubfieldIndexMainField);
+			}
+		}
 
-        ///<summary>
-        /// Retrieves the CameraFileUuid field</summary>
-        /// <returns>Returns String representing the CameraFileUuid field</returns>
-        public String GetCameraFileUuidAsString()
-        {
-            byte[] data = (byte[])GetFieldValue(2, 0, Fit.SubfieldIndexMainField);
-            return data != null ? Encoding.UTF8.GetString(data, 0, data.Length - 1) : null;
-        }
+		///<summary>
+		/// Retrieves the CameraEventType field</summary>
+		/// <returns>Returns nullable CameraEventType enum representing the CameraEventType field</returns>
+		public CameraEventType? CameraEventType
+		{
+			get
+			{
+				object obj = GetFieldValue(1, 0, Fit.SubfieldIndexMainField);
+				CameraEventType? value = obj == null ? (CameraEventType?)null : (CameraEventType)obj;
+				return value;
+			}
+			set
+			{
+				SetFieldValue(1, 0, value, Fit.SubfieldIndexMainField);
+			}
+		}
 
-        ///<summary>
-        /// Set CameraFileUuid field</summary>
-        /// <param name="cameraFileUuid_"> field value to be set</param>
-        public void SetCameraFileUuid(String cameraFileUuid_)
-        {
-            byte[] data = Encoding.UTF8.GetBytes(cameraFileUuid_);
-            byte[] zdata = new byte[data.Length + 1];
-            data.CopyTo(zdata, 0);
-            SetFieldValue(2, 0, zdata, Fit.SubfieldIndexMainField);
-        }
+		///<summary>
+		/// Retrieves the CameraFileUuid field</summary>
+		/// <returns>Returns byte[] representing the CameraFileUuid field</returns>
+		public byte[] CameraFileUuid
+		{
+			get
+			{
+				byte[] data = (byte[])GetFieldValue(2, 0, Fit.SubfieldIndexMainField);
+				return data.Take(data.Length - 1).ToArray();
+			}
+			set
+			{
+				SetFieldValue(2, 0, value, Fit.SubfieldIndexMainField);
+			}
+		}
 
-        
-        /// <summary>
-        /// Set CameraFileUuid field</summary>
-        /// <param name="cameraFileUuid_">field value to be set</param>
-        public void SetCameraFileUuid(byte[] cameraFileUuid_)
-        {
-            SetFieldValue(2, 0, cameraFileUuid_, Fit.SubfieldIndexMainField);
-        }
-        
-        ///<summary>
-        /// Retrieves the CameraOrientation field</summary>
-        /// <returns>Returns nullable CameraOrientationType enum representing the CameraOrientation field</returns>
-        public CameraOrientationType? GetCameraOrientation()
-        {
-            object obj = GetFieldValue(3, 0, Fit.SubfieldIndexMainField);
-            CameraOrientationType? value = obj == null ? (CameraOrientationType?)null : (CameraOrientationType)obj;
-            return value;
-        }
+		///<summary>
+		/// Retrieves the CameraFileUuid field</summary>
+		/// <returns>Returns String representing the CameraFileUuid field</returns>
+		public String GetCameraFileUuidAsString()
+		{
+			byte[] data = (byte[])GetFieldValue(2, 0, Fit.SubfieldIndexMainField);
+			return data != null ? Encoding.UTF8.GetString(data, 0, data.Length - 1) : null;
+		}
 
-        /// <summary>
-        /// Set CameraOrientation field</summary>
-        /// <param name="cameraOrientation_">Nullable field value to be set</param>
-        public void SetCameraOrientation(CameraOrientationType? cameraOrientation_)
-        {
-            SetFieldValue(3, 0, cameraOrientation_, Fit.SubfieldIndexMainField);
-        }
-        
-        #endregion // Methods
-    } // Class
+		///<summary>
+		/// Set CameraFileUuid field</summary>
+		/// <param name="cameraFileUuid_"> field value to be set</param>
+		public void SetCameraFileUuid(String cameraFileUuid_)
+		{
+			byte[] data = Encoding.UTF8.GetBytes(cameraFileUuid_);
+			byte[] zdata = new byte[data.Length + 1];
+			data.CopyTo(zdata, 0);
+			SetFieldValue(2, 0, zdata, Fit.SubfieldIndexMainField);
+		}
+
+		///<summary>
+		/// Retrieves the CameraOrientation field</summary>
+		/// <returns>Returns nullable CameraOrientationType enum representing the CameraOrientation field</returns>
+		public CameraOrientationType? CameraOrientation
+		{
+			get
+			{
+				object obj = GetFieldValue(3, 0, Fit.SubfieldIndexMainField);
+				CameraOrientationType? value = obj == null ? (CameraOrientationType?)null : (CameraOrientationType)obj;
+				return value;
+			}
+			set
+			{
+				SetFieldValue(3, 0, value, Fit.SubfieldIndexMainField);
+			}
+		}
+
+		#endregion // Methods
+	} // Class
 } // namespace

--- a/Dynastream/Fit/Profile/Mesgs/CapabilitiesMesg.cs
+++ b/Dynastream/Fit/Profile/Mesgs/CapabilitiesMesg.cs
@@ -21,157 +21,155 @@ using System.Linq;
 
 namespace Dynastream.Fit
 {
-    /// <summary>
-    /// Implements the Capabilities profile message.
-    /// </summary>
-    public class CapabilitiesMesg : Mesg
-    {
-        #region Fields
-        #endregion
+	/// <summary>
+	/// Implements the Capabilities profile message.
+	/// </summary>
+	public class CapabilitiesMesg : Mesg
+	{
+		#region Fields
+		#endregion
 
-        /// <summary>
-        /// Field Numbers for <see cref="CapabilitiesMesg"/>
-        /// </summary>
-        public sealed class FieldDefNum
-        {
-            public const byte Languages = 0;
-            public const byte Sports = 1;
-            public const byte WorkoutsSupported = 21;
-            public const byte ConnectivitySupported = 23;
-            public const byte Invalid = Fit.FieldNumInvalid;
-        }
+		/// <summary>
+		/// Field Numbers for <see cref="CapabilitiesMesg"/>
+		/// </summary>
+		public sealed class FieldDefNum
+		{
+			public const byte Languages = 0;
+			public const byte Sports = 1;
+			public const byte WorkoutsSupported = 21;
+			public const byte ConnectivitySupported = 23;
+			public const byte Invalid = Fit.FieldNumInvalid;
+		}
 
-        #region Constructors
-        public CapabilitiesMesg() : base(Profile.GetMesg(MesgNum.Capabilities))
-        {
-        }
+		#region Constructors
+		public CapabilitiesMesg() : base(Profile.GetMesg(MesgNum.Capabilities))
+		{
+		}
 
-        public CapabilitiesMesg(Mesg mesg) : base(mesg)
-        {
-        }
-        #endregion // Constructors
+		public CapabilitiesMesg(Mesg mesg) : base(mesg)
+		{
+		}
+		#endregion // Constructors
 
-        #region Methods
-        
-        /// <summary>
-        ///
-        /// </summary>
-        /// <returns>returns number of elements in field Languages</returns>
-        public int GetNumLanguages()
-        {
-            return GetNumFieldValues(0, Fit.SubfieldIndexMainField);
-        }
+		#region Methods
 
-        ///<summary>
-        /// Retrieves the Languages field
-        /// Comment: Use language_bits_x types where x is index of array.</summary>
-        /// <param name="index">0 based index of Languages element to retrieve</param>
-        /// <returns>Returns nullable byte representing the Languages field</returns>
-        public byte? GetLanguages(int index)
-        {
-            Object val = GetFieldValue(0, index, Fit.SubfieldIndexMainField);
-            if(val == null)
-            {
-                return null;
-            }
+		/// <summary>
+		///
+		/// </summary>
+		/// <returns>returns number of elements in field Languages</returns>
+		public int GetNumLanguages()
+		{
+			return GetNumFieldValues(0, Fit.SubfieldIndexMainField);
+		}
 
-            return (Convert.ToByte(val));
-            
-        }
+		///<summary>
+		/// Retrieves the Languages field
+		/// Comment: Use language_bits_x types where x is index of array.</summary>
+		/// <param name="index">0 based index of Languages element to retrieve</param>
+		/// <returns>Returns nullable byte representing the Languages field</returns>
+		public byte? GetLanguages(int index)
+		{
+			Object val = GetFieldValue(0, index, Fit.SubfieldIndexMainField);
+			if (val == null)
+			{
+				return null;
+			}
 
-        /// <summary>
-        /// Set Languages field
-        /// Comment: Use language_bits_x types where x is index of array.</summary>
-        /// <param name="index">0 based index of languages</param>
-        /// <param name="languages_">Nullable field value to be set</param>
-        public void SetLanguages(int index, byte? languages_)
-        {
-            SetFieldValue(0, index, languages_, Fit.SubfieldIndexMainField);
-        }
-        
-        
-        /// <summary>
-        ///
-        /// </summary>
-        /// <returns>returns number of elements in field Sports</returns>
-        public int GetNumSports()
-        {
-            return GetNumFieldValues(1, Fit.SubfieldIndexMainField);
-        }
+			return (Convert.ToByte(val));
 
-        ///<summary>
-        /// Retrieves the Sports field
-        /// Comment: Use sport_bits_x types where x is index of array.</summary>
-        /// <param name="index">0 based index of Sports element to retrieve</param>
-        /// <returns>Returns nullable byte representing the Sports field</returns>
-        public byte? GetSports(int index)
-        {
-            Object val = GetFieldValue(1, index, Fit.SubfieldIndexMainField);
-            if(val == null)
-            {
-                return null;
-            }
+		}
 
-            return (Convert.ToByte(val));
-            
-        }
+		/// <summary>
+		/// Set Languages field
+		/// Comment: Use language_bits_x types where x is index of array.</summary>
+		/// <param name="index">0 based index of languages</param>
+		/// <param name="languages_">Nullable field value to be set</param>
+		public void SetLanguages(int index, byte? languages_)
+		{
+			SetFieldValue(0, index, languages_, Fit.SubfieldIndexMainField);
+		}
 
-        /// <summary>
-        /// Set Sports field
-        /// Comment: Use sport_bits_x types where x is index of array.</summary>
-        /// <param name="index">0 based index of sports</param>
-        /// <param name="sports_">Nullable field value to be set</param>
-        public void SetSports(int index, byte? sports_)
-        {
-            SetFieldValue(1, index, sports_, Fit.SubfieldIndexMainField);
-        }
-        
-        ///<summary>
-        /// Retrieves the WorkoutsSupported field</summary>
-        /// <returns>Returns nullable uint representing the WorkoutsSupported field</returns>
-        public uint? GetWorkoutsSupported()
-        {
-            Object val = GetFieldValue(21, 0, Fit.SubfieldIndexMainField);
-            if(val == null)
-            {
-                return null;
-            }
 
-            return (Convert.ToUInt32(val));
-            
-        }
+		/// <summary>
+		///
+		/// </summary>
+		/// <returns>returns number of elements in field Sports</returns>
+		public int GetNumSports()
+		{
+			return GetNumFieldValues(1, Fit.SubfieldIndexMainField);
+		}
 
-        /// <summary>
-        /// Set WorkoutsSupported field</summary>
-        /// <param name="workoutsSupported_">Nullable field value to be set</param>
-        public void SetWorkoutsSupported(uint? workoutsSupported_)
-        {
-            SetFieldValue(21, 0, workoutsSupported_, Fit.SubfieldIndexMainField);
-        }
-        
-        ///<summary>
-        /// Retrieves the ConnectivitySupported field</summary>
-        /// <returns>Returns nullable uint representing the ConnectivitySupported field</returns>
-        public uint? GetConnectivitySupported()
-        {
-            Object val = GetFieldValue(23, 0, Fit.SubfieldIndexMainField);
-            if(val == null)
-            {
-                return null;
-            }
+		///<summary>
+		/// Retrieves the Sports field
+		/// Comment: Use sport_bits_x types where x is index of array.</summary>
+		/// <param name="index">0 based index of Sports element to retrieve</param>
+		/// <returns>Returns nullable byte representing the Sports field</returns>
+		public byte? GetSports(int index)
+		{
+			Object val = GetFieldValue(1, index, Fit.SubfieldIndexMainField);
+			if (val == null)
+			{
+				return null;
+			}
 
-            return (Convert.ToUInt32(val));
-            
-        }
+			return (Convert.ToByte(val));
 
-        /// <summary>
-        /// Set ConnectivitySupported field</summary>
-        /// <param name="connectivitySupported_">Nullable field value to be set</param>
-        public void SetConnectivitySupported(uint? connectivitySupported_)
-        {
-            SetFieldValue(23, 0, connectivitySupported_, Fit.SubfieldIndexMainField);
-        }
-        
-        #endregion // Methods
-    } // Class
+		}
+
+		/// <summary>
+		/// Set Sports field
+		/// Comment: Use sport_bits_x types where x is index of array.</summary>
+		/// <param name="index">0 based index of sports</param>
+		/// <param name="sports_">Nullable field value to be set</param>
+		public void SetSports(int index, byte? sports_)
+		{
+			SetFieldValue(1, index, sports_, Fit.SubfieldIndexMainField);
+		}
+
+		///<summary>
+		/// Retrieves the WorkoutsSupported field</summary>
+		/// <returns>Returns nullable uint representing the WorkoutsSupported field</returns>
+		public uint? WorkoutsSupported
+		{
+			get
+			{
+				Object val = GetFieldValue(21, 0, Fit.SubfieldIndexMainField);
+				if (val == null)
+				{
+					return null;
+				}
+
+				return (Convert.ToUInt32(val));
+
+			}
+			set
+			{
+				SetFieldValue(21, 0, value, Fit.SubfieldIndexMainField);
+			}
+		}
+
+		///<summary>
+		/// Retrieves the ConnectivitySupported field</summary>
+		/// <returns>Returns nullable uint representing the ConnectivitySupported field</returns>
+		public uint? ConnectivitySupported
+		{
+			get
+			{
+				Object val = GetFieldValue(23, 0, Fit.SubfieldIndexMainField);
+				if (val == null)
+				{
+					return null;
+				}
+
+				return (Convert.ToUInt32(val));
+
+			}
+			set
+			{
+				SetFieldValue(23, 0, value, Fit.SubfieldIndexMainField);
+			}
+		}
+
+		#endregion // Methods
+	} // Class
 } // namespace

--- a/Dynastream/Fit/Profile/Mesgs/ChronoShotDataMesg.cs
+++ b/Dynastream/Fit/Profile/Mesgs/ChronoShotDataMesg.cs
@@ -21,107 +21,103 @@ using System.Linq;
 
 namespace Dynastream.Fit
 {
-    /// <summary>
-    /// Implements the ChronoShotData profile message.
-    /// </summary>
-    public class ChronoShotDataMesg : Mesg
-    {
-        #region Fields
-        #endregion
+	/// <summary>
+	/// Implements the ChronoShotData profile message.
+	/// </summary>
+	public class ChronoShotDataMesg : Mesg
+	{
+		#region Fields
+		#endregion
 
-        /// <summary>
-        /// Field Numbers for <see cref="ChronoShotDataMesg"/>
-        /// </summary>
-        public sealed class FieldDefNum
-        {
-            public const byte Timestamp = 253;
-            public const byte ShotSpeed = 0;
-            public const byte ShotNum = 1;
-            public const byte Invalid = Fit.FieldNumInvalid;
-        }
+		/// <summary>
+		/// Field Numbers for <see cref="ChronoShotDataMesg"/>
+		/// </summary>
+		public sealed class FieldDefNum
+		{
+			public const byte Timestamp = 253;
+			public const byte ShotSpeed = 0;
+			public const byte ShotNum = 1;
+			public const byte Invalid = Fit.FieldNumInvalid;
+		}
 
-        #region Constructors
-        public ChronoShotDataMesg() : base(Profile.GetMesg(MesgNum.ChronoShotData))
-        {
-        }
+		#region Constructors
+		public ChronoShotDataMesg() : base(Profile.GetMesg(MesgNum.ChronoShotData))
+		{
+		}
 
-        public ChronoShotDataMesg(Mesg mesg) : base(mesg)
-        {
-        }
-        #endregion // Constructors
+		public ChronoShotDataMesg(Mesg mesg) : base(mesg)
+		{
+		}
+		#endregion // Constructors
 
-        #region Methods
-        ///<summary>
-        /// Retrieves the Timestamp field</summary>
-        /// <returns>Returns DateTime representing the Timestamp field</returns>
-        public DateTime GetTimestamp()
-        {
-            Object val = GetFieldValue(253, 0, Fit.SubfieldIndexMainField);
-            if(val == null)
-            {
-                return null;
-            }
+		#region Methods
+		///<summary>
+		/// Retrieves the Timestamp field</summary>
+		/// <returns>Returns DateTime representing the Timestamp field</returns>
+		public DateTime Timestamp
+		{
+			get
+			{
+				Object val = GetFieldValue(253, 0, Fit.SubfieldIndexMainField);
+				if (val == null)
+				{
+					return null;
+				}
 
-            return TimestampToDateTime(Convert.ToUInt32(val));
-            
-        }
+				return TimestampToDateTime(Convert.ToUInt32(val));
 
-        /// <summary>
-        /// Set Timestamp field</summary>
-        /// <param name="timestamp_">Nullable field value to be set</param>
-        public void SetTimestamp(DateTime timestamp_)
-        {
-            SetFieldValue(253, 0, timestamp_.GetTimeStamp(), Fit.SubfieldIndexMainField);
-        }
-        
-        ///<summary>
-        /// Retrieves the ShotSpeed field
-        /// Units: m/s</summary>
-        /// <returns>Returns nullable float representing the ShotSpeed field</returns>
-        public float? GetShotSpeed()
-        {
-            Object val = GetFieldValue(0, 0, Fit.SubfieldIndexMainField);
-            if(val == null)
-            {
-                return null;
-            }
+			}
+			set
+			{
+				SetFieldValue(253, 0, value.GetTimeStamp(), Fit.SubfieldIndexMainField);
+			}
+		}
 
-            return (Convert.ToSingle(val));
-            
-        }
+		///<summary>
+		/// Retrieves the ShotSpeed field
+		/// Units: m/s</summary>
+		/// <returns>Returns nullable float representing the ShotSpeed field</returns>
+		public float? ShotSpeed
+		{
+			get
+			{
+				Object val = GetFieldValue(0, 0, Fit.SubfieldIndexMainField);
+				if (val == null)
+				{
+					return null;
+				}
 
-        /// <summary>
-        /// Set ShotSpeed field
-        /// Units: m/s</summary>
-        /// <param name="shotSpeed_">Nullable field value to be set</param>
-        public void SetShotSpeed(float? shotSpeed_)
-        {
-            SetFieldValue(0, 0, shotSpeed_, Fit.SubfieldIndexMainField);
-        }
-        
-        ///<summary>
-        /// Retrieves the ShotNum field</summary>
-        /// <returns>Returns nullable ushort representing the ShotNum field</returns>
-        public ushort? GetShotNum()
-        {
-            Object val = GetFieldValue(1, 0, Fit.SubfieldIndexMainField);
-            if(val == null)
-            {
-                return null;
-            }
+				return (Convert.ToSingle(val));
 
-            return (Convert.ToUInt16(val));
-            
-        }
+			}
+			set
+			{
+				SetFieldValue(0, 0, value, Fit.SubfieldIndexMainField);
+			}
+		}
 
-        /// <summary>
-        /// Set ShotNum field</summary>
-        /// <param name="shotNum_">Nullable field value to be set</param>
-        public void SetShotNum(ushort? shotNum_)
-        {
-            SetFieldValue(1, 0, shotNum_, Fit.SubfieldIndexMainField);
-        }
-        
-        #endregion // Methods
-    } // Class
+		///<summary>
+		/// Retrieves the ShotNum field</summary>
+		/// <returns>Returns nullable ushort representing the ShotNum field</returns>
+		public ushort? ShotNum
+		{
+			get
+			{
+				Object val = GetFieldValue(1, 0, Fit.SubfieldIndexMainField);
+				if (val == null)
+				{
+					return null;
+				}
+
+				return (Convert.ToUInt16(val));
+
+			}
+			set
+			{
+				SetFieldValue(1, 0, value, Fit.SubfieldIndexMainField);
+			}
+		}
+
+		#endregion // Methods
+	} // Class
 } // namespace

--- a/Dynastream/Fit/Profile/Mesgs/ChronoShotSessionMesg.cs
+++ b/Dynastream/Fit/Profile/Mesgs/ChronoShotSessionMesg.cs
@@ -21,230 +21,217 @@ using System.Linq;
 
 namespace Dynastream.Fit
 {
-    /// <summary>
-    /// Implements the ChronoShotSession profile message.
-    /// </summary>
-    public class ChronoShotSessionMesg : Mesg
-    {
-        #region Fields
-        #endregion
+	/// <summary>
+	/// Implements the ChronoShotSession profile message.
+	/// </summary>
+	public class ChronoShotSessionMesg : Mesg
+	{
+		#region Fields
+		#endregion
 
-        /// <summary>
-        /// Field Numbers for <see cref="ChronoShotSessionMesg"/>
-        /// </summary>
-        public sealed class FieldDefNum
-        {
-            public const byte Timestamp = 253;
-            public const byte MinSpeed = 0;
-            public const byte MaxSpeed = 1;
-            public const byte AvgSpeed = 2;
-            public const byte ShotCount = 3;
-            public const byte ProjectileType = 4;
-            public const byte GrainWeight = 5;
-            public const byte StandardDeviation = 6;
-            public const byte Invalid = Fit.FieldNumInvalid;
-        }
+		/// <summary>
+		/// Field Numbers for <see cref="ChronoShotSessionMesg"/>
+		/// </summary>
+		public sealed class FieldDefNum
+		{
+			public const byte Timestamp = 253;
+			public const byte MinSpeed = 0;
+			public const byte MaxSpeed = 1;
+			public const byte AvgSpeed = 2;
+			public const byte ShotCount = 3;
+			public const byte ProjectileType = 4;
+			public const byte GrainWeight = 5;
+			public const byte StandardDeviation = 6;
+			public const byte Invalid = Fit.FieldNumInvalid;
+		}
 
-        #region Constructors
-        public ChronoShotSessionMesg() : base(Profile.GetMesg(MesgNum.ChronoShotSession))
-        {
-        }
+		#region Constructors
+		public ChronoShotSessionMesg() : base(Profile.GetMesg(MesgNum.ChronoShotSession))
+		{
+		}
 
-        public ChronoShotSessionMesg(Mesg mesg) : base(mesg)
-        {
-        }
-        #endregion // Constructors
+		public ChronoShotSessionMesg(Mesg mesg) : base(mesg)
+		{
+		}
+		#endregion // Constructors
 
-        #region Methods
-        ///<summary>
-        /// Retrieves the Timestamp field</summary>
-        /// <returns>Returns DateTime representing the Timestamp field</returns>
-        public DateTime GetTimestamp()
-        {
-            Object val = GetFieldValue(253, 0, Fit.SubfieldIndexMainField);
-            if(val == null)
-            {
-                return null;
-            }
+		#region Methods
+		///<summary>
+		/// Retrieves the Timestamp field</summary>
+		/// <returns>Returns DateTime representing the Timestamp field</returns>
+		public DateTime Timestamp
+		{
+			get
+			{
+				Object val = GetFieldValue(253, 0, Fit.SubfieldIndexMainField);
+				if (val == null)
+				{
+					return null;
+				}
 
-            return TimestampToDateTime(Convert.ToUInt32(val));
-            
-        }
+				return TimestampToDateTime(Convert.ToUInt32(val));
 
-        /// <summary>
-        /// Set Timestamp field</summary>
-        /// <param name="timestamp_">Nullable field value to be set</param>
-        public void SetTimestamp(DateTime timestamp_)
-        {
-            SetFieldValue(253, 0, timestamp_.GetTimeStamp(), Fit.SubfieldIndexMainField);
-        }
-        
-        ///<summary>
-        /// Retrieves the MinSpeed field
-        /// Units: m/s</summary>
-        /// <returns>Returns nullable float representing the MinSpeed field</returns>
-        public float? GetMinSpeed()
-        {
-            Object val = GetFieldValue(0, 0, Fit.SubfieldIndexMainField);
-            if(val == null)
-            {
-                return null;
-            }
+			}
+			set
+			{
+				SetFieldValue(253, 0, value.GetTimeStamp(), Fit.SubfieldIndexMainField);
+			}
+		}
 
-            return (Convert.ToSingle(val));
-            
-        }
+		///<summary>
+		/// Retrieves the MinSpeed field
+		/// Units: m/s</summary>
+		/// <returns>Returns nullable float representing the MinSpeed field</returns>
+		public float? MinSpeed
+		{
+			get
+			{
+				Object val = GetFieldValue(0, 0, Fit.SubfieldIndexMainField);
+				if (val == null)
+				{
+					return null;
+				}
 
-        /// <summary>
-        /// Set MinSpeed field
-        /// Units: m/s</summary>
-        /// <param name="minSpeed_">Nullable field value to be set</param>
-        public void SetMinSpeed(float? minSpeed_)
-        {
-            SetFieldValue(0, 0, minSpeed_, Fit.SubfieldIndexMainField);
-        }
-        
-        ///<summary>
-        /// Retrieves the MaxSpeed field
-        /// Units: m/s</summary>
-        /// <returns>Returns nullable float representing the MaxSpeed field</returns>
-        public float? GetMaxSpeed()
-        {
-            Object val = GetFieldValue(1, 0, Fit.SubfieldIndexMainField);
-            if(val == null)
-            {
-                return null;
-            }
+				return (Convert.ToSingle(val));
 
-            return (Convert.ToSingle(val));
-            
-        }
+			}
+			set
+			{
+				SetFieldValue(0, 0, value, Fit.SubfieldIndexMainField);
+			}
+		}
 
-        /// <summary>
-        /// Set MaxSpeed field
-        /// Units: m/s</summary>
-        /// <param name="maxSpeed_">Nullable field value to be set</param>
-        public void SetMaxSpeed(float? maxSpeed_)
-        {
-            SetFieldValue(1, 0, maxSpeed_, Fit.SubfieldIndexMainField);
-        }
-        
-        ///<summary>
-        /// Retrieves the AvgSpeed field
-        /// Units: m/s</summary>
-        /// <returns>Returns nullable float representing the AvgSpeed field</returns>
-        public float? GetAvgSpeed()
-        {
-            Object val = GetFieldValue(2, 0, Fit.SubfieldIndexMainField);
-            if(val == null)
-            {
-                return null;
-            }
+		///<summary>
+		/// Retrieves the MaxSpeed field
+		/// Units: m/s</summary>
+		/// <returns>Returns nullable float representing the MaxSpeed field</returns>
+		public float? MaxSpeed
+		{
+			get
+			{
+				Object val = GetFieldValue(1, 0, Fit.SubfieldIndexMainField);
+				if (val == null)
+				{
+					return null;
+				}
 
-            return (Convert.ToSingle(val));
-            
-        }
+				return (Convert.ToSingle(val));
 
-        /// <summary>
-        /// Set AvgSpeed field
-        /// Units: m/s</summary>
-        /// <param name="avgSpeed_">Nullable field value to be set</param>
-        public void SetAvgSpeed(float? avgSpeed_)
-        {
-            SetFieldValue(2, 0, avgSpeed_, Fit.SubfieldIndexMainField);
-        }
-        
-        ///<summary>
-        /// Retrieves the ShotCount field</summary>
-        /// <returns>Returns nullable ushort representing the ShotCount field</returns>
-        public ushort? GetShotCount()
-        {
-            Object val = GetFieldValue(3, 0, Fit.SubfieldIndexMainField);
-            if(val == null)
-            {
-                return null;
-            }
+			}
+			set
+			{
+				SetFieldValue(1, 0, value, Fit.SubfieldIndexMainField);
+			}
+		}
 
-            return (Convert.ToUInt16(val));
-            
-        }
+		///<summary>
+		/// Retrieves the AvgSpeed field
+		/// Units: m/s</summary>
+		/// <returns>Returns nullable float representing the AvgSpeed field</returns>
+		public float? AvgSpeed
+		{
+			get
+			{
+				Object val = GetFieldValue(2, 0, Fit.SubfieldIndexMainField);
+				if (val == null)
+				{
+					return null;
+				}
 
-        /// <summary>
-        /// Set ShotCount field</summary>
-        /// <param name="shotCount_">Nullable field value to be set</param>
-        public void SetShotCount(ushort? shotCount_)
-        {
-            SetFieldValue(3, 0, shotCount_, Fit.SubfieldIndexMainField);
-        }
-        
-        ///<summary>
-        /// Retrieves the ProjectileType field</summary>
-        /// <returns>Returns nullable ProjectileType enum representing the ProjectileType field</returns>
-        public ProjectileType? GetProjectileType()
-        {
-            object obj = GetFieldValue(4, 0, Fit.SubfieldIndexMainField);
-            ProjectileType? value = obj == null ? (ProjectileType?)null : (ProjectileType)obj;
-            return value;
-        }
+				return (Convert.ToSingle(val));
 
-        /// <summary>
-        /// Set ProjectileType field</summary>
-        /// <param name="projectileType_">Nullable field value to be set</param>
-        public void SetProjectileType(ProjectileType? projectileType_)
-        {
-            SetFieldValue(4, 0, projectileType_, Fit.SubfieldIndexMainField);
-        }
-        
-        ///<summary>
-        /// Retrieves the GrainWeight field
-        /// Units: gr</summary>
-        /// <returns>Returns nullable float representing the GrainWeight field</returns>
-        public float? GetGrainWeight()
-        {
-            Object val = GetFieldValue(5, 0, Fit.SubfieldIndexMainField);
-            if(val == null)
-            {
-                return null;
-            }
+			}
+			set
+			{
+				SetFieldValue(2, 0, value, Fit.SubfieldIndexMainField);
+			}
+		}
 
-            return (Convert.ToSingle(val));
-            
-        }
+		///<summary>
+		/// Retrieves the ShotCount field</summary>
+		/// <returns>Returns nullable ushort representing the ShotCount field</returns>
+		public ushort? ShotCount
+		{
+			get
+			{
+				Object val = GetFieldValue(3, 0, Fit.SubfieldIndexMainField);
+				if (val == null)
+				{
+					return null;
+				}
 
-        /// <summary>
-        /// Set GrainWeight field
-        /// Units: gr</summary>
-        /// <param name="grainWeight_">Nullable field value to be set</param>
-        public void SetGrainWeight(float? grainWeight_)
-        {
-            SetFieldValue(5, 0, grainWeight_, Fit.SubfieldIndexMainField);
-        }
-        
-        ///<summary>
-        /// Retrieves the StandardDeviation field
-        /// Units: m/s</summary>
-        /// <returns>Returns nullable float representing the StandardDeviation field</returns>
-        public float? GetStandardDeviation()
-        {
-            Object val = GetFieldValue(6, 0, Fit.SubfieldIndexMainField);
-            if(val == null)
-            {
-                return null;
-            }
+				return (Convert.ToUInt16(val));
 
-            return (Convert.ToSingle(val));
-            
-        }
+			}
+			set
+			{
+				SetFieldValue(3, 0, value, Fit.SubfieldIndexMainField);
+			}
+		}
 
-        /// <summary>
-        /// Set StandardDeviation field
-        /// Units: m/s</summary>
-        /// <param name="standardDeviation_">Nullable field value to be set</param>
-        public void SetStandardDeviation(float? standardDeviation_)
-        {
-            SetFieldValue(6, 0, standardDeviation_, Fit.SubfieldIndexMainField);
-        }
-        
-        #endregion // Methods
-    } // Class
+		///<summary>
+		/// Retrieves the ProjectileType field</summary>
+		/// <returns>Returns nullable ProjectileType enum representing the ProjectileType field</returns>
+		public ProjectileType? ProjectileType
+		{
+			get
+			{
+				object obj = GetFieldValue(4, 0, Fit.SubfieldIndexMainField);
+				ProjectileType? value = obj == null ? (ProjectileType?)null : (ProjectileType)obj;
+				return value;
+			}
+			set
+			{
+				SetFieldValue(4, 0, value, Fit.SubfieldIndexMainField);
+			}
+		}
+
+		///<summary>
+		/// Retrieves the GrainWeight field
+		/// Units: gr</summary>
+		/// <returns>Returns nullable float representing the GrainWeight field</returns>
+		public float? GrainWeight
+		{
+			get
+			{
+				Object val = GetFieldValue(5, 0, Fit.SubfieldIndexMainField);
+				if (val == null)
+				{
+					return null;
+				}
+
+				return (Convert.ToSingle(val));
+
+			}
+			set
+			{
+				SetFieldValue(5, 0, value, Fit.SubfieldIndexMainField);
+			}
+		}
+
+		///<summary>
+		/// Retrieves the StandardDeviation field
+		/// Units: m/s</summary>
+		/// <returns>Returns nullable float representing the StandardDeviation field</returns>
+		public float? StandardDeviation
+		{
+			get
+			{
+				Object val = GetFieldValue(6, 0, Fit.SubfieldIndexMainField);
+				if (val == null)
+				{
+					return null;
+				}
+
+				return (Convert.ToSingle(val));
+
+			}
+			set
+			{
+				SetFieldValue(6, 0, value, Fit.SubfieldIndexMainField);
+			}
+		}
+
+		#endregion // Methods
+	} // Class
 } // namespace

--- a/Dynastream/Fit/Profile/Mesgs/ClimbProMesg.cs
+++ b/Dynastream/Fit/Profile/Mesgs/ClimbProMesg.cs
@@ -21,204 +21,193 @@ using System.Linq;
 
 namespace Dynastream.Fit
 {
-    /// <summary>
-    /// Implements the ClimbPro profile message.
-    /// </summary>
-    public class ClimbProMesg : Mesg
-    {
-        #region Fields
-        #endregion
+	/// <summary>
+	/// Implements the ClimbPro profile message.
+	/// </summary>
+	public class ClimbProMesg : Mesg
+	{
+		#region Fields
+		#endregion
 
-        /// <summary>
-        /// Field Numbers for <see cref="ClimbProMesg"/>
-        /// </summary>
-        public sealed class FieldDefNum
-        {
-            public const byte Timestamp = 253;
-            public const byte PositionLat = 0;
-            public const byte PositionLong = 1;
-            public const byte ClimbProEvent = 2;
-            public const byte ClimbNumber = 3;
-            public const byte ClimbCategory = 4;
-            public const byte CurrentDist = 5;
-            public const byte Invalid = Fit.FieldNumInvalid;
-        }
+		/// <summary>
+		/// Field Numbers for <see cref="ClimbProMesg"/>
+		/// </summary>
+		public sealed class FieldDefNum
+		{
+			public const byte Timestamp = 253;
+			public const byte PositionLat = 0;
+			public const byte PositionLong = 1;
+			public const byte ClimbProEvent = 2;
+			public const byte ClimbNumber = 3;
+			public const byte ClimbCategory = 4;
+			public const byte CurrentDist = 5;
+			public const byte Invalid = Fit.FieldNumInvalid;
+		}
 
-        #region Constructors
-        public ClimbProMesg() : base(Profile.GetMesg(MesgNum.ClimbPro))
-        {
-        }
+		#region Constructors
+		public ClimbProMesg() : base(Profile.GetMesg(MesgNum.ClimbPro))
+		{
+		}
 
-        public ClimbProMesg(Mesg mesg) : base(mesg)
-        {
-        }
-        #endregion // Constructors
+		public ClimbProMesg(Mesg mesg) : base(mesg)
+		{
+		}
+		#endregion // Constructors
 
-        #region Methods
-        ///<summary>
-        /// Retrieves the Timestamp field
-        /// Units: s</summary>
-        /// <returns>Returns DateTime representing the Timestamp field</returns>
-        public DateTime GetTimestamp()
-        {
-            Object val = GetFieldValue(253, 0, Fit.SubfieldIndexMainField);
-            if(val == null)
-            {
-                return null;
-            }
+		#region Methods
+		///<summary>
+		/// Retrieves the Timestamp field
+		/// Units: s</summary>
+		/// <returns>Returns DateTime representing the Timestamp field</returns>
+		public DateTime Timestamp
+		{
+			get
+			{
+				Object val = GetFieldValue(253, 0, Fit.SubfieldIndexMainField);
+				if (val == null)
+				{
+					return null;
+				}
 
-            return TimestampToDateTime(Convert.ToUInt32(val));
-            
-        }
+				return TimestampToDateTime(Convert.ToUInt32(val));
 
-        /// <summary>
-        /// Set Timestamp field
-        /// Units: s</summary>
-        /// <param name="timestamp_">Nullable field value to be set</param>
-        public void SetTimestamp(DateTime timestamp_)
-        {
-            SetFieldValue(253, 0, timestamp_.GetTimeStamp(), Fit.SubfieldIndexMainField);
-        }
-        
-        ///<summary>
-        /// Retrieves the PositionLat field
-        /// Units: semicircles</summary>
-        /// <returns>Returns nullable int representing the PositionLat field</returns>
-        public int? GetPositionLat()
-        {
-            Object val = GetFieldValue(0, 0, Fit.SubfieldIndexMainField);
-            if(val == null)
-            {
-                return null;
-            }
+			}
+			set
+			{
+				SetFieldValue(253, 0, value.GetTimeStamp(), Fit.SubfieldIndexMainField);
+			}
+		}
 
-            return (Convert.ToInt32(val));
-            
-        }
+		///<summary>
+		/// Retrieves the PositionLat field
+		/// Units: semicircles</summary>
+		/// <returns>Returns nullable int representing the PositionLat field</returns>
+		public int? PositionLat
+		{
+			get
+			{
+				Object val = GetFieldValue(0, 0, Fit.SubfieldIndexMainField);
+				if (val == null)
+				{
+					return null;
+				}
 
-        /// <summary>
-        /// Set PositionLat field
-        /// Units: semicircles</summary>
-        /// <param name="positionLat_">Nullable field value to be set</param>
-        public void SetPositionLat(int? positionLat_)
-        {
-            SetFieldValue(0, 0, positionLat_, Fit.SubfieldIndexMainField);
-        }
-        
-        ///<summary>
-        /// Retrieves the PositionLong field
-        /// Units: semicircles</summary>
-        /// <returns>Returns nullable int representing the PositionLong field</returns>
-        public int? GetPositionLong()
-        {
-            Object val = GetFieldValue(1, 0, Fit.SubfieldIndexMainField);
-            if(val == null)
-            {
-                return null;
-            }
+				return (Convert.ToInt32(val));
 
-            return (Convert.ToInt32(val));
-            
-        }
+			}
+			set
+			{
+				SetFieldValue(0, 0, value, Fit.SubfieldIndexMainField);
+			}
+		}
 
-        /// <summary>
-        /// Set PositionLong field
-        /// Units: semicircles</summary>
-        /// <param name="positionLong_">Nullable field value to be set</param>
-        public void SetPositionLong(int? positionLong_)
-        {
-            SetFieldValue(1, 0, positionLong_, Fit.SubfieldIndexMainField);
-        }
-        
-        ///<summary>
-        /// Retrieves the ClimbProEvent field</summary>
-        /// <returns>Returns nullable ClimbProEvent enum representing the ClimbProEvent field</returns>
-        public ClimbProEvent? GetClimbProEvent()
-        {
-            object obj = GetFieldValue(2, 0, Fit.SubfieldIndexMainField);
-            ClimbProEvent? value = obj == null ? (ClimbProEvent?)null : (ClimbProEvent)obj;
-            return value;
-        }
+		///<summary>
+		/// Retrieves the PositionLong field
+		/// Units: semicircles</summary>
+		/// <returns>Returns nullable int representing the PositionLong field</returns>
+		public int? PositionLong
+		{
+			get
+			{
+				Object val = GetFieldValue(1, 0, Fit.SubfieldIndexMainField);
+				if (val == null)
+				{
+					return null;
+				}
 
-        /// <summary>
-        /// Set ClimbProEvent field</summary>
-        /// <param name="climbProEvent_">Nullable field value to be set</param>
-        public void SetClimbProEvent(ClimbProEvent? climbProEvent_)
-        {
-            SetFieldValue(2, 0, climbProEvent_, Fit.SubfieldIndexMainField);
-        }
-        
-        ///<summary>
-        /// Retrieves the ClimbNumber field</summary>
-        /// <returns>Returns nullable ushort representing the ClimbNumber field</returns>
-        public ushort? GetClimbNumber()
-        {
-            Object val = GetFieldValue(3, 0, Fit.SubfieldIndexMainField);
-            if(val == null)
-            {
-                return null;
-            }
+				return (Convert.ToInt32(val));
 
-            return (Convert.ToUInt16(val));
-            
-        }
+			}
+			set
+			{
+				SetFieldValue(1, 0, value, Fit.SubfieldIndexMainField);
+			}
+		}
 
-        /// <summary>
-        /// Set ClimbNumber field</summary>
-        /// <param name="climbNumber_">Nullable field value to be set</param>
-        public void SetClimbNumber(ushort? climbNumber_)
-        {
-            SetFieldValue(3, 0, climbNumber_, Fit.SubfieldIndexMainField);
-        }
-        
-        ///<summary>
-        /// Retrieves the ClimbCategory field</summary>
-        /// <returns>Returns nullable byte representing the ClimbCategory field</returns>
-        public byte? GetClimbCategory()
-        {
-            Object val = GetFieldValue(4, 0, Fit.SubfieldIndexMainField);
-            if(val == null)
-            {
-                return null;
-            }
+		///<summary>
+		/// Retrieves the ClimbProEvent field</summary>
+		/// <returns>Returns nullable ClimbProEvent enum representing the ClimbProEvent field</returns>
+		public ClimbProEvent? ClimbProEvent
+		{
+			get
+			{
+				object obj = GetFieldValue(2, 0, Fit.SubfieldIndexMainField);
+				ClimbProEvent? value = obj == null ? (ClimbProEvent?)null : (ClimbProEvent)obj;
+				return value;
+			}
+			set
+			{
+				SetFieldValue(2, 0, value, Fit.SubfieldIndexMainField);
+			}
+		}
 
-            return (Convert.ToByte(val));
-            
-        }
+		///<summary>
+		/// Retrieves the ClimbNumber field</summary>
+		/// <returns>Returns nullable ushort representing the ClimbNumber field</returns>
+		public ushort? ClimbNumber
+		{
+			get
+			{
+				Object val = GetFieldValue(3, 0, Fit.SubfieldIndexMainField);
+				if (val == null)
+				{
+					return null;
+				}
 
-        /// <summary>
-        /// Set ClimbCategory field</summary>
-        /// <param name="climbCategory_">Nullable field value to be set</param>
-        public void SetClimbCategory(byte? climbCategory_)
-        {
-            SetFieldValue(4, 0, climbCategory_, Fit.SubfieldIndexMainField);
-        }
-        
-        ///<summary>
-        /// Retrieves the CurrentDist field
-        /// Units: m</summary>
-        /// <returns>Returns nullable float representing the CurrentDist field</returns>
-        public float? GetCurrentDist()
-        {
-            Object val = GetFieldValue(5, 0, Fit.SubfieldIndexMainField);
-            if(val == null)
-            {
-                return null;
-            }
+				return (Convert.ToUInt16(val));
 
-            return (Convert.ToSingle(val));
-            
-        }
+			}
+			set
+			{
+				SetFieldValue(3, 0, value, Fit.SubfieldIndexMainField);
+			}
+		}
 
-        /// <summary>
-        /// Set CurrentDist field
-        /// Units: m</summary>
-        /// <param name="currentDist_">Nullable field value to be set</param>
-        public void SetCurrentDist(float? currentDist_)
-        {
-            SetFieldValue(5, 0, currentDist_, Fit.SubfieldIndexMainField);
-        }
-        
-        #endregion // Methods
-    } // Class
+		///<summary>
+		/// Retrieves the ClimbCategory field</summary>
+		/// <returns>Returns nullable byte representing the ClimbCategory field</returns>
+		public byte? ClimbCategory
+		{
+			get
+			{
+				Object val = GetFieldValue(4, 0, Fit.SubfieldIndexMainField);
+				if (val == null)
+				{
+					return null;
+				}
+
+				return (Convert.ToByte(val));
+
+			}
+			set
+			{
+				SetFieldValue(4, 0, value, Fit.SubfieldIndexMainField);
+			}
+		}
+
+		///<summary>
+		/// Retrieves the CurrentDist field
+		/// Units: m</summary>
+		/// <returns>Returns nullable float representing the CurrentDist field</returns>
+		public float? CurrentDist
+		{
+			get
+			{
+				Object val = GetFieldValue(5, 0, Fit.SubfieldIndexMainField);
+				if (val == null)
+				{
+					return null;
+				}
+
+				return (Convert.ToSingle(val));
+
+			}
+			set
+			{
+				SetFieldValue(5, 0, value, Fit.SubfieldIndexMainField);
+			}
+		}
+
+		#endregion // Methods
+	} // Class
 } // namespace

--- a/Dynastream/Fit/Profile/Mesgs/ConnectivityMesg.cs
+++ b/Dynastream/Fit/Profile/Mesgs/ConnectivityMesg.cs
@@ -21,306 +21,289 @@ using System.Linq;
 
 namespace Dynastream.Fit
 {
-    /// <summary>
-    /// Implements the Connectivity profile message.
-    /// </summary>
-    public class ConnectivityMesg : Mesg
-    {
-        #region Fields
-        #endregion
+	/// <summary>
+	/// Implements the Connectivity profile message.
+	/// </summary>
+	public class ConnectivityMesg : Mesg
+	{
+		#region Fields
+		#endregion
 
-        /// <summary>
-        /// Field Numbers for <see cref="ConnectivityMesg"/>
-        /// </summary>
-        public sealed class FieldDefNum
-        {
-            public const byte BluetoothEnabled = 0;
-            public const byte BluetoothLeEnabled = 1;
-            public const byte AntEnabled = 2;
-            public const byte Name = 3;
-            public const byte LiveTrackingEnabled = 4;
-            public const byte WeatherConditionsEnabled = 5;
-            public const byte WeatherAlertsEnabled = 6;
-            public const byte AutoActivityUploadEnabled = 7;
-            public const byte CourseDownloadEnabled = 8;
-            public const byte WorkoutDownloadEnabled = 9;
-            public const byte GpsEphemerisDownloadEnabled = 10;
-            public const byte IncidentDetectionEnabled = 11;
-            public const byte GrouptrackEnabled = 12;
-            public const byte Invalid = Fit.FieldNumInvalid;
-        }
+		/// <summary>
+		/// Field Numbers for <see cref="ConnectivityMesg"/>
+		/// </summary>
+		public sealed class FieldDefNum
+		{
+			public const byte BluetoothEnabled = 0;
+			public const byte BluetoothLeEnabled = 1;
+			public const byte AntEnabled = 2;
+			public const byte Name = 3;
+			public const byte LiveTrackingEnabled = 4;
+			public const byte WeatherConditionsEnabled = 5;
+			public const byte WeatherAlertsEnabled = 6;
+			public const byte AutoActivityUploadEnabled = 7;
+			public const byte CourseDownloadEnabled = 8;
+			public const byte WorkoutDownloadEnabled = 9;
+			public const byte GpsEphemerisDownloadEnabled = 10;
+			public const byte IncidentDetectionEnabled = 11;
+			public const byte GrouptrackEnabled = 12;
+			public const byte Invalid = Fit.FieldNumInvalid;
+		}
 
-        #region Constructors
-        public ConnectivityMesg() : base(Profile.GetMesg(MesgNum.Connectivity))
-        {
-        }
+		#region Constructors
+		public ConnectivityMesg() : base(Profile.GetMesg(MesgNum.Connectivity))
+		{
+		}
 
-        public ConnectivityMesg(Mesg mesg) : base(mesg)
-        {
-        }
-        #endregion // Constructors
+		public ConnectivityMesg(Mesg mesg) : base(mesg)
+		{
+		}
+		#endregion // Constructors
 
-        #region Methods
-        ///<summary>
-        /// Retrieves the BluetoothEnabled field
-        /// Comment: Use Bluetooth for connectivity features</summary>
-        /// <returns>Returns nullable Bool enum representing the BluetoothEnabled field</returns>
-        public Bool? GetBluetoothEnabled()
-        {
-            object obj = GetFieldValue(0, 0, Fit.SubfieldIndexMainField);
-            Bool? value = obj == null ? (Bool?)null : (Bool)obj;
-            return value;
-        }
+		#region Methods
+		///<summary>
+		/// Retrieves the BluetoothEnabled field
+		/// Comment: Use Bluetooth for connectivity features</summary>
+		/// <returns>Returns nullable Bool enum representing the BluetoothEnabled field</returns>
+		public Bool? BluetoothEnabled
+		{
+			get
+			{
+				object obj = GetFieldValue(0, 0, Fit.SubfieldIndexMainField);
+				Bool? value = obj == null ? (Bool?)null : (Bool)obj;
+				return value;
+			}
+			set
+			{
+				SetFieldValue(0, 0, value, Fit.SubfieldIndexMainField);
+			}
+		}
 
-        /// <summary>
-        /// Set BluetoothEnabled field
-        /// Comment: Use Bluetooth for connectivity features</summary>
-        /// <param name="bluetoothEnabled_">Nullable field value to be set</param>
-        public void SetBluetoothEnabled(Bool? bluetoothEnabled_)
-        {
-            SetFieldValue(0, 0, bluetoothEnabled_, Fit.SubfieldIndexMainField);
-        }
-        
-        ///<summary>
-        /// Retrieves the BluetoothLeEnabled field
-        /// Comment: Use Bluetooth Low Energy for connectivity features</summary>
-        /// <returns>Returns nullable Bool enum representing the BluetoothLeEnabled field</returns>
-        public Bool? GetBluetoothLeEnabled()
-        {
-            object obj = GetFieldValue(1, 0, Fit.SubfieldIndexMainField);
-            Bool? value = obj == null ? (Bool?)null : (Bool)obj;
-            return value;
-        }
+		///<summary>
+		/// Retrieves the BluetoothLeEnabled field
+		/// Comment: Use Bluetooth Low Energy for connectivity features</summary>
+		/// <returns>Returns nullable Bool enum representing the BluetoothLeEnabled field</returns>
+		public Bool? BluetoothLeEnabled
+		{
+			get
+			{
+				object obj = GetFieldValue(1, 0, Fit.SubfieldIndexMainField);
+				Bool? value = obj == null ? (Bool?)null : (Bool)obj;
+				return value;
+			}
+			set
+			{
+				SetFieldValue(1, 0, value, Fit.SubfieldIndexMainField);
+			}
+		}
 
-        /// <summary>
-        /// Set BluetoothLeEnabled field
-        /// Comment: Use Bluetooth Low Energy for connectivity features</summary>
-        /// <param name="bluetoothLeEnabled_">Nullable field value to be set</param>
-        public void SetBluetoothLeEnabled(Bool? bluetoothLeEnabled_)
-        {
-            SetFieldValue(1, 0, bluetoothLeEnabled_, Fit.SubfieldIndexMainField);
-        }
-        
-        ///<summary>
-        /// Retrieves the AntEnabled field
-        /// Comment: Use ANT for connectivity features</summary>
-        /// <returns>Returns nullable Bool enum representing the AntEnabled field</returns>
-        public Bool? GetAntEnabled()
-        {
-            object obj = GetFieldValue(2, 0, Fit.SubfieldIndexMainField);
-            Bool? value = obj == null ? (Bool?)null : (Bool)obj;
-            return value;
-        }
+		///<summary>
+		/// Retrieves the AntEnabled field
+		/// Comment: Use ANT for connectivity features</summary>
+		/// <returns>Returns nullable Bool enum representing the AntEnabled field</returns>
+		public Bool? AntEnabled
+		{
+			get
+			{
+				object obj = GetFieldValue(2, 0, Fit.SubfieldIndexMainField);
+				Bool? value = obj == null ? (Bool?)null : (Bool)obj;
+				return value;
+			}
+			set
+			{
+				SetFieldValue(2, 0, value, Fit.SubfieldIndexMainField);
+			}
+		}
 
-        /// <summary>
-        /// Set AntEnabled field
-        /// Comment: Use ANT for connectivity features</summary>
-        /// <param name="antEnabled_">Nullable field value to be set</param>
-        public void SetAntEnabled(Bool? antEnabled_)
-        {
-            SetFieldValue(2, 0, antEnabled_, Fit.SubfieldIndexMainField);
-        }
-        
-        ///<summary>
-        /// Retrieves the Name field</summary>
-        /// <returns>Returns byte[] representing the Name field</returns>
-        public byte[] GetName()
-        {
-            byte[] data = (byte[])GetFieldValue(3, 0, Fit.SubfieldIndexMainField);
-            return data.Take(data.Length - 1).ToArray();
-        }
+		///<summary>
+		/// Retrieves the Name field</summary>
+		/// <returns>Returns byte[] representing the Name field</returns>
+		public byte[] Name
+		{
+			get
+			{
+				byte[] data = (byte[])GetFieldValue(3, 0, Fit.SubfieldIndexMainField);
+				return data.Take(data.Length - 1).ToArray();
+			}
+			set
+			{
+				SetFieldValue(3, 0, value, Fit.SubfieldIndexMainField);
+			}
+		}
 
-        ///<summary>
-        /// Retrieves the Name field</summary>
-        /// <returns>Returns String representing the Name field</returns>
-        public String GetNameAsString()
-        {
-            byte[] data = (byte[])GetFieldValue(3, 0, Fit.SubfieldIndexMainField);
-            return data != null ? Encoding.UTF8.GetString(data, 0, data.Length - 1) : null;
-        }
+		///<summary>
+		/// Retrieves the Name field</summary>
+		/// <returns>Returns String representing the Name field</returns>
+		public String GetNameAsString()
+		{
+			byte[] data = (byte[])GetFieldValue(3, 0, Fit.SubfieldIndexMainField);
+			return data != null ? Encoding.UTF8.GetString(data, 0, data.Length - 1) : null;
+		}
 
-        ///<summary>
-        /// Set Name field</summary>
-        /// <param name="name_"> field value to be set</param>
-        public void SetName(String name_)
-        {
-            byte[] data = Encoding.UTF8.GetBytes(name_);
-            byte[] zdata = new byte[data.Length + 1];
-            data.CopyTo(zdata, 0);
-            SetFieldValue(3, 0, zdata, Fit.SubfieldIndexMainField);
-        }
+		///<summary>
+		/// Set Name field</summary>
+		/// <param name="name_"> field value to be set</param>
+		public void SetName(String name_)
+		{
+			byte[] data = Encoding.UTF8.GetBytes(name_);
+			byte[] zdata = new byte[data.Length + 1];
+			data.CopyTo(zdata, 0);
+			SetFieldValue(3, 0, zdata, Fit.SubfieldIndexMainField);
+		}
 
-        
-        /// <summary>
-        /// Set Name field</summary>
-        /// <param name="name_">field value to be set</param>
-        public void SetName(byte[] name_)
-        {
-            SetFieldValue(3, 0, name_, Fit.SubfieldIndexMainField);
-        }
-        
-        ///<summary>
-        /// Retrieves the LiveTrackingEnabled field</summary>
-        /// <returns>Returns nullable Bool enum representing the LiveTrackingEnabled field</returns>
-        public Bool? GetLiveTrackingEnabled()
-        {
-            object obj = GetFieldValue(4, 0, Fit.SubfieldIndexMainField);
-            Bool? value = obj == null ? (Bool?)null : (Bool)obj;
-            return value;
-        }
+		///<summary>
+		/// Retrieves the LiveTrackingEnabled field</summary>
+		/// <returns>Returns nullable Bool enum representing the LiveTrackingEnabled field</returns>
+		public Bool? LiveTrackingEnabled
+		{
+			get
+			{
+				object obj = GetFieldValue(4, 0, Fit.SubfieldIndexMainField);
+				Bool? value = obj == null ? (Bool?)null : (Bool)obj;
+				return value;
+			}
+			set
+			{
+				SetFieldValue(4, 0, value, Fit.SubfieldIndexMainField);
+			}
+		}
 
-        /// <summary>
-        /// Set LiveTrackingEnabled field</summary>
-        /// <param name="liveTrackingEnabled_">Nullable field value to be set</param>
-        public void SetLiveTrackingEnabled(Bool? liveTrackingEnabled_)
-        {
-            SetFieldValue(4, 0, liveTrackingEnabled_, Fit.SubfieldIndexMainField);
-        }
-        
-        ///<summary>
-        /// Retrieves the WeatherConditionsEnabled field</summary>
-        /// <returns>Returns nullable Bool enum representing the WeatherConditionsEnabled field</returns>
-        public Bool? GetWeatherConditionsEnabled()
-        {
-            object obj = GetFieldValue(5, 0, Fit.SubfieldIndexMainField);
-            Bool? value = obj == null ? (Bool?)null : (Bool)obj;
-            return value;
-        }
+		///<summary>
+		/// Retrieves the WeatherConditionsEnabled field</summary>
+		/// <returns>Returns nullable Bool enum representing the WeatherConditionsEnabled field</returns>
+		public Bool? WeatherConditionsEnabled
+		{
+			get
+			{
+				object obj = GetFieldValue(5, 0, Fit.SubfieldIndexMainField);
+				Bool? value = obj == null ? (Bool?)null : (Bool)obj;
+				return value;
+			}
+			set
+			{
+				SetFieldValue(5, 0, value, Fit.SubfieldIndexMainField);
+			}
+		}
 
-        /// <summary>
-        /// Set WeatherConditionsEnabled field</summary>
-        /// <param name="weatherConditionsEnabled_">Nullable field value to be set</param>
-        public void SetWeatherConditionsEnabled(Bool? weatherConditionsEnabled_)
-        {
-            SetFieldValue(5, 0, weatherConditionsEnabled_, Fit.SubfieldIndexMainField);
-        }
-        
-        ///<summary>
-        /// Retrieves the WeatherAlertsEnabled field</summary>
-        /// <returns>Returns nullable Bool enum representing the WeatherAlertsEnabled field</returns>
-        public Bool? GetWeatherAlertsEnabled()
-        {
-            object obj = GetFieldValue(6, 0, Fit.SubfieldIndexMainField);
-            Bool? value = obj == null ? (Bool?)null : (Bool)obj;
-            return value;
-        }
+		///<summary>
+		/// Retrieves the WeatherAlertsEnabled field</summary>
+		/// <returns>Returns nullable Bool enum representing the WeatherAlertsEnabled field</returns>
+		public Bool? WeatherAlertsEnabled
+		{
+			get
+			{
+				object obj = GetFieldValue(6, 0, Fit.SubfieldIndexMainField);
+				Bool? value = obj == null ? (Bool?)null : (Bool)obj;
+				return value;
+			}
+			set
+			{
+				SetFieldValue(6, 0, value, Fit.SubfieldIndexMainField);
+			}
+		}
 
-        /// <summary>
-        /// Set WeatherAlertsEnabled field</summary>
-        /// <param name="weatherAlertsEnabled_">Nullable field value to be set</param>
-        public void SetWeatherAlertsEnabled(Bool? weatherAlertsEnabled_)
-        {
-            SetFieldValue(6, 0, weatherAlertsEnabled_, Fit.SubfieldIndexMainField);
-        }
-        
-        ///<summary>
-        /// Retrieves the AutoActivityUploadEnabled field</summary>
-        /// <returns>Returns nullable Bool enum representing the AutoActivityUploadEnabled field</returns>
-        public Bool? GetAutoActivityUploadEnabled()
-        {
-            object obj = GetFieldValue(7, 0, Fit.SubfieldIndexMainField);
-            Bool? value = obj == null ? (Bool?)null : (Bool)obj;
-            return value;
-        }
+		///<summary>
+		/// Retrieves the AutoActivityUploadEnabled field</summary>
+		/// <returns>Returns nullable Bool enum representing the AutoActivityUploadEnabled field</returns>
+		public Bool? AutoActivityUploadEnabled
+		{
+			get
+			{
+				object obj = GetFieldValue(7, 0, Fit.SubfieldIndexMainField);
+				Bool? value = obj == null ? (Bool?)null : (Bool)obj;
+				return value;
+			}
+			set
+			{
+				SetFieldValue(7, 0, value, Fit.SubfieldIndexMainField);
+			}
+		}
 
-        /// <summary>
-        /// Set AutoActivityUploadEnabled field</summary>
-        /// <param name="autoActivityUploadEnabled_">Nullable field value to be set</param>
-        public void SetAutoActivityUploadEnabled(Bool? autoActivityUploadEnabled_)
-        {
-            SetFieldValue(7, 0, autoActivityUploadEnabled_, Fit.SubfieldIndexMainField);
-        }
-        
-        ///<summary>
-        /// Retrieves the CourseDownloadEnabled field</summary>
-        /// <returns>Returns nullable Bool enum representing the CourseDownloadEnabled field</returns>
-        public Bool? GetCourseDownloadEnabled()
-        {
-            object obj = GetFieldValue(8, 0, Fit.SubfieldIndexMainField);
-            Bool? value = obj == null ? (Bool?)null : (Bool)obj;
-            return value;
-        }
+		///<summary>
+		/// Retrieves the CourseDownloadEnabled field</summary>
+		/// <returns>Returns nullable Bool enum representing the CourseDownloadEnabled field</returns>
+		public Bool? CourseDownloadEnabled
+		{
+			get
+			{
+				object obj = GetFieldValue(8, 0, Fit.SubfieldIndexMainField);
+				Bool? value = obj == null ? (Bool?)null : (Bool)obj;
+				return value;
+			}
+			set
+			{
+				SetFieldValue(8, 0, value, Fit.SubfieldIndexMainField);
+			}
+		}
 
-        /// <summary>
-        /// Set CourseDownloadEnabled field</summary>
-        /// <param name="courseDownloadEnabled_">Nullable field value to be set</param>
-        public void SetCourseDownloadEnabled(Bool? courseDownloadEnabled_)
-        {
-            SetFieldValue(8, 0, courseDownloadEnabled_, Fit.SubfieldIndexMainField);
-        }
-        
-        ///<summary>
-        /// Retrieves the WorkoutDownloadEnabled field</summary>
-        /// <returns>Returns nullable Bool enum representing the WorkoutDownloadEnabled field</returns>
-        public Bool? GetWorkoutDownloadEnabled()
-        {
-            object obj = GetFieldValue(9, 0, Fit.SubfieldIndexMainField);
-            Bool? value = obj == null ? (Bool?)null : (Bool)obj;
-            return value;
-        }
+		///<summary>
+		/// Retrieves the WorkoutDownloadEnabled field</summary>
+		/// <returns>Returns nullable Bool enum representing the WorkoutDownloadEnabled field</returns>
+		public Bool? WorkoutDownloadEnabled
+		{
+			get
+			{
+				object obj = GetFieldValue(9, 0, Fit.SubfieldIndexMainField);
+				Bool? value = obj == null ? (Bool?)null : (Bool)obj;
+				return value;
+			}
+			set
+			{
+				SetFieldValue(9, 0, value, Fit.SubfieldIndexMainField);
+			}
+		}
 
-        /// <summary>
-        /// Set WorkoutDownloadEnabled field</summary>
-        /// <param name="workoutDownloadEnabled_">Nullable field value to be set</param>
-        public void SetWorkoutDownloadEnabled(Bool? workoutDownloadEnabled_)
-        {
-            SetFieldValue(9, 0, workoutDownloadEnabled_, Fit.SubfieldIndexMainField);
-        }
-        
-        ///<summary>
-        /// Retrieves the GpsEphemerisDownloadEnabled field</summary>
-        /// <returns>Returns nullable Bool enum representing the GpsEphemerisDownloadEnabled field</returns>
-        public Bool? GetGpsEphemerisDownloadEnabled()
-        {
-            object obj = GetFieldValue(10, 0, Fit.SubfieldIndexMainField);
-            Bool? value = obj == null ? (Bool?)null : (Bool)obj;
-            return value;
-        }
+		///<summary>
+		/// Retrieves the GpsEphemerisDownloadEnabled field</summary>
+		/// <returns>Returns nullable Bool enum representing the GpsEphemerisDownloadEnabled field</returns>
+		public Bool? GpsEphemerisDownloadEnabled
+		{
+			get
+			{
+				object obj = GetFieldValue(10, 0, Fit.SubfieldIndexMainField);
+				Bool? value = obj == null ? (Bool?)null : (Bool)obj;
+				return value;
+			}
+			set
+			{
+				SetFieldValue(10, 0, value, Fit.SubfieldIndexMainField);
+			}
+		}
 
-        /// <summary>
-        /// Set GpsEphemerisDownloadEnabled field</summary>
-        /// <param name="gpsEphemerisDownloadEnabled_">Nullable field value to be set</param>
-        public void SetGpsEphemerisDownloadEnabled(Bool? gpsEphemerisDownloadEnabled_)
-        {
-            SetFieldValue(10, 0, gpsEphemerisDownloadEnabled_, Fit.SubfieldIndexMainField);
-        }
-        
-        ///<summary>
-        /// Retrieves the IncidentDetectionEnabled field</summary>
-        /// <returns>Returns nullable Bool enum representing the IncidentDetectionEnabled field</returns>
-        public Bool? GetIncidentDetectionEnabled()
-        {
-            object obj = GetFieldValue(11, 0, Fit.SubfieldIndexMainField);
-            Bool? value = obj == null ? (Bool?)null : (Bool)obj;
-            return value;
-        }
+		///<summary>
+		/// Retrieves the IncidentDetectionEnabled field</summary>
+		/// <returns>Returns nullable Bool enum representing the IncidentDetectionEnabled field</returns>
+		public Bool? IncidentDetectionEnabled
+		{
+			get
+			{
+				object obj = GetFieldValue(11, 0, Fit.SubfieldIndexMainField);
+				Bool? value = obj == null ? (Bool?)null : (Bool)obj;
+				return value;
+			}
+			set
+			{
+				SetFieldValue(11, 0, value, Fit.SubfieldIndexMainField);
+			}
+		}
 
-        /// <summary>
-        /// Set IncidentDetectionEnabled field</summary>
-        /// <param name="incidentDetectionEnabled_">Nullable field value to be set</param>
-        public void SetIncidentDetectionEnabled(Bool? incidentDetectionEnabled_)
-        {
-            SetFieldValue(11, 0, incidentDetectionEnabled_, Fit.SubfieldIndexMainField);
-        }
-        
-        ///<summary>
-        /// Retrieves the GrouptrackEnabled field</summary>
-        /// <returns>Returns nullable Bool enum representing the GrouptrackEnabled field</returns>
-        public Bool? GetGrouptrackEnabled()
-        {
-            object obj = GetFieldValue(12, 0, Fit.SubfieldIndexMainField);
-            Bool? value = obj == null ? (Bool?)null : (Bool)obj;
-            return value;
-        }
+		///<summary>
+		/// Retrieves the GrouptrackEnabled field</summary>
+		/// <returns>Returns nullable Bool enum representing the GrouptrackEnabled field</returns>
+		public Bool? GrouptrackEnabled
+		{
+			get
+			{
+				object obj = GetFieldValue(12, 0, Fit.SubfieldIndexMainField);
+				Bool? value = obj == null ? (Bool?)null : (Bool)obj;
+				return value;
+			}
+			set
+			{
+				SetFieldValue(12, 0, value, Fit.SubfieldIndexMainField);
+			}
+		}
 
-        /// <summary>
-        /// Set GrouptrackEnabled field</summary>
-        /// <param name="grouptrackEnabled_">Nullable field value to be set</param>
-        public void SetGrouptrackEnabled(Bool? grouptrackEnabled_)
-        {
-            SetFieldValue(12, 0, grouptrackEnabled_, Fit.SubfieldIndexMainField);
-        }
-        
-        #endregion // Methods
-    } // Class
+		#endregion // Methods
+	} // Class
 } // namespace

--- a/Dynastream/Fit/Profile/Mesgs/CourseMesg.cs
+++ b/Dynastream/Fit/Profile/Mesgs/CourseMesg.cs
@@ -21,134 +21,129 @@ using System.Linq;
 
 namespace Dynastream.Fit
 {
-    /// <summary>
-    /// Implements the Course profile message.
-    /// </summary>
-    public class CourseMesg : Mesg
-    {
-        #region Fields
-        #endregion
+	/// <summary>
+	/// Implements the Course profile message.
+	/// </summary>
+	public class CourseMesg : Mesg
+	{
+		#region Fields
+		#endregion
 
-        /// <summary>
-        /// Field Numbers for <see cref="CourseMesg"/>
-        /// </summary>
-        public sealed class FieldDefNum
-        {
-            public const byte Sport = 4;
-            public const byte Name = 5;
-            public const byte Capabilities = 6;
-            public const byte SubSport = 7;
-            public const byte Invalid = Fit.FieldNumInvalid;
-        }
+		/// <summary>
+		/// Field Numbers for <see cref="CourseMesg"/>
+		/// </summary>
+		public sealed class FieldDefNum
+		{
+			public const byte Sport = 4;
+			public const byte Name = 5;
+			public const byte Capabilities = 6;
+			public const byte SubSport = 7;
+			public const byte Invalid = Fit.FieldNumInvalid;
+		}
 
-        #region Constructors
-        public CourseMesg() : base(Profile.GetMesg(MesgNum.Course))
-        {
-        }
+		#region Constructors
+		public CourseMesg() : base(Profile.GetMesg(MesgNum.Course))
+		{
+		}
 
-        public CourseMesg(Mesg mesg) : base(mesg)
-        {
-        }
-        #endregion // Constructors
+		public CourseMesg(Mesg mesg) : base(mesg)
+		{
+		}
+		#endregion // Constructors
 
-        #region Methods
-        ///<summary>
-        /// Retrieves the Sport field</summary>
-        /// <returns>Returns nullable Sport enum representing the Sport field</returns>
-        public Sport? GetSport()
-        {
-            object obj = GetFieldValue(4, 0, Fit.SubfieldIndexMainField);
-            Sport? value = obj == null ? (Sport?)null : (Sport)obj;
-            return value;
-        }
+		#region Methods
+		///<summary>
+		/// Retrieves the Sport field</summary>
+		/// <returns>Returns nullable Sport enum representing the Sport field</returns>
+		public Sport? Sport
+		{
+			get
+			{
+				object obj = GetFieldValue(4, 0, Fit.SubfieldIndexMainField);
+				Sport? value = obj == null ? (Sport?)null : (Sport)obj;
+				return value;
+			}
+			set
+			{
+				SetFieldValue(4, 0, value, Fit.SubfieldIndexMainField);
+			}
+		}
 
-        /// <summary>
-        /// Set Sport field</summary>
-        /// <param name="sport_">Nullable field value to be set</param>
-        public void SetSport(Sport? sport_)
-        {
-            SetFieldValue(4, 0, sport_, Fit.SubfieldIndexMainField);
-        }
-        
-        ///<summary>
-        /// Retrieves the Name field</summary>
-        /// <returns>Returns byte[] representing the Name field</returns>
-        public byte[] GetName()
-        {
-            byte[] data = (byte[])GetFieldValue(5, 0, Fit.SubfieldIndexMainField);
-            return data.Take(data.Length - 1).ToArray();
-        }
+		///<summary>
+		/// Retrieves the Name field</summary>
+		/// <returns>Returns byte[] representing the Name field</returns>
+		public byte[] Name
+		{
+			get
+			{
+				byte[] data = (byte[])GetFieldValue(5, 0, Fit.SubfieldIndexMainField);
+				return data.Take(data.Length - 1).ToArray();
+			}
+			set
+			{
+				SetFieldValue(5, 0, value, Fit.SubfieldIndexMainField);
+			}
+		}
 
-        ///<summary>
-        /// Retrieves the Name field</summary>
-        /// <returns>Returns String representing the Name field</returns>
-        public String GetNameAsString()
-        {
-            byte[] data = (byte[])GetFieldValue(5, 0, Fit.SubfieldIndexMainField);
-            return data != null ? Encoding.UTF8.GetString(data, 0, data.Length - 1) : null;
-        }
+		///<summary>
+		/// Retrieves the Name field</summary>
+		/// <returns>Returns String representing the Name field</returns>
+		public String GetNameAsString()
+		{
+			byte[] data = (byte[])GetFieldValue(5, 0, Fit.SubfieldIndexMainField);
+			return data != null ? Encoding.UTF8.GetString(data, 0, data.Length - 1) : null;
+		}
 
-        ///<summary>
-        /// Set Name field</summary>
-        /// <param name="name_"> field value to be set</param>
-        public void SetName(String name_)
-        {
-            byte[] data = Encoding.UTF8.GetBytes(name_);
-            byte[] zdata = new byte[data.Length + 1];
-            data.CopyTo(zdata, 0);
-            SetFieldValue(5, 0, zdata, Fit.SubfieldIndexMainField);
-        }
+		///<summary>
+		/// Set Name field</summary>
+		/// <param name="name_"> field value to be set</param>
+		public void SetName(String name_)
+		{
+			byte[] data = Encoding.UTF8.GetBytes(name_);
+			byte[] zdata = new byte[data.Length + 1];
+			data.CopyTo(zdata, 0);
+			SetFieldValue(5, 0, zdata, Fit.SubfieldIndexMainField);
+		}
 
-        
-        /// <summary>
-        /// Set Name field</summary>
-        /// <param name="name_">field value to be set</param>
-        public void SetName(byte[] name_)
-        {
-            SetFieldValue(5, 0, name_, Fit.SubfieldIndexMainField);
-        }
-        
-        ///<summary>
-        /// Retrieves the Capabilities field</summary>
-        /// <returns>Returns nullable uint representing the Capabilities field</returns>
-        public uint? GetCapabilities()
-        {
-            Object val = GetFieldValue(6, 0, Fit.SubfieldIndexMainField);
-            if(val == null)
-            {
-                return null;
-            }
+		///<summary>
+		/// Retrieves the Capabilities field</summary>
+		/// <returns>Returns nullable uint representing the Capabilities field</returns>
+		public uint? Capabilities
+		{
+			get
+			{
+				Object val = GetFieldValue(6, 0, Fit.SubfieldIndexMainField);
+				if (val == null)
+				{
+					return null;
+				}
 
-            return (Convert.ToUInt32(val));
-            
-        }
+				return (Convert.ToUInt32(val));
 
-        /// <summary>
-        /// Set Capabilities field</summary>
-        /// <param name="capabilities_">Nullable field value to be set</param>
-        public void SetCapabilities(uint? capabilities_)
-        {
-            SetFieldValue(6, 0, capabilities_, Fit.SubfieldIndexMainField);
-        }
-        
-        ///<summary>
-        /// Retrieves the SubSport field</summary>
-        /// <returns>Returns nullable SubSport enum representing the SubSport field</returns>
-        public SubSport? GetSubSport()
-        {
-            object obj = GetFieldValue(7, 0, Fit.SubfieldIndexMainField);
-            SubSport? value = obj == null ? (SubSport?)null : (SubSport)obj;
-            return value;
-        }
+			}
+			set
+			{
+				SetFieldValue(6, 0, value, Fit.SubfieldIndexMainField);
+			}
+		}
 
-        /// <summary>
-        /// Set SubSport field</summary>
-        /// <param name="subSport_">Nullable field value to be set</param>
-        public void SetSubSport(SubSport? subSport_)
-        {
-            SetFieldValue(7, 0, subSport_, Fit.SubfieldIndexMainField);
-        }
-        
-        #endregion // Methods
-    } // Class
+		///<summary>
+		/// Retrieves the SubSport field</summary>
+		/// <returns>Returns nullable SubSport enum representing the SubSport field</returns>
+		public SubSport? SubSport
+		{
+			get
+			{
+				object obj = GetFieldValue(7, 0, Fit.SubfieldIndexMainField);
+				SubSport? value = obj == null ? (SubSport?)null : (SubSport)obj;
+				return value;
+			}
+			set
+			{
+				SetFieldValue(7, 0, value, Fit.SubfieldIndexMainField);
+			}
+		}
+
+		#endregion // Methods
+	} // Class
 } // namespace

--- a/Dynastream/Fit/Profile/Mesgs/CoursePointMesg.cs
+++ b/Dynastream/Fit/Profile/Mesgs/CoursePointMesg.cs
@@ -21,236 +21,224 @@ using System.Linq;
 
 namespace Dynastream.Fit
 {
-    /// <summary>
-    /// Implements the CoursePoint profile message.
-    /// </summary>
-    public class CoursePointMesg : Mesg
-    {
-        #region Fields
-        #endregion
+	/// <summary>
+	/// Implements the CoursePoint profile message.
+	/// </summary>
+	public class CoursePointMesg : Mesg
+	{
+		#region Fields
+		#endregion
 
-        /// <summary>
-        /// Field Numbers for <see cref="CoursePointMesg"/>
-        /// </summary>
-        public sealed class FieldDefNum
-        {
-            public const byte MessageIndex = 254;
-            public const byte Timestamp = 1;
-            public const byte PositionLat = 2;
-            public const byte PositionLong = 3;
-            public const byte Distance = 4;
-            public const byte Type = 5;
-            public const byte Name = 6;
-            public const byte Favorite = 8;
-            public const byte Invalid = Fit.FieldNumInvalid;
-        }
+		/// <summary>
+		/// Field Numbers for <see cref="CoursePointMesg"/>
+		/// </summary>
+		public sealed class FieldDefNum
+		{
+			public const byte MessageIndex = 254;
+			public const byte Timestamp = 1;
+			public const byte PositionLat = 2;
+			public const byte PositionLong = 3;
+			public const byte Distance = 4;
+			public const byte Type = 5;
+			public const byte Name = 6;
+			public const byte Favorite = 8;
+			public const byte Invalid = Fit.FieldNumInvalid;
+		}
 
-        #region Constructors
-        public CoursePointMesg() : base(Profile.GetMesg(MesgNum.CoursePoint))
-        {
-        }
+		#region Constructors
+		public CoursePointMesg() : base(Profile.GetMesg(MesgNum.CoursePoint))
+		{
+		}
 
-        public CoursePointMesg(Mesg mesg) : base(mesg)
-        {
-        }
-        #endregion // Constructors
+		public CoursePointMesg(Mesg mesg) : base(mesg)
+		{
+		}
+		#endregion // Constructors
 
-        #region Methods
-        ///<summary>
-        /// Retrieves the MessageIndex field</summary>
-        /// <returns>Returns nullable ushort representing the MessageIndex field</returns>
-        public ushort? GetMessageIndex()
-        {
-            Object val = GetFieldValue(254, 0, Fit.SubfieldIndexMainField);
-            if(val == null)
-            {
-                return null;
-            }
+		#region Methods
+		///<summary>
+		/// Retrieves the MessageIndex field</summary>
+		/// <returns>Returns nullable ushort representing the MessageIndex field</returns>
+		public ushort? MessageIndex
+		{
+			get
+			{
+				Object val = GetFieldValue(254, 0, Fit.SubfieldIndexMainField);
+				if (val == null)
+				{
+					return null;
+				}
 
-            return (Convert.ToUInt16(val));
-            
-        }
+				return (Convert.ToUInt16(val));
 
-        /// <summary>
-        /// Set MessageIndex field</summary>
-        /// <param name="messageIndex_">Nullable field value to be set</param>
-        public void SetMessageIndex(ushort? messageIndex_)
-        {
-            SetFieldValue(254, 0, messageIndex_, Fit.SubfieldIndexMainField);
-        }
-        
-        ///<summary>
-        /// Retrieves the Timestamp field</summary>
-        /// <returns>Returns DateTime representing the Timestamp field</returns>
-        public DateTime GetTimestamp()
-        {
-            Object val = GetFieldValue(1, 0, Fit.SubfieldIndexMainField);
-            if(val == null)
-            {
-                return null;
-            }
+			}
+			set
+			{
+				SetFieldValue(254, 0, value, Fit.SubfieldIndexMainField);
+			}
+		}
 
-            return TimestampToDateTime(Convert.ToUInt32(val));
-            
-        }
+		///<summary>
+		/// Retrieves the Timestamp field</summary>
+		/// <returns>Returns DateTime representing the Timestamp field</returns>
+		public DateTime Timestamp
+		{
+			get
+			{
+				Object val = GetFieldValue(1, 0, Fit.SubfieldIndexMainField);
+				if (val == null)
+				{
+					return null;
+				}
 
-        /// <summary>
-        /// Set Timestamp field</summary>
-        /// <param name="timestamp_">Nullable field value to be set</param>
-        public void SetTimestamp(DateTime timestamp_)
-        {
-            SetFieldValue(1, 0, timestamp_.GetTimeStamp(), Fit.SubfieldIndexMainField);
-        }
-        
-        ///<summary>
-        /// Retrieves the PositionLat field
-        /// Units: semicircles</summary>
-        /// <returns>Returns nullable int representing the PositionLat field</returns>
-        public int? GetPositionLat()
-        {
-            Object val = GetFieldValue(2, 0, Fit.SubfieldIndexMainField);
-            if(val == null)
-            {
-                return null;
-            }
+				return TimestampToDateTime(Convert.ToUInt32(val));
 
-            return (Convert.ToInt32(val));
-            
-        }
+			}
+			set
+			{
+				SetFieldValue(1, 0, value.GetTimeStamp(), Fit.SubfieldIndexMainField);
+			}
+		}
 
-        /// <summary>
-        /// Set PositionLat field
-        /// Units: semicircles</summary>
-        /// <param name="positionLat_">Nullable field value to be set</param>
-        public void SetPositionLat(int? positionLat_)
-        {
-            SetFieldValue(2, 0, positionLat_, Fit.SubfieldIndexMainField);
-        }
-        
-        ///<summary>
-        /// Retrieves the PositionLong field
-        /// Units: semicircles</summary>
-        /// <returns>Returns nullable int representing the PositionLong field</returns>
-        public int? GetPositionLong()
-        {
-            Object val = GetFieldValue(3, 0, Fit.SubfieldIndexMainField);
-            if(val == null)
-            {
-                return null;
-            }
+		///<summary>
+		/// Retrieves the PositionLat field
+		/// Units: semicircles</summary>
+		/// <returns>Returns nullable int representing the PositionLat field</returns>
+		public int? PositionLat
+		{
+			get
+			{
+				Object val = GetFieldValue(2, 0, Fit.SubfieldIndexMainField);
+				if (val == null)
+				{
+					return null;
+				}
 
-            return (Convert.ToInt32(val));
-            
-        }
+				return (Convert.ToInt32(val));
 
-        /// <summary>
-        /// Set PositionLong field
-        /// Units: semicircles</summary>
-        /// <param name="positionLong_">Nullable field value to be set</param>
-        public void SetPositionLong(int? positionLong_)
-        {
-            SetFieldValue(3, 0, positionLong_, Fit.SubfieldIndexMainField);
-        }
-        
-        ///<summary>
-        /// Retrieves the Distance field
-        /// Units: m</summary>
-        /// <returns>Returns nullable float representing the Distance field</returns>
-        public float? GetDistance()
-        {
-            Object val = GetFieldValue(4, 0, Fit.SubfieldIndexMainField);
-            if(val == null)
-            {
-                return null;
-            }
+			}
+			set
+			{
+				SetFieldValue(2, 0, value, Fit.SubfieldIndexMainField);
+			}
+		}
 
-            return (Convert.ToSingle(val));
-            
-        }
+		///<summary>
+		/// Retrieves the PositionLong field
+		/// Units: semicircles</summary>
+		/// <returns>Returns nullable int representing the PositionLong field</returns>
+		public int? PositionLong
+		{
+			get
+			{
+				Object val = GetFieldValue(3, 0, Fit.SubfieldIndexMainField);
+				if (val == null)
+				{
+					return null;
+				}
 
-        /// <summary>
-        /// Set Distance field
-        /// Units: m</summary>
-        /// <param name="distance_">Nullable field value to be set</param>
-        public void SetDistance(float? distance_)
-        {
-            SetFieldValue(4, 0, distance_, Fit.SubfieldIndexMainField);
-        }
-        
-        ///<summary>
-        /// Retrieves the Type field</summary>
-        /// <returns>Returns nullable CoursePoint enum representing the Type field</returns>
-        new public CoursePoint? GetType()
-        {
-            object obj = GetFieldValue(5, 0, Fit.SubfieldIndexMainField);
-            CoursePoint? value = obj == null ? (CoursePoint?)null : (CoursePoint)obj;
-            return value;
-        }
+				return (Convert.ToInt32(val));
 
-        /// <summary>
-        /// Set Type field</summary>
-        /// <param name="type_">Nullable field value to be set</param>
-        public void SetType(CoursePoint? type_)
-        {
-            SetFieldValue(5, 0, type_, Fit.SubfieldIndexMainField);
-        }
-        
-        ///<summary>
-        /// Retrieves the Name field</summary>
-        /// <returns>Returns byte[] representing the Name field</returns>
-        public byte[] GetName()
-        {
-            byte[] data = (byte[])GetFieldValue(6, 0, Fit.SubfieldIndexMainField);
-            return data.Take(data.Length - 1).ToArray();
-        }
+			}
+			set
+			{
+				SetFieldValue(3, 0, value, Fit.SubfieldIndexMainField);
+			}
+		}
 
-        ///<summary>
-        /// Retrieves the Name field</summary>
-        /// <returns>Returns String representing the Name field</returns>
-        public String GetNameAsString()
-        {
-            byte[] data = (byte[])GetFieldValue(6, 0, Fit.SubfieldIndexMainField);
-            return data != null ? Encoding.UTF8.GetString(data, 0, data.Length - 1) : null;
-        }
+		///<summary>
+		/// Retrieves the Distance field
+		/// Units: m</summary>
+		/// <returns>Returns nullable float representing the Distance field</returns>
+		public float? Distance
+		{
+			get
+			{
+				Object val = GetFieldValue(4, 0, Fit.SubfieldIndexMainField);
+				if (val == null)
+				{
+					return null;
+				}
 
-        ///<summary>
-        /// Set Name field</summary>
-        /// <param name="name_"> field value to be set</param>
-        public void SetName(String name_)
-        {
-            byte[] data = Encoding.UTF8.GetBytes(name_);
-            byte[] zdata = new byte[data.Length + 1];
-            data.CopyTo(zdata, 0);
-            SetFieldValue(6, 0, zdata, Fit.SubfieldIndexMainField);
-        }
+				return (Convert.ToSingle(val));
 
-        
-        /// <summary>
-        /// Set Name field</summary>
-        /// <param name="name_">field value to be set</param>
-        public void SetName(byte[] name_)
-        {
-            SetFieldValue(6, 0, name_, Fit.SubfieldIndexMainField);
-        }
-        
-        ///<summary>
-        /// Retrieves the Favorite field</summary>
-        /// <returns>Returns nullable Bool enum representing the Favorite field</returns>
-        public Bool? GetFavorite()
-        {
-            object obj = GetFieldValue(8, 0, Fit.SubfieldIndexMainField);
-            Bool? value = obj == null ? (Bool?)null : (Bool)obj;
-            return value;
-        }
+			}
+			set
+			{
+				SetFieldValue(4, 0, value, Fit.SubfieldIndexMainField);
+			}
+		}
 
-        /// <summary>
-        /// Set Favorite field</summary>
-        /// <param name="favorite_">Nullable field value to be set</param>
-        public void SetFavorite(Bool? favorite_)
-        {
-            SetFieldValue(8, 0, favorite_, Fit.SubfieldIndexMainField);
-        }
-        
-        #endregion // Methods
-    } // Class
+		///<summary>
+		/// Retrieves the Type field</summary>
+		/// <returns>Returns nullable CoursePoint enum representing the Type field</returns>
+		public CoursePoint? Type
+		{
+			get
+			{
+				object obj = GetFieldValue(5, 0, Fit.SubfieldIndexMainField);
+				CoursePoint? value = obj == null ? (CoursePoint?)null : (CoursePoint)obj;
+				return value;
+			}
+			set
+			{
+				SetFieldValue(5, 0, value, Fit.SubfieldIndexMainField);
+			}
+		}
+
+		///<summary>
+		/// Retrieves the Name field</summary>
+		/// <returns>Returns byte[] representing the Name field</returns>
+		public byte[] Name
+		{
+			get
+			{
+				byte[] data = (byte[])GetFieldValue(6, 0, Fit.SubfieldIndexMainField);
+				return data.Take(data.Length - 1).ToArray();
+			}
+			set
+			{
+				SetFieldValue(6, 0, value, Fit.SubfieldIndexMainField);
+			}
+		}
+
+		///<summary>
+		/// Retrieves the Name field</summary>
+		/// <returns>Returns String representing the Name field</returns>
+		public String GetNameAsString()
+		{
+			byte[] data = (byte[])GetFieldValue(6, 0, Fit.SubfieldIndexMainField);
+			return data != null ? Encoding.UTF8.GetString(data, 0, data.Length - 1) : null;
+		}
+
+		///<summary>
+		/// Set Name field</summary>
+		/// <param name="name_"> field value to be set</param>
+		public void SetName(String name_)
+		{
+			byte[] data = Encoding.UTF8.GetBytes(name_);
+			byte[] zdata = new byte[data.Length + 1];
+			data.CopyTo(zdata, 0);
+			SetFieldValue(6, 0, zdata, Fit.SubfieldIndexMainField);
+		}
+
+		///<summary>
+		/// Retrieves the Favorite field</summary>
+		/// <returns>Returns nullable Bool enum representing the Favorite field</returns>
+		public Bool? Favorite
+		{
+			get
+			{
+				object obj = GetFieldValue(8, 0, Fit.SubfieldIndexMainField);
+				Bool? value = obj == null ? (Bool?)null : (Bool)obj;
+				return value;
+			}
+			set
+			{
+				SetFieldValue(8, 0, value, Fit.SubfieldIndexMainField);
+			}
+		}
+
+		#endregion // Methods
+	} // Class
 } // namespace

--- a/Dynastream/Fit/Profile/Mesgs/DeveloperDataIdMesg.cs
+++ b/Dynastream/Fit/Profile/Mesgs/DeveloperDataIdMesg.cs
@@ -21,177 +21,174 @@ using System.Linq;
 
 namespace Dynastream.Fit
 {
-    /// <summary>
-    /// Implements the DeveloperDataId profile message.
-    /// </summary>
-    public class DeveloperDataIdMesg : Mesg
-    {
-        #region Fields
-        #endregion
+	/// <summary>
+	/// Implements the DeveloperDataId profile message.
+	/// </summary>
+	public class DeveloperDataIdMesg : Mesg
+	{
+		#region Fields
+		#endregion
 
-        /// <summary>
-        /// Field Numbers for <see cref="DeveloperDataIdMesg"/>
-        /// </summary>
-        public sealed class FieldDefNum
-        {
-            public const byte DeveloperId = 0;
-            public const byte ApplicationId = 1;
-            public const byte ManufacturerId = 2;
-            public const byte DeveloperDataIndex = 3;
-            public const byte ApplicationVersion = 4;
-            public const byte Invalid = Fit.FieldNumInvalid;
-        }
+		/// <summary>
+		/// Field Numbers for <see cref="DeveloperDataIdMesg"/>
+		/// </summary>
+		public sealed class FieldDefNum
+		{
+			public const byte DeveloperId = 0;
+			public const byte ApplicationId = 1;
+			public const byte ManufacturerId = 2;
+			public const byte DeveloperDataIndex = 3;
+			public const byte ApplicationVersion = 4;
+			public const byte Invalid = Fit.FieldNumInvalid;
+		}
 
-        #region Constructors
-        public DeveloperDataIdMesg() : base(Profile.GetMesg(MesgNum.DeveloperDataId))
-        {
-        }
+		#region Constructors
+		public DeveloperDataIdMesg() : base(Profile.GetMesg(MesgNum.DeveloperDataId))
+		{
+		}
 
-        public DeveloperDataIdMesg(Mesg mesg) : base(mesg)
-        {
-        }
-        #endregion // Constructors
+		public DeveloperDataIdMesg(Mesg mesg) : base(mesg)
+		{
+		}
+		#endregion // Constructors
 
-        #region Methods
-        
-        /// <summary>
-        ///
-        /// </summary>
-        /// <returns>returns number of elements in field DeveloperId</returns>
-        public int GetNumDeveloperId()
-        {
-            return GetNumFieldValues(0, Fit.SubfieldIndexMainField);
-        }
+		#region Methods
 
-        ///<summary>
-        /// Retrieves the DeveloperId field</summary>
-        /// <param name="index">0 based index of DeveloperId element to retrieve</param>
-        /// <returns>Returns nullable byte representing the DeveloperId field</returns>
-        public byte? GetDeveloperId(int index)
-        {
-            Object val = GetFieldValue(0, index, Fit.SubfieldIndexMainField);
-            if(val == null)
-            {
-                return null;
-            }
+		/// <summary>
+		///
+		/// </summary>
+		/// <returns>returns number of elements in field DeveloperId</returns>
+		public int GetNumDeveloperId()
+		{
+			return GetNumFieldValues(0, Fit.SubfieldIndexMainField);
+		}
 
-            return (Convert.ToByte(val));
-            
-        }
+		///<summary>
+		/// Retrieves the DeveloperId field</summary>
+		/// <param name="index">0 based index of DeveloperId element to retrieve</param>
+		/// <returns>Returns nullable byte representing the DeveloperId field</returns>
+		public byte? GetDeveloperId(int index)
+		{
+			Object val = GetFieldValue(0, index, Fit.SubfieldIndexMainField);
+			if (val == null)
+			{
+				return null;
+			}
 
-        /// <summary>
-        /// Set DeveloperId field</summary>
-        /// <param name="index">0 based index of developer_id</param>
-        /// <param name="developerId_">Nullable field value to be set</param>
-        public void SetDeveloperId(int index, byte? developerId_)
-        {
-            SetFieldValue(0, index, developerId_, Fit.SubfieldIndexMainField);
-        }
-        
-        
-        /// <summary>
-        ///
-        /// </summary>
-        /// <returns>returns number of elements in field ApplicationId</returns>
-        public int GetNumApplicationId()
-        {
-            return GetNumFieldValues(1, Fit.SubfieldIndexMainField);
-        }
+			return (Convert.ToByte(val));
 
-        ///<summary>
-        /// Retrieves the ApplicationId field</summary>
-        /// <param name="index">0 based index of ApplicationId element to retrieve</param>
-        /// <returns>Returns nullable byte representing the ApplicationId field</returns>
-        public byte? GetApplicationId(int index)
-        {
-            Object val = GetFieldValue(1, index, Fit.SubfieldIndexMainField);
-            if(val == null)
-            {
-                return null;
-            }
+		}
 
-            return (Convert.ToByte(val));
-            
-        }
+		/// <summary>
+		/// Set DeveloperId field</summary>
+		/// <param name="index">0 based index of developer_id</param>
+		/// <param name="developerId_">Nullable field value to be set</param>
+		public void SetDeveloperId(int index, byte? developerId_)
+		{
+			SetFieldValue(0, index, developerId_, Fit.SubfieldIndexMainField);
+		}
 
-        /// <summary>
-        /// Set ApplicationId field</summary>
-        /// <param name="index">0 based index of application_id</param>
-        /// <param name="applicationId_">Nullable field value to be set</param>
-        public void SetApplicationId(int index, byte? applicationId_)
-        {
-            SetFieldValue(1, index, applicationId_, Fit.SubfieldIndexMainField);
-        }
-        
-        ///<summary>
-        /// Retrieves the ManufacturerId field</summary>
-        /// <returns>Returns nullable ushort representing the ManufacturerId field</returns>
-        public ushort? GetManufacturerId()
-        {
-            Object val = GetFieldValue(2, 0, Fit.SubfieldIndexMainField);
-            if(val == null)
-            {
-                return null;
-            }
 
-            return (Convert.ToUInt16(val));
-            
-        }
+		/// <summary>
+		///
+		/// </summary>
+		/// <returns>returns number of elements in field ApplicationId</returns>
+		public int GetNumApplicationId()
+		{
+			return GetNumFieldValues(1, Fit.SubfieldIndexMainField);
+		}
 
-        /// <summary>
-        /// Set ManufacturerId field</summary>
-        /// <param name="manufacturerId_">Nullable field value to be set</param>
-        public void SetManufacturerId(ushort? manufacturerId_)
-        {
-            SetFieldValue(2, 0, manufacturerId_, Fit.SubfieldIndexMainField);
-        }
-        
-        ///<summary>
-        /// Retrieves the DeveloperDataIndex field</summary>
-        /// <returns>Returns nullable byte representing the DeveloperDataIndex field</returns>
-        public byte? GetDeveloperDataIndex()
-        {
-            Object val = GetFieldValue(3, 0, Fit.SubfieldIndexMainField);
-            if(val == null)
-            {
-                return null;
-            }
+		///<summary>
+		/// Retrieves the ApplicationId field</summary>
+		/// <param name="index">0 based index of ApplicationId element to retrieve</param>
+		/// <returns>Returns nullable byte representing the ApplicationId field</returns>
+		public byte? GetApplicationId(int index)
+		{
+			Object val = GetFieldValue(1, index, Fit.SubfieldIndexMainField);
+			if (val == null)
+			{
+				return null;
+			}
 
-            return (Convert.ToByte(val));
-            
-        }
+			return (Convert.ToByte(val));
 
-        /// <summary>
-        /// Set DeveloperDataIndex field</summary>
-        /// <param name="developerDataIndex_">Nullable field value to be set</param>
-        public void SetDeveloperDataIndex(byte? developerDataIndex_)
-        {
-            SetFieldValue(3, 0, developerDataIndex_, Fit.SubfieldIndexMainField);
-        }
-        
-        ///<summary>
-        /// Retrieves the ApplicationVersion field</summary>
-        /// <returns>Returns nullable uint representing the ApplicationVersion field</returns>
-        public uint? GetApplicationVersion()
-        {
-            Object val = GetFieldValue(4, 0, Fit.SubfieldIndexMainField);
-            if(val == null)
-            {
-                return null;
-            }
+		}
 
-            return (Convert.ToUInt32(val));
-            
-        }
+		/// <summary>
+		/// Set ApplicationId field</summary>
+		/// <param name="index">0 based index of application_id</param>
+		/// <param name="applicationId_">Nullable field value to be set</param>
+		public void SetApplicationId(int index, byte? applicationId_)
+		{
+			SetFieldValue(1, index, applicationId_, Fit.SubfieldIndexMainField);
+		}
 
-        /// <summary>
-        /// Set ApplicationVersion field</summary>
-        /// <param name="applicationVersion_">Nullable field value to be set</param>
-        public void SetApplicationVersion(uint? applicationVersion_)
-        {
-            SetFieldValue(4, 0, applicationVersion_, Fit.SubfieldIndexMainField);
-        }
-        
-        #endregion // Methods
-    } // Class
+		///<summary>
+		/// Retrieves the ManufacturerId field</summary>
+		/// <returns>Returns nullable ushort representing the ManufacturerId field</returns>
+		public ushort? ManufacturerId
+		{
+			get
+			{
+				Object val = GetFieldValue(2, 0, Fit.SubfieldIndexMainField);
+				if (val == null)
+				{
+					return null;
+				}
+
+				return (Convert.ToUInt16(val));
+
+			}
+			set
+			{
+				SetFieldValue(2, 0, value, Fit.SubfieldIndexMainField);
+			}
+		}
+
+		///<summary>
+		/// Retrieves the DeveloperDataIndex field</summary>
+		/// <returns>Returns nullable byte representing the DeveloperDataIndex field</returns>
+		public byte? DeveloperDataIndex
+		{
+			get
+			{
+				Object val = GetFieldValue(3, 0, Fit.SubfieldIndexMainField);
+				if (val == null)
+				{
+					return null;
+				}
+
+				return (Convert.ToByte(val));
+
+			}
+			set
+			{
+				SetFieldValue(3, 0, value, Fit.SubfieldIndexMainField);
+			}
+		}
+
+		///<summary>
+		/// Retrieves the ApplicationVersion field</summary>
+		/// <returns>Returns nullable uint representing the ApplicationVersion field</returns>
+		public uint? ApplicationVersion
+		{
+			get
+			{
+				Object val = GetFieldValue(4, 0, Fit.SubfieldIndexMainField);
+				if (val == null)
+				{
+					return null;
+				}
+
+				return (Convert.ToUInt32(val));
+
+			}
+			set
+			{
+				SetFieldValue(4, 0, value, Fit.SubfieldIndexMainField);
+			}
+		}
+
+		#endregion // Methods
+	} // Class
 } // namespace

--- a/Dynastream/Fit/Profile/Mesgs/DeviceAuxBatteryInfoMesg.cs
+++ b/Dynastream/Fit/Profile/Mesgs/DeviceAuxBatteryInfoMesg.cs
@@ -21,155 +21,149 @@ using System.Linq;
 
 namespace Dynastream.Fit
 {
-    /// <summary>
-    /// Implements the DeviceAuxBatteryInfo profile message.
-    /// </summary>
-    public class DeviceAuxBatteryInfoMesg : Mesg
-    {
-        #region Fields
-        #endregion
+	/// <summary>
+	/// Implements the DeviceAuxBatteryInfo profile message.
+	/// </summary>
+	public class DeviceAuxBatteryInfoMesg : Mesg
+	{
+		#region Fields
+		#endregion
 
-        /// <summary>
-        /// Field Numbers for <see cref="DeviceAuxBatteryInfoMesg"/>
-        /// </summary>
-        public sealed class FieldDefNum
-        {
-            public const byte Timestamp = 253;
-            public const byte DeviceIndex = 0;
-            public const byte BatteryVoltage = 1;
-            public const byte BatteryStatus = 2;
-            public const byte BatteryIdentifier = 3;
-            public const byte Invalid = Fit.FieldNumInvalid;
-        }
+		/// <summary>
+		/// Field Numbers for <see cref="DeviceAuxBatteryInfoMesg"/>
+		/// </summary>
+		public sealed class FieldDefNum
+		{
+			public const byte Timestamp = 253;
+			public const byte DeviceIndex = 0;
+			public const byte BatteryVoltage = 1;
+			public const byte BatteryStatus = 2;
+			public const byte BatteryIdentifier = 3;
+			public const byte Invalid = Fit.FieldNumInvalid;
+		}
 
-        #region Constructors
-        public DeviceAuxBatteryInfoMesg() : base(Profile.GetMesg(MesgNum.DeviceAuxBatteryInfo))
-        {
-        }
+		#region Constructors
+		public DeviceAuxBatteryInfoMesg() : base(Profile.GetMesg(MesgNum.DeviceAuxBatteryInfo))
+		{
+		}
 
-        public DeviceAuxBatteryInfoMesg(Mesg mesg) : base(mesg)
-        {
-        }
-        #endregion // Constructors
+		public DeviceAuxBatteryInfoMesg(Mesg mesg) : base(mesg)
+		{
+		}
+		#endregion // Constructors
 
-        #region Methods
-        ///<summary>
-        /// Retrieves the Timestamp field</summary>
-        /// <returns>Returns DateTime representing the Timestamp field</returns>
-        public DateTime GetTimestamp()
-        {
-            Object val = GetFieldValue(253, 0, Fit.SubfieldIndexMainField);
-            if(val == null)
-            {
-                return null;
-            }
+		#region Methods
+		///<summary>
+		/// Retrieves the Timestamp field</summary>
+		/// <returns>Returns DateTime representing the Timestamp field</returns>
+		public DateTime Timestamp
+		{
+			get
+			{
+				Object val = GetFieldValue(253, 0, Fit.SubfieldIndexMainField);
+				if (val == null)
+				{
+					return null;
+				}
 
-            return TimestampToDateTime(Convert.ToUInt32(val));
-            
-        }
+				return TimestampToDateTime(Convert.ToUInt32(val));
 
-        /// <summary>
-        /// Set Timestamp field</summary>
-        /// <param name="timestamp_">Nullable field value to be set</param>
-        public void SetTimestamp(DateTime timestamp_)
-        {
-            SetFieldValue(253, 0, timestamp_.GetTimeStamp(), Fit.SubfieldIndexMainField);
-        }
-        
-        ///<summary>
-        /// Retrieves the DeviceIndex field</summary>
-        /// <returns>Returns nullable byte representing the DeviceIndex field</returns>
-        public byte? GetDeviceIndex()
-        {
-            Object val = GetFieldValue(0, 0, Fit.SubfieldIndexMainField);
-            if(val == null)
-            {
-                return null;
-            }
+			}
+			set
+			{
+				SetFieldValue(253, 0, value.GetTimeStamp(), Fit.SubfieldIndexMainField);
+			}
+		}
 
-            return (Convert.ToByte(val));
-            
-        }
+		///<summary>
+		/// Retrieves the DeviceIndex field</summary>
+		/// <returns>Returns nullable byte representing the DeviceIndex field</returns>
+		public byte? DeviceIndex
+		{
+			get
+			{
+				Object val = GetFieldValue(0, 0, Fit.SubfieldIndexMainField);
+				if (val == null)
+				{
+					return null;
+				}
 
-        /// <summary>
-        /// Set DeviceIndex field</summary>
-        /// <param name="deviceIndex_">Nullable field value to be set</param>
-        public void SetDeviceIndex(byte? deviceIndex_)
-        {
-            SetFieldValue(0, 0, deviceIndex_, Fit.SubfieldIndexMainField);
-        }
-        
-        ///<summary>
-        /// Retrieves the BatteryVoltage field
-        /// Units: V</summary>
-        /// <returns>Returns nullable float representing the BatteryVoltage field</returns>
-        public float? GetBatteryVoltage()
-        {
-            Object val = GetFieldValue(1, 0, Fit.SubfieldIndexMainField);
-            if(val == null)
-            {
-                return null;
-            }
+				return (Convert.ToByte(val));
 
-            return (Convert.ToSingle(val));
-            
-        }
+			}
+			set
+			{
+				SetFieldValue(0, 0, value, Fit.SubfieldIndexMainField);
+			}
+		}
 
-        /// <summary>
-        /// Set BatteryVoltage field
-        /// Units: V</summary>
-        /// <param name="batteryVoltage_">Nullable field value to be set</param>
-        public void SetBatteryVoltage(float? batteryVoltage_)
-        {
-            SetFieldValue(1, 0, batteryVoltage_, Fit.SubfieldIndexMainField);
-        }
-        
-        ///<summary>
-        /// Retrieves the BatteryStatus field</summary>
-        /// <returns>Returns nullable byte representing the BatteryStatus field</returns>
-        public byte? GetBatteryStatus()
-        {
-            Object val = GetFieldValue(2, 0, Fit.SubfieldIndexMainField);
-            if(val == null)
-            {
-                return null;
-            }
+		///<summary>
+		/// Retrieves the BatteryVoltage field
+		/// Units: V</summary>
+		/// <returns>Returns nullable float representing the BatteryVoltage field</returns>
+		public float? BatteryVoltage
+		{
+			get
+			{
+				Object val = GetFieldValue(1, 0, Fit.SubfieldIndexMainField);
+				if (val == null)
+				{
+					return null;
+				}
 
-            return (Convert.ToByte(val));
-            
-        }
+				return (Convert.ToSingle(val));
 
-        /// <summary>
-        /// Set BatteryStatus field</summary>
-        /// <param name="batteryStatus_">Nullable field value to be set</param>
-        public void SetBatteryStatus(byte? batteryStatus_)
-        {
-            SetFieldValue(2, 0, batteryStatus_, Fit.SubfieldIndexMainField);
-        }
-        
-        ///<summary>
-        /// Retrieves the BatteryIdentifier field</summary>
-        /// <returns>Returns nullable byte representing the BatteryIdentifier field</returns>
-        public byte? GetBatteryIdentifier()
-        {
-            Object val = GetFieldValue(3, 0, Fit.SubfieldIndexMainField);
-            if(val == null)
-            {
-                return null;
-            }
+			}
+			set
+			{
+				SetFieldValue(1, 0, value, Fit.SubfieldIndexMainField);
+			}
+		}
 
-            return (Convert.ToByte(val));
-            
-        }
+		///<summary>
+		/// Retrieves the BatteryStatus field</summary>
+		/// <returns>Returns nullable byte representing the BatteryStatus field</returns>
+		public byte? BatteryStatus
+		{
+			get
+			{
+				Object val = GetFieldValue(2, 0, Fit.SubfieldIndexMainField);
+				if (val == null)
+				{
+					return null;
+				}
 
-        /// <summary>
-        /// Set BatteryIdentifier field</summary>
-        /// <param name="batteryIdentifier_">Nullable field value to be set</param>
-        public void SetBatteryIdentifier(byte? batteryIdentifier_)
-        {
-            SetFieldValue(3, 0, batteryIdentifier_, Fit.SubfieldIndexMainField);
-        }
-        
-        #endregion // Methods
-    } // Class
+				return (Convert.ToByte(val));
+
+			}
+			set
+			{
+				SetFieldValue(2, 0, value, Fit.SubfieldIndexMainField);
+			}
+		}
+
+		///<summary>
+		/// Retrieves the BatteryIdentifier field</summary>
+		/// <returns>Returns nullable byte representing the BatteryIdentifier field</returns>
+		public byte? BatteryIdentifier
+		{
+			get
+			{
+				Object val = GetFieldValue(3, 0, Fit.SubfieldIndexMainField);
+				if (val == null)
+				{
+					return null;
+				}
+
+				return (Convert.ToByte(val));
+
+			}
+			set
+			{
+				SetFieldValue(3, 0, value, Fit.SubfieldIndexMainField);
+			}
+		}
+
+		#endregion // Methods
+	} // Class
 } // namespace

--- a/Dynastream/Fit/Profile/Mesgs/DeviceInfoMesg.cs
+++ b/Dynastream/Fit/Profile/Mesgs/DeviceInfoMesg.cs
@@ -21,686 +21,645 @@ using System.Linq;
 
 namespace Dynastream.Fit
 {
-    /// <summary>
-    /// Implements the DeviceInfo profile message.
-    /// </summary>
-    public class DeviceInfoMesg : Mesg
-    {
-        #region Fields
-        static class DeviceTypeSubfield
-        {
-            public static ushort BleDeviceType = 0;
-            public static ushort AntplusDeviceType = 1;
-            public static ushort AntDeviceType = 2;
-            public static ushort LocalDeviceType = 3;
-            public static ushort Subfields = 4;
-            public static ushort Active = Fit.SubfieldIndexActiveSubfield;
-            public static ushort MainField = Fit.SubfieldIndexMainField;
-        }
-        static class ProductSubfield
-        {
-            public static ushort FaveroProduct = 0;
-            public static ushort GarminProduct = 1;
-            public static ushort Subfields = 2;
-            public static ushort Active = Fit.SubfieldIndexActiveSubfield;
-            public static ushort MainField = Fit.SubfieldIndexMainField;
-        }
-        #endregion
+	/// <summary>
+	/// Implements the DeviceInfo profile message.
+	/// </summary>
+	public class DeviceInfoMesg : Mesg
+	{
+		#region Fields
+		static class DeviceTypeSubfield
+		{
+			public static ushort BleDeviceType = 0;
+			public static ushort AntplusDeviceType = 1;
+			public static ushort AntDeviceType = 2;
+			public static ushort LocalDeviceType = 3;
+			public static ushort Subfields = 4;
+			public static ushort Active = Fit.SubfieldIndexActiveSubfield;
+			public static ushort MainField = Fit.SubfieldIndexMainField;
+		}
+		static class ProductSubfield
+		{
+			public static ushort FaveroProduct = 0;
+			public static ushort GarminProduct = 1;
+			public static ushort Subfields = 2;
+			public static ushort Active = Fit.SubfieldIndexActiveSubfield;
+			public static ushort MainField = Fit.SubfieldIndexMainField;
+		}
+		#endregion
 
-        /// <summary>
-        /// Field Numbers for <see cref="DeviceInfoMesg"/>
-        /// </summary>
-        public sealed class FieldDefNum
-        {
-            public const byte Timestamp = 253;
-            public const byte DeviceIndex = 0;
-            public const byte DeviceType = 1;
-            public const byte Manufacturer = 2;
-            public const byte SerialNumber = 3;
-            public const byte Product = 4;
-            public const byte SoftwareVersion = 5;
-            public const byte HardwareVersion = 6;
-            public const byte CumOperatingTime = 7;
-            public const byte BatteryVoltage = 10;
-            public const byte BatteryStatus = 11;
-            public const byte SensorPosition = 18;
-            public const byte Descriptor = 19;
-            public const byte AntTransmissionType = 20;
-            public const byte AntDeviceNumber = 21;
-            public const byte AntNetwork = 22;
-            public const byte SourceType = 25;
-            public const byte ProductName = 27;
-            public const byte BatteryLevel = 32;
-            public const byte Invalid = Fit.FieldNumInvalid;
-        }
+		/// <summary>
+		/// Field Numbers for <see cref="DeviceInfoMesg"/>
+		/// </summary>
+		public sealed class FieldDefNum
+		{
+			public const byte Timestamp = 253;
+			public const byte DeviceIndex = 0;
+			public const byte DeviceType = 1;
+			public const byte Manufacturer = 2;
+			public const byte SerialNumber = 3;
+			public const byte Product = 4;
+			public const byte SoftwareVersion = 5;
+			public const byte HardwareVersion = 6;
+			public const byte CumOperatingTime = 7;
+			public const byte BatteryVoltage = 10;
+			public const byte BatteryStatus = 11;
+			public const byte SensorPosition = 18;
+			public const byte Descriptor = 19;
+			public const byte AntTransmissionType = 20;
+			public const byte AntDeviceNumber = 21;
+			public const byte AntNetwork = 22;
+			public const byte SourceType = 25;
+			public const byte ProductName = 27;
+			public const byte BatteryLevel = 32;
+			public const byte Invalid = Fit.FieldNumInvalid;
+		}
 
-        #region Constructors
-        public DeviceInfoMesg() : base(Profile.GetMesg(MesgNum.DeviceInfo))
-        {
-        }
+		#region Constructors
+		public DeviceInfoMesg() : base(Profile.GetMesg(MesgNum.DeviceInfo))
+		{
+		}
 
-        public DeviceInfoMesg(Mesg mesg) : base(mesg)
-        {
-        }
-        #endregion // Constructors
+		public DeviceInfoMesg(Mesg mesg) : base(mesg)
+		{
+		}
+		#endregion // Constructors
 
-        #region Methods
-        ///<summary>
-        /// Retrieves the Timestamp field
-        /// Units: s</summary>
-        /// <returns>Returns DateTime representing the Timestamp field</returns>
-        public DateTime GetTimestamp()
-        {
-            Object val = GetFieldValue(253, 0, Fit.SubfieldIndexMainField);
-            if(val == null)
-            {
-                return null;
-            }
+		#region Methods
+		///<summary>
+		/// Retrieves the Timestamp field
+		/// Units: s</summary>
+		/// <returns>Returns DateTime representing the Timestamp field</returns>
+		public DateTime Timestamp
+		{
+			get
+			{
+				Object val = GetFieldValue(253, 0, Fit.SubfieldIndexMainField);
+				if (val == null)
+				{
+					return null;
+				}
 
-            return TimestampToDateTime(Convert.ToUInt32(val));
-            
-        }
+				return TimestampToDateTime(Convert.ToUInt32(val));
 
-        /// <summary>
-        /// Set Timestamp field
-        /// Units: s</summary>
-        /// <param name="timestamp_">Nullable field value to be set</param>
-        public void SetTimestamp(DateTime timestamp_)
-        {
-            SetFieldValue(253, 0, timestamp_.GetTimeStamp(), Fit.SubfieldIndexMainField);
-        }
-        
-        ///<summary>
-        /// Retrieves the DeviceIndex field</summary>
-        /// <returns>Returns nullable byte representing the DeviceIndex field</returns>
-        public byte? GetDeviceIndex()
-        {
-            Object val = GetFieldValue(0, 0, Fit.SubfieldIndexMainField);
-            if(val == null)
-            {
-                return null;
-            }
+			}
+			set
+			{
+				SetFieldValue(253, 0, value.GetTimeStamp(), Fit.SubfieldIndexMainField);
+			}
+		}
 
-            return (Convert.ToByte(val));
-            
-        }
+		///<summary>
+		/// Retrieves the DeviceIndex field</summary>
+		/// <returns>Returns nullable byte representing the DeviceIndex field</returns>
+		public byte? DeviceIndex
+		{
+			get
+			{
+				Object val = GetFieldValue(0, 0, Fit.SubfieldIndexMainField);
+				if (val == null)
+				{
+					return null;
+				}
 
-        /// <summary>
-        /// Set DeviceIndex field</summary>
-        /// <param name="deviceIndex_">Nullable field value to be set</param>
-        public void SetDeviceIndex(byte? deviceIndex_)
-        {
-            SetFieldValue(0, 0, deviceIndex_, Fit.SubfieldIndexMainField);
-        }
-        
-        ///<summary>
-        /// Retrieves the DeviceType field</summary>
-        /// <returns>Returns nullable byte representing the DeviceType field</returns>
-        public byte? GetDeviceType()
-        {
-            Object val = GetFieldValue(1, 0, Fit.SubfieldIndexMainField);
-            if(val == null)
-            {
-                return null;
-            }
+				return (Convert.ToByte(val));
 
-            return (Convert.ToByte(val));
-            
-        }
+			}
+			set
+			{
+				SetFieldValue(0, 0, value, Fit.SubfieldIndexMainField);
+			}
+		}
 
-        /// <summary>
-        /// Set DeviceType field</summary>
-        /// <param name="deviceType_">Nullable field value to be set</param>
-        public void SetDeviceType(byte? deviceType_)
-        {
-            SetFieldValue(1, 0, deviceType_, Fit.SubfieldIndexMainField);
-        }
-        
+		///<summary>
+		/// Retrieves the DeviceType field</summary>
+		/// <returns>Returns nullable byte representing the DeviceType field</returns>
+		public byte? DeviceType
+		{
+			get
+			{
+				Object val = GetFieldValue(1, 0, Fit.SubfieldIndexMainField);
+				if (val == null)
+				{
+					return null;
+				}
 
-        /// <summary>
-        /// Retrieves the BleDeviceType subfield</summary>
-        /// <returns>Nullable byte representing the BleDeviceType subfield</returns>
-        public byte? GetBleDeviceType()
-        {
-            Object val = GetFieldValue(1, 0, DeviceTypeSubfield.BleDeviceType);
-            if(val == null)
-            {
-                return null;
-            }
+				return (Convert.ToByte(val));
 
-            return (Convert.ToByte(val));
-            
-        }
+			}
+			set
+			{
+				SetFieldValue(1, 0, value, Fit.SubfieldIndexMainField);
+			}
+		}
 
-        /// <summary>
-        ///
-        /// Set BleDeviceType subfield</summary>
-        /// <param name="bleDeviceType">Subfield value to be set</param>
-        public void SetBleDeviceType(byte? bleDeviceType)
-        {
-            SetFieldValue(1, 0, bleDeviceType, DeviceTypeSubfield.BleDeviceType);
-        }
 
-        /// <summary>
-        /// Retrieves the AntplusDeviceType subfield</summary>
-        /// <returns>Nullable byte representing the AntplusDeviceType subfield</returns>
-        public byte? GetAntplusDeviceType()
-        {
-            Object val = GetFieldValue(1, 0, DeviceTypeSubfield.AntplusDeviceType);
-            if(val == null)
-            {
-                return null;
-            }
+		/// <summary>
+		/// Retrieves the BleDeviceType subfield</summary>
+		/// <returns>Nullable byte representing the BleDeviceType subfield</returns>
+		public byte? BleDeviceType
+		{
+			get
+			{
+				Object val = GetFieldValue(1, 0, DeviceTypeSubfield.BleDeviceType);
+				if (val == null)
+				{
+					return null;
+				}
 
-            return (Convert.ToByte(val));
-            
-        }
+				return (Convert.ToByte(val));
 
-        /// <summary>
-        ///
-        /// Set AntplusDeviceType subfield</summary>
-        /// <param name="antplusDeviceType">Subfield value to be set</param>
-        public void SetAntplusDeviceType(byte? antplusDeviceType)
-        {
-            SetFieldValue(1, 0, antplusDeviceType, DeviceTypeSubfield.AntplusDeviceType);
-        }
+			}
+			set
+			{
+				SetFieldValue(1, 0, value, DeviceTypeSubfield.BleDeviceType);
+			}
+		}
 
-        /// <summary>
-        /// Retrieves the AntDeviceType subfield</summary>
-        /// <returns>Nullable byte representing the AntDeviceType subfield</returns>
-        public byte? GetAntDeviceType()
-        {
-            Object val = GetFieldValue(1, 0, DeviceTypeSubfield.AntDeviceType);
-            if(val == null)
-            {
-                return null;
-            }
+		/// <summary>
+		/// Retrieves the AntplusDeviceType subfield</summary>
+		/// <returns>Nullable byte representing the AntplusDeviceType subfield</returns>
+		public byte? AntplusDeviceType
+		{
+			get
+			{
+				Object val = GetFieldValue(1, 0, DeviceTypeSubfield.AntplusDeviceType);
+				if (val == null)
+				{
+					return null;
+				}
 
-            return (Convert.ToByte(val));
-            
-        }
+				return (Convert.ToByte(val));
 
-        /// <summary>
-        ///
-        /// Set AntDeviceType subfield</summary>
-        /// <param name="antDeviceType">Subfield value to be set</param>
-        public void SetAntDeviceType(byte? antDeviceType)
-        {
-            SetFieldValue(1, 0, antDeviceType, DeviceTypeSubfield.AntDeviceType);
-        }
+			}
+			set
+			{
+				SetFieldValue(1, 0, value, DeviceTypeSubfield.AntplusDeviceType);
+			}
+		}
 
-        /// <summary>
-        /// Retrieves the LocalDeviceType subfield</summary>
-        /// <returns>Nullable byte representing the LocalDeviceType subfield</returns>
-        public byte? GetLocalDeviceType()
-        {
-            Object val = GetFieldValue(1, 0, DeviceTypeSubfield.LocalDeviceType);
-            if(val == null)
-            {
-                return null;
-            }
+		/// <summary>
+		/// Retrieves the AntDeviceType subfield</summary>
+		/// <returns>Nullable byte representing the AntDeviceType subfield</returns>
+		public byte? AntDeviceType
+		{
+			get
+			{
+				Object val = GetFieldValue(1, 0, DeviceTypeSubfield.AntDeviceType);
+				if (val == null)
+				{
+					return null;
+				}
 
-            return (Convert.ToByte(val));
-            
-        }
+				return (Convert.ToByte(val));
 
-        /// <summary>
-        ///
-        /// Set LocalDeviceType subfield</summary>
-        /// <param name="localDeviceType">Subfield value to be set</param>
-        public void SetLocalDeviceType(byte? localDeviceType)
-        {
-            SetFieldValue(1, 0, localDeviceType, DeviceTypeSubfield.LocalDeviceType);
-        }
-        ///<summary>
-        /// Retrieves the Manufacturer field</summary>
-        /// <returns>Returns nullable ushort representing the Manufacturer field</returns>
-        public ushort? GetManufacturer()
-        {
-            Object val = GetFieldValue(2, 0, Fit.SubfieldIndexMainField);
-            if(val == null)
-            {
-                return null;
-            }
+			}
+			set
+			{
+				SetFieldValue(1, 0, value, DeviceTypeSubfield.AntDeviceType);
+			}
+		}
 
-            return (Convert.ToUInt16(val));
-            
-        }
+		/// <summary>
+		/// Retrieves the LocalDeviceType subfield</summary>
+		/// <returns>Nullable byte representing the LocalDeviceType subfield</returns>
+		public byte? LocalDeviceType
+		{
+			get
+			{
+				Object val = GetFieldValue(1, 0, DeviceTypeSubfield.LocalDeviceType);
+				if (val == null)
+				{
+					return null;
+				}
 
-        /// <summary>
-        /// Set Manufacturer field</summary>
-        /// <param name="manufacturer_">Nullable field value to be set</param>
-        public void SetManufacturer(ushort? manufacturer_)
-        {
-            SetFieldValue(2, 0, manufacturer_, Fit.SubfieldIndexMainField);
-        }
-        
-        ///<summary>
-        /// Retrieves the SerialNumber field</summary>
-        /// <returns>Returns nullable uint representing the SerialNumber field</returns>
-        public uint? GetSerialNumber()
-        {
-            Object val = GetFieldValue(3, 0, Fit.SubfieldIndexMainField);
-            if(val == null)
-            {
-                return null;
-            }
+				return (Convert.ToByte(val));
 
-            return (Convert.ToUInt32(val));
-            
-        }
+			}
+			set
+			{
+				SetFieldValue(1, 0, value, DeviceTypeSubfield.LocalDeviceType);
+			}
+		}
+		///<summary>
+		/// Retrieves the Manufacturer field</summary>
+		/// <returns>Returns nullable ushort representing the Manufacturer field</returns>
+		public ushort? Manufacturer
+		{
+			get
+			{
+				Object val = GetFieldValue(2, 0, Fit.SubfieldIndexMainField);
+				if (val == null)
+				{
+					return null;
+				}
 
-        /// <summary>
-        /// Set SerialNumber field</summary>
-        /// <param name="serialNumber_">Nullable field value to be set</param>
-        public void SetSerialNumber(uint? serialNumber_)
-        {
-            SetFieldValue(3, 0, serialNumber_, Fit.SubfieldIndexMainField);
-        }
-        
-        ///<summary>
-        /// Retrieves the Product field</summary>
-        /// <returns>Returns nullable ushort representing the Product field</returns>
-        public ushort? GetProduct()
-        {
-            Object val = GetFieldValue(4, 0, Fit.SubfieldIndexMainField);
-            if(val == null)
-            {
-                return null;
-            }
+				return (Convert.ToUInt16(val));
 
-            return (Convert.ToUInt16(val));
-            
-        }
+			}
+			set
+			{
+				SetFieldValue(2, 0, value, Fit.SubfieldIndexMainField);
+			}
+		}
 
-        /// <summary>
-        /// Set Product field</summary>
-        /// <param name="product_">Nullable field value to be set</param>
-        public void SetProduct(ushort? product_)
-        {
-            SetFieldValue(4, 0, product_, Fit.SubfieldIndexMainField);
-        }
-        
+		///<summary>
+		/// Retrieves the SerialNumber field</summary>
+		/// <returns>Returns nullable uint representing the SerialNumber field</returns>
+		public uint? SerialNumber
+		{
+			get
+			{
+				Object val = GetFieldValue(3, 0, Fit.SubfieldIndexMainField);
+				if (val == null)
+				{
+					return null;
+				}
 
-        /// <summary>
-        /// Retrieves the FaveroProduct subfield</summary>
-        /// <returns>Nullable ushort representing the FaveroProduct subfield</returns>
-        public ushort? GetFaveroProduct()
-        {
-            Object val = GetFieldValue(4, 0, ProductSubfield.FaveroProduct);
-            if(val == null)
-            {
-                return null;
-            }
+				return (Convert.ToUInt32(val));
 
-            return (Convert.ToUInt16(val));
-            
-        }
+			}
+			set
+			{
+				SetFieldValue(3, 0, value, Fit.SubfieldIndexMainField);
+			}
+		}
 
-        /// <summary>
-        ///
-        /// Set FaveroProduct subfield</summary>
-        /// <param name="faveroProduct">Subfield value to be set</param>
-        public void SetFaveroProduct(ushort? faveroProduct)
-        {
-            SetFieldValue(4, 0, faveroProduct, ProductSubfield.FaveroProduct);
-        }
+		///<summary>
+		/// Retrieves the Product field</summary>
+		/// <returns>Returns nullable ushort representing the Product field</returns>
+		public ushort? Product
+		{
+			get
+			{
+				Object val = GetFieldValue(4, 0, Fit.SubfieldIndexMainField);
+				if (val == null)
+				{
+					return null;
+				}
 
-        /// <summary>
-        /// Retrieves the GarminProduct subfield</summary>
-        /// <returns>Nullable ushort representing the GarminProduct subfield</returns>
-        public ushort? GetGarminProduct()
-        {
-            Object val = GetFieldValue(4, 0, ProductSubfield.GarminProduct);
-            if(val == null)
-            {
-                return null;
-            }
+				return (Convert.ToUInt16(val));
 
-            return (Convert.ToUInt16(val));
-            
-        }
+			}
+			set
+			{
+				SetFieldValue(4, 0, value, Fit.SubfieldIndexMainField);
+			}
+		}
 
-        /// <summary>
-        ///
-        /// Set GarminProduct subfield</summary>
-        /// <param name="garminProduct">Subfield value to be set</param>
-        public void SetGarminProduct(ushort? garminProduct)
-        {
-            SetFieldValue(4, 0, garminProduct, ProductSubfield.GarminProduct);
-        }
-        ///<summary>
-        /// Retrieves the SoftwareVersion field</summary>
-        /// <returns>Returns nullable float representing the SoftwareVersion field</returns>
-        public float? GetSoftwareVersion()
-        {
-            Object val = GetFieldValue(5, 0, Fit.SubfieldIndexMainField);
-            if(val == null)
-            {
-                return null;
-            }
 
-            return (Convert.ToSingle(val));
-            
-        }
+		/// <summary>
+		/// Retrieves the FaveroProduct subfield</summary>
+		/// <returns>Nullable ushort representing the FaveroProduct subfield</returns>
+		public ushort? FaveroProduct
+		{
+			get
+			{
+				Object val = GetFieldValue(4, 0, ProductSubfield.FaveroProduct);
+				if (val == null)
+				{
+					return null;
+				}
 
-        /// <summary>
-        /// Set SoftwareVersion field</summary>
-        /// <param name="softwareVersion_">Nullable field value to be set</param>
-        public void SetSoftwareVersion(float? softwareVersion_)
-        {
-            SetFieldValue(5, 0, softwareVersion_, Fit.SubfieldIndexMainField);
-        }
-        
-        ///<summary>
-        /// Retrieves the HardwareVersion field</summary>
-        /// <returns>Returns nullable byte representing the HardwareVersion field</returns>
-        public byte? GetHardwareVersion()
-        {
-            Object val = GetFieldValue(6, 0, Fit.SubfieldIndexMainField);
-            if(val == null)
-            {
-                return null;
-            }
+				return (Convert.ToUInt16(val));
 
-            return (Convert.ToByte(val));
-            
-        }
+			}
+			set
+			{
+				SetFieldValue(4, 0, value, ProductSubfield.FaveroProduct);
+			}
+		}
 
-        /// <summary>
-        /// Set HardwareVersion field</summary>
-        /// <param name="hardwareVersion_">Nullable field value to be set</param>
-        public void SetHardwareVersion(byte? hardwareVersion_)
-        {
-            SetFieldValue(6, 0, hardwareVersion_, Fit.SubfieldIndexMainField);
-        }
-        
-        ///<summary>
-        /// Retrieves the CumOperatingTime field
-        /// Units: s
-        /// Comment: Reset by new battery or charge.</summary>
-        /// <returns>Returns nullable uint representing the CumOperatingTime field</returns>
-        public uint? GetCumOperatingTime()
-        {
-            Object val = GetFieldValue(7, 0, Fit.SubfieldIndexMainField);
-            if(val == null)
-            {
-                return null;
-            }
+		/// <summary>
+		/// Retrieves the GarminProduct subfield</summary>
+		/// <returns>Nullable ushort representing the GarminProduct subfield</returns>
+		public ushort? GarminProduct
+		{
+			get
+			{
+				Object val = GetFieldValue(4, 0, ProductSubfield.GarminProduct);
+				if (val == null)
+				{
+					return null;
+				}
 
-            return (Convert.ToUInt32(val));
-            
-        }
+				return (Convert.ToUInt16(val));
 
-        /// <summary>
-        /// Set CumOperatingTime field
-        /// Units: s
-        /// Comment: Reset by new battery or charge.</summary>
-        /// <param name="cumOperatingTime_">Nullable field value to be set</param>
-        public void SetCumOperatingTime(uint? cumOperatingTime_)
-        {
-            SetFieldValue(7, 0, cumOperatingTime_, Fit.SubfieldIndexMainField);
-        }
-        
-        ///<summary>
-        /// Retrieves the BatteryVoltage field
-        /// Units: V</summary>
-        /// <returns>Returns nullable float representing the BatteryVoltage field</returns>
-        public float? GetBatteryVoltage()
-        {
-            Object val = GetFieldValue(10, 0, Fit.SubfieldIndexMainField);
-            if(val == null)
-            {
-                return null;
-            }
+			}
+			set
+			{
+				SetFieldValue(4, 0, value, ProductSubfield.GarminProduct);
+			}
+		}
+		///<summary>
+		/// Retrieves the SoftwareVersion field</summary>
+		/// <returns>Returns nullable float representing the SoftwareVersion field</returns>
+		public float? SoftwareVersion
+		{
+			get
+			{
+				Object val = GetFieldValue(5, 0, Fit.SubfieldIndexMainField);
+				if (val == null)
+				{
+					return null;
+				}
 
-            return (Convert.ToSingle(val));
-            
-        }
+				return (Convert.ToSingle(val));
 
-        /// <summary>
-        /// Set BatteryVoltage field
-        /// Units: V</summary>
-        /// <param name="batteryVoltage_">Nullable field value to be set</param>
-        public void SetBatteryVoltage(float? batteryVoltage_)
-        {
-            SetFieldValue(10, 0, batteryVoltage_, Fit.SubfieldIndexMainField);
-        }
-        
-        ///<summary>
-        /// Retrieves the BatteryStatus field</summary>
-        /// <returns>Returns nullable byte representing the BatteryStatus field</returns>
-        public byte? GetBatteryStatus()
-        {
-            Object val = GetFieldValue(11, 0, Fit.SubfieldIndexMainField);
-            if(val == null)
-            {
-                return null;
-            }
+			}
+			set
+			{
+				SetFieldValue(5, 0, value, Fit.SubfieldIndexMainField);
+			}
+		}
 
-            return (Convert.ToByte(val));
-            
-        }
+		///<summary>
+		/// Retrieves the HardwareVersion field</summary>
+		/// <returns>Returns nullable byte representing the HardwareVersion field</returns>
+		public byte? HardwareVersion
+		{
+			get
+			{
+				Object val = GetFieldValue(6, 0, Fit.SubfieldIndexMainField);
+				if (val == null)
+				{
+					return null;
+				}
 
-        /// <summary>
-        /// Set BatteryStatus field</summary>
-        /// <param name="batteryStatus_">Nullable field value to be set</param>
-        public void SetBatteryStatus(byte? batteryStatus_)
-        {
-            SetFieldValue(11, 0, batteryStatus_, Fit.SubfieldIndexMainField);
-        }
-        
-        ///<summary>
-        /// Retrieves the SensorPosition field
-        /// Comment: Indicates the location of the sensor</summary>
-        /// <returns>Returns nullable BodyLocation enum representing the SensorPosition field</returns>
-        public BodyLocation? GetSensorPosition()
-        {
-            object obj = GetFieldValue(18, 0, Fit.SubfieldIndexMainField);
-            BodyLocation? value = obj == null ? (BodyLocation?)null : (BodyLocation)obj;
-            return value;
-        }
+				return (Convert.ToByte(val));
 
-        /// <summary>
-        /// Set SensorPosition field
-        /// Comment: Indicates the location of the sensor</summary>
-        /// <param name="sensorPosition_">Nullable field value to be set</param>
-        public void SetSensorPosition(BodyLocation? sensorPosition_)
-        {
-            SetFieldValue(18, 0, sensorPosition_, Fit.SubfieldIndexMainField);
-        }
-        
-        ///<summary>
-        /// Retrieves the Descriptor field
-        /// Comment: Used to describe the sensor or location</summary>
-        /// <returns>Returns byte[] representing the Descriptor field</returns>
-        public byte[] GetDescriptor()
-        {
-            byte[] data = (byte[])GetFieldValue(19, 0, Fit.SubfieldIndexMainField);
-            return data.Take(data.Length - 1).ToArray();
-        }
+			}
+			set
+			{
+				SetFieldValue(6, 0, value, Fit.SubfieldIndexMainField);
+			}
+		}
 
-        ///<summary>
-        /// Retrieves the Descriptor field
-        /// Comment: Used to describe the sensor or location</summary>
-        /// <returns>Returns String representing the Descriptor field</returns>
-        public String GetDescriptorAsString()
-        {
-            byte[] data = (byte[])GetFieldValue(19, 0, Fit.SubfieldIndexMainField);
-            return data != null ? Encoding.UTF8.GetString(data, 0, data.Length - 1) : null;
-        }
+		///<summary>
+		/// Retrieves the CumOperatingTime field
+		/// Units: s
+		/// Comment: Reset by new battery or charge.</summary>
+		/// <returns>Returns nullable uint representing the CumOperatingTime field</returns>
+		public uint? CumOperatingTime
+		{
+			get
+			{
+				Object val = GetFieldValue(7, 0, Fit.SubfieldIndexMainField);
+				if (val == null)
+				{
+					return null;
+				}
 
-        ///<summary>
-        /// Set Descriptor field
-        /// Comment: Used to describe the sensor or location</summary>
-        /// <param name="descriptor_"> field value to be set</param>
-        public void SetDescriptor(String descriptor_)
-        {
-            byte[] data = Encoding.UTF8.GetBytes(descriptor_);
-            byte[] zdata = new byte[data.Length + 1];
-            data.CopyTo(zdata, 0);
-            SetFieldValue(19, 0, zdata, Fit.SubfieldIndexMainField);
-        }
+				return (Convert.ToUInt32(val));
 
-        
-        /// <summary>
-        /// Set Descriptor field
-        /// Comment: Used to describe the sensor or location</summary>
-        /// <param name="descriptor_">field value to be set</param>
-        public void SetDescriptor(byte[] descriptor_)
-        {
-            SetFieldValue(19, 0, descriptor_, Fit.SubfieldIndexMainField);
-        }
-        
-        ///<summary>
-        /// Retrieves the AntTransmissionType field</summary>
-        /// <returns>Returns nullable byte representing the AntTransmissionType field</returns>
-        public byte? GetAntTransmissionType()
-        {
-            Object val = GetFieldValue(20, 0, Fit.SubfieldIndexMainField);
-            if(val == null)
-            {
-                return null;
-            }
+			}
+			set
+			{
+				SetFieldValue(7, 0, value, Fit.SubfieldIndexMainField);
+			}
+		}
 
-            return (Convert.ToByte(val));
-            
-        }
+		///<summary>
+		/// Retrieves the BatteryVoltage field
+		/// Units: V</summary>
+		/// <returns>Returns nullable float representing the BatteryVoltage field</returns>
+		public float? BatteryVoltage
+		{
+			get
+			{
+				Object val = GetFieldValue(10, 0, Fit.SubfieldIndexMainField);
+				if (val == null)
+				{
+					return null;
+				}
 
-        /// <summary>
-        /// Set AntTransmissionType field</summary>
-        /// <param name="antTransmissionType_">Nullable field value to be set</param>
-        public void SetAntTransmissionType(byte? antTransmissionType_)
-        {
-            SetFieldValue(20, 0, antTransmissionType_, Fit.SubfieldIndexMainField);
-        }
-        
-        ///<summary>
-        /// Retrieves the AntDeviceNumber field</summary>
-        /// <returns>Returns nullable ushort representing the AntDeviceNumber field</returns>
-        public ushort? GetAntDeviceNumber()
-        {
-            Object val = GetFieldValue(21, 0, Fit.SubfieldIndexMainField);
-            if(val == null)
-            {
-                return null;
-            }
+				return (Convert.ToSingle(val));
 
-            return (Convert.ToUInt16(val));
-            
-        }
+			}
+			set
+			{
+				SetFieldValue(10, 0, value, Fit.SubfieldIndexMainField);
+			}
+		}
 
-        /// <summary>
-        /// Set AntDeviceNumber field</summary>
-        /// <param name="antDeviceNumber_">Nullable field value to be set</param>
-        public void SetAntDeviceNumber(ushort? antDeviceNumber_)
-        {
-            SetFieldValue(21, 0, antDeviceNumber_, Fit.SubfieldIndexMainField);
-        }
-        
-        ///<summary>
-        /// Retrieves the AntNetwork field</summary>
-        /// <returns>Returns nullable AntNetwork enum representing the AntNetwork field</returns>
-        public AntNetwork? GetAntNetwork()
-        {
-            object obj = GetFieldValue(22, 0, Fit.SubfieldIndexMainField);
-            AntNetwork? value = obj == null ? (AntNetwork?)null : (AntNetwork)obj;
-            return value;
-        }
+		///<summary>
+		/// Retrieves the BatteryStatus field</summary>
+		/// <returns>Returns nullable byte representing the BatteryStatus field</returns>
+		public byte? BatteryStatus
+		{
+			get
+			{
+				Object val = GetFieldValue(11, 0, Fit.SubfieldIndexMainField);
+				if (val == null)
+				{
+					return null;
+				}
 
-        /// <summary>
-        /// Set AntNetwork field</summary>
-        /// <param name="antNetwork_">Nullable field value to be set</param>
-        public void SetAntNetwork(AntNetwork? antNetwork_)
-        {
-            SetFieldValue(22, 0, antNetwork_, Fit.SubfieldIndexMainField);
-        }
-        
-        ///<summary>
-        /// Retrieves the SourceType field</summary>
-        /// <returns>Returns nullable SourceType enum representing the SourceType field</returns>
-        public SourceType? GetSourceType()
-        {
-            object obj = GetFieldValue(25, 0, Fit.SubfieldIndexMainField);
-            SourceType? value = obj == null ? (SourceType?)null : (SourceType)obj;
-            return value;
-        }
+				return (Convert.ToByte(val));
 
-        /// <summary>
-        /// Set SourceType field</summary>
-        /// <param name="sourceType_">Nullable field value to be set</param>
-        public void SetSourceType(SourceType? sourceType_)
-        {
-            SetFieldValue(25, 0, sourceType_, Fit.SubfieldIndexMainField);
-        }
-        
-        ///<summary>
-        /// Retrieves the ProductName field
-        /// Comment: Optional free form string to indicate the devices name or model</summary>
-        /// <returns>Returns byte[] representing the ProductName field</returns>
-        public byte[] GetProductName()
-        {
-            byte[] data = (byte[])GetFieldValue(27, 0, Fit.SubfieldIndexMainField);
-            return data.Take(data.Length - 1).ToArray();
-        }
+			}
+			set
+			{
+				SetFieldValue(11, 0, value, Fit.SubfieldIndexMainField);
+			}
+		}
 
-        ///<summary>
-        /// Retrieves the ProductName field
-        /// Comment: Optional free form string to indicate the devices name or model</summary>
-        /// <returns>Returns String representing the ProductName field</returns>
-        public String GetProductNameAsString()
-        {
-            byte[] data = (byte[])GetFieldValue(27, 0, Fit.SubfieldIndexMainField);
-            return data != null ? Encoding.UTF8.GetString(data, 0, data.Length - 1) : null;
-        }
+		///<summary>
+		/// Retrieves the SensorPosition field
+		/// Comment: Indicates the location of the sensor</summary>
+		/// <returns>Returns nullable BodyLocation enum representing the SensorPosition field</returns>
+		public BodyLocation? SensorPosition
+		{
+			get
+			{
+				object obj = GetFieldValue(18, 0, Fit.SubfieldIndexMainField);
+				BodyLocation? value = obj == null ? (BodyLocation?)null : (BodyLocation)obj;
+				return value;
+			}
+			set
+			{
+				SetFieldValue(18, 0, value, Fit.SubfieldIndexMainField);
+			}
+		}
 
-        ///<summary>
-        /// Set ProductName field
-        /// Comment: Optional free form string to indicate the devices name or model</summary>
-        /// <param name="productName_"> field value to be set</param>
-        public void SetProductName(String productName_)
-        {
-            byte[] data = Encoding.UTF8.GetBytes(productName_);
-            byte[] zdata = new byte[data.Length + 1];
-            data.CopyTo(zdata, 0);
-            SetFieldValue(27, 0, zdata, Fit.SubfieldIndexMainField);
-        }
+		///<summary>
+		/// Retrieves the Descriptor field
+		/// Comment: Used to describe the sensor or location</summary>
+		/// <returns>Returns byte[] representing the Descriptor field</returns>
+		public byte[] Descriptor
+		{
+			get
+			{
+				byte[] data = (byte[])GetFieldValue(19, 0, Fit.SubfieldIndexMainField);
+				return data.Take(data.Length - 1).ToArray();
+			}
+			set
+			{
+				SetFieldValue(19, 0, value, Fit.SubfieldIndexMainField);
+			}
+		}
 
-        
-        /// <summary>
-        /// Set ProductName field
-        /// Comment: Optional free form string to indicate the devices name or model</summary>
-        /// <param name="productName_">field value to be set</param>
-        public void SetProductName(byte[] productName_)
-        {
-            SetFieldValue(27, 0, productName_, Fit.SubfieldIndexMainField);
-        }
-        
-        ///<summary>
-        /// Retrieves the BatteryLevel field
-        /// Units: %</summary>
-        /// <returns>Returns nullable byte representing the BatteryLevel field</returns>
-        public byte? GetBatteryLevel()
-        {
-            Object val = GetFieldValue(32, 0, Fit.SubfieldIndexMainField);
-            if(val == null)
-            {
-                return null;
-            }
+		///<summary>
+		/// Retrieves the Descriptor field
+		/// Comment: Used to describe the sensor or location</summary>
+		/// <returns>Returns String representing the Descriptor field</returns>
+		public String GetDescriptorAsString()
+		{
+			byte[] data = (byte[])GetFieldValue(19, 0, Fit.SubfieldIndexMainField);
+			return data != null ? Encoding.UTF8.GetString(data, 0, data.Length - 1) : null;
+		}
 
-            return (Convert.ToByte(val));
-            
-        }
+		///<summary>
+		/// Set Descriptor field
+		/// Comment: Used to describe the sensor or location</summary>
+		/// <param name="descriptor_"> field value to be set</param>
+		public void SetDescriptor(String descriptor_)
+		{
+			byte[] data = Encoding.UTF8.GetBytes(descriptor_);
+			byte[] zdata = new byte[data.Length + 1];
+			data.CopyTo(zdata, 0);
+			SetFieldValue(19, 0, zdata, Fit.SubfieldIndexMainField);
+		}
 
-        /// <summary>
-        /// Set BatteryLevel field
-        /// Units: %</summary>
-        /// <param name="batteryLevel_">Nullable field value to be set</param>
-        public void SetBatteryLevel(byte? batteryLevel_)
-        {
-            SetFieldValue(32, 0, batteryLevel_, Fit.SubfieldIndexMainField);
-        }
-        
-        #endregion // Methods
-    } // Class
+		///<summary>
+		/// Retrieves the AntTransmissionType field</summary>
+		/// <returns>Returns nullable byte representing the AntTransmissionType field</returns>
+		public byte? AntTransmissionType
+		{
+			get
+			{
+				Object val = GetFieldValue(20, 0, Fit.SubfieldIndexMainField);
+				if (val == null)
+				{
+					return null;
+				}
+
+				return (Convert.ToByte(val));
+
+			}
+			set
+			{
+				SetFieldValue(20, 0, value, Fit.SubfieldIndexMainField);
+			}
+		}
+
+		///<summary>
+		/// Retrieves the AntDeviceNumber field</summary>
+		/// <returns>Returns nullable ushort representing the AntDeviceNumber field</returns>
+		public ushort? AntDeviceNumber
+		{
+			get
+			{
+				Object val = GetFieldValue(21, 0, Fit.SubfieldIndexMainField);
+				if (val == null)
+				{
+					return null;
+				}
+
+				return (Convert.ToUInt16(val));
+
+			}
+			set
+			{
+				SetFieldValue(21, 0, value, Fit.SubfieldIndexMainField);
+			}
+		}
+
+		///<summary>
+		/// Retrieves the AntNetwork field</summary>
+		/// <returns>Returns nullable AntNetwork enum representing the AntNetwork field</returns>
+		public AntNetwork? AntNetwork
+		{
+			get
+			{
+				object obj = GetFieldValue(22, 0, Fit.SubfieldIndexMainField);
+				AntNetwork? value = obj == null ? (AntNetwork?)null : (AntNetwork)obj;
+				return value;
+			}
+			set
+			{
+				SetFieldValue(22, 0, value, Fit.SubfieldIndexMainField);
+			}
+		}
+
+		///<summary>
+		/// Retrieves the SourceType field</summary>
+		/// <returns>Returns nullable SourceType enum representing the SourceType field</returns>
+		public SourceType? SourceType
+		{
+			get
+			{
+				object obj = GetFieldValue(25, 0, Fit.SubfieldIndexMainField);
+				SourceType? value = obj == null ? (SourceType?)null : (SourceType)obj;
+				return value;
+			}
+			set
+			{
+				SetFieldValue(25, 0, value, Fit.SubfieldIndexMainField);
+			}
+		}
+
+		///<summary>
+		/// Retrieves the ProductName field
+		/// Comment: Optional free form string to indicate the devices name or model</summary>
+		/// <returns>Returns byte[] representing the ProductName field</returns>
+		public byte[] ProductName
+		{
+			get
+			{
+				byte[] data = (byte[])GetFieldValue(27, 0, Fit.SubfieldIndexMainField);
+				return data.Take(data.Length - 1).ToArray();
+			}
+			set
+			{
+				SetFieldValue(27, 0, value, Fit.SubfieldIndexMainField);
+			}
+		}
+
+		///<summary>
+		/// Retrieves the ProductName field
+		/// Comment: Optional free form string to indicate the devices name or model</summary>
+		/// <returns>Returns String representing the ProductName field</returns>
+		public String GetProductNameAsString()
+		{
+			byte[] data = (byte[])GetFieldValue(27, 0, Fit.SubfieldIndexMainField);
+			return data != null ? Encoding.UTF8.GetString(data, 0, data.Length - 1) : null;
+		}
+
+		///<summary>
+		/// Set ProductName field
+		/// Comment: Optional free form string to indicate the devices name or model</summary>
+		/// <param name="productName_"> field value to be set</param>
+		public void SetProductName(String productName_)
+		{
+			byte[] data = Encoding.UTF8.GetBytes(productName_);
+			byte[] zdata = new byte[data.Length + 1];
+			data.CopyTo(zdata, 0);
+			SetFieldValue(27, 0, zdata, Fit.SubfieldIndexMainField);
+		}
+
+		///<summary>
+		/// Retrieves the BatteryLevel field
+		/// Units: %</summary>
+		/// <returns>Returns nullable byte representing the BatteryLevel field</returns>
+		public byte? BatteryLevel
+		{
+			get
+			{
+				Object val = GetFieldValue(32, 0, Fit.SubfieldIndexMainField);
+				if (val == null)
+				{
+					return null;
+				}
+
+				return (Convert.ToByte(val));
+
+			}
+			set
+			{
+				SetFieldValue(32, 0, value, Fit.SubfieldIndexMainField);
+			}
+		}
+
+		#endregion // Methods
+	} // Class
 } // namespace

--- a/Dynastream/Fit/Profile/Mesgs/DeviceSettingsMesg.cs
+++ b/Dynastream/Fit/Profile/Mesgs/DeviceSettingsMesg.cs
@@ -21,654 +21,617 @@ using System.Linq;
 
 namespace Dynastream.Fit
 {
-    /// <summary>
-    /// Implements the DeviceSettings profile message.
-    /// </summary>
-    public class DeviceSettingsMesg : Mesg
-    {
-        #region Fields
-        #endregion
+	/// <summary>
+	/// Implements the DeviceSettings profile message.
+	/// </summary>
+	public class DeviceSettingsMesg : Mesg
+	{
+		#region Fields
+		#endregion
 
-        /// <summary>
-        /// Field Numbers for <see cref="DeviceSettingsMesg"/>
-        /// </summary>
-        public sealed class FieldDefNum
-        {
-            public const byte ActiveTimeZone = 0;
-            public const byte UtcOffset = 1;
-            public const byte TimeOffset = 2;
-            public const byte TimeMode = 4;
-            public const byte TimeZoneOffset = 5;
-            public const byte BacklightMode = 12;
-            public const byte ActivityTrackerEnabled = 36;
-            public const byte ClockTime = 39;
-            public const byte PagesEnabled = 40;
-            public const byte MoveAlertEnabled = 46;
-            public const byte DateMode = 47;
-            public const byte DisplayOrientation = 55;
-            public const byte MountingSide = 56;
-            public const byte DefaultPage = 57;
-            public const byte AutosyncMinSteps = 58;
-            public const byte AutosyncMinTime = 59;
-            public const byte LactateThresholdAutodetectEnabled = 80;
-            public const byte BleAutoUploadEnabled = 86;
-            public const byte AutoSyncFrequency = 89;
-            public const byte AutoActivityDetect = 90;
-            public const byte NumberOfScreens = 94;
-            public const byte SmartNotificationDisplayOrientation = 95;
-            public const byte TapInterface = 134;
-            public const byte TapSensitivity = 174;
-            public const byte Invalid = Fit.FieldNumInvalid;
-        }
+		/// <summary>
+		/// Field Numbers for <see cref="DeviceSettingsMesg"/>
+		/// </summary>
+		public sealed class FieldDefNum
+		{
+			public const byte ActiveTimeZone = 0;
+			public const byte UtcOffset = 1;
+			public const byte TimeOffset = 2;
+			public const byte TimeMode = 4;
+			public const byte TimeZoneOffset = 5;
+			public const byte BacklightMode = 12;
+			public const byte ActivityTrackerEnabled = 36;
+			public const byte ClockTime = 39;
+			public const byte PagesEnabled = 40;
+			public const byte MoveAlertEnabled = 46;
+			public const byte DateMode = 47;
+			public const byte DisplayOrientation = 55;
+			public const byte MountingSide = 56;
+			public const byte DefaultPage = 57;
+			public const byte AutosyncMinSteps = 58;
+			public const byte AutosyncMinTime = 59;
+			public const byte LactateThresholdAutodetectEnabled = 80;
+			public const byte BleAutoUploadEnabled = 86;
+			public const byte AutoSyncFrequency = 89;
+			public const byte AutoActivityDetect = 90;
+			public const byte NumberOfScreens = 94;
+			public const byte SmartNotificationDisplayOrientation = 95;
+			public const byte TapInterface = 134;
+			public const byte TapSensitivity = 174;
+			public const byte Invalid = Fit.FieldNumInvalid;
+		}
 
-        #region Constructors
-        public DeviceSettingsMesg() : base(Profile.GetMesg(MesgNum.DeviceSettings))
-        {
-        }
+		#region Constructors
+		public DeviceSettingsMesg() : base(Profile.GetMesg(MesgNum.DeviceSettings))
+		{
+		}
 
-        public DeviceSettingsMesg(Mesg mesg) : base(mesg)
-        {
-        }
-        #endregion // Constructors
+		public DeviceSettingsMesg(Mesg mesg) : base(mesg)
+		{
+		}
+		#endregion // Constructors
 
-        #region Methods
-        ///<summary>
-        /// Retrieves the ActiveTimeZone field
-        /// Comment: Index into time zone arrays.</summary>
-        /// <returns>Returns nullable byte representing the ActiveTimeZone field</returns>
-        public byte? GetActiveTimeZone()
-        {
-            Object val = GetFieldValue(0, 0, Fit.SubfieldIndexMainField);
-            if(val == null)
-            {
-                return null;
-            }
+		#region Methods
+		///<summary>
+		/// Retrieves the ActiveTimeZone field
+		/// Comment: Index into time zone arrays.</summary>
+		/// <returns>Returns nullable byte representing the ActiveTimeZone field</returns>
+		public byte? ActiveTimeZone
+		{
+			get
+			{
+				Object val = GetFieldValue(0, 0, Fit.SubfieldIndexMainField);
+				if (val == null)
+				{
+					return null;
+				}
 
-            return (Convert.ToByte(val));
-            
-        }
+				return (Convert.ToByte(val));
 
-        /// <summary>
-        /// Set ActiveTimeZone field
-        /// Comment: Index into time zone arrays.</summary>
-        /// <param name="activeTimeZone_">Nullable field value to be set</param>
-        public void SetActiveTimeZone(byte? activeTimeZone_)
-        {
-            SetFieldValue(0, 0, activeTimeZone_, Fit.SubfieldIndexMainField);
-        }
-        
-        ///<summary>
-        /// Retrieves the UtcOffset field
-        /// Comment: Offset from system time. Required to convert timestamp from system time to UTC.</summary>
-        /// <returns>Returns nullable uint representing the UtcOffset field</returns>
-        public uint? GetUtcOffset()
-        {
-            Object val = GetFieldValue(1, 0, Fit.SubfieldIndexMainField);
-            if(val == null)
-            {
-                return null;
-            }
+			}
+			set
+			{
+				SetFieldValue(0, 0, value, Fit.SubfieldIndexMainField);
+			}
+		}
 
-            return (Convert.ToUInt32(val));
-            
-        }
+		///<summary>
+		/// Retrieves the UtcOffset field
+		/// Comment: Offset from system time. Required to convert timestamp from system time to UTC.</summary>
+		/// <returns>Returns nullable uint representing the UtcOffset field</returns>
+		public uint? UtcOffset
+		{
+			get
+			{
+				Object val = GetFieldValue(1, 0, Fit.SubfieldIndexMainField);
+				if (val == null)
+				{
+					return null;
+				}
 
-        /// <summary>
-        /// Set UtcOffset field
-        /// Comment: Offset from system time. Required to convert timestamp from system time to UTC.</summary>
-        /// <param name="utcOffset_">Nullable field value to be set</param>
-        public void SetUtcOffset(uint? utcOffset_)
-        {
-            SetFieldValue(1, 0, utcOffset_, Fit.SubfieldIndexMainField);
-        }
-        
-        
-        /// <summary>
-        ///
-        /// </summary>
-        /// <returns>returns number of elements in field TimeOffset</returns>
-        public int GetNumTimeOffset()
-        {
-            return GetNumFieldValues(2, Fit.SubfieldIndexMainField);
-        }
+				return (Convert.ToUInt32(val));
 
-        ///<summary>
-        /// Retrieves the TimeOffset field
-        /// Units: s
-        /// Comment: Offset from system time.</summary>
-        /// <param name="index">0 based index of TimeOffset element to retrieve</param>
-        /// <returns>Returns nullable uint representing the TimeOffset field</returns>
-        public uint? GetTimeOffset(int index)
-        {
-            Object val = GetFieldValue(2, index, Fit.SubfieldIndexMainField);
-            if(val == null)
-            {
-                return null;
-            }
+			}
+			set
+			{
+				SetFieldValue(1, 0, value, Fit.SubfieldIndexMainField);
+			}
+		}
 
-            return (Convert.ToUInt32(val));
-            
-        }
 
-        /// <summary>
-        /// Set TimeOffset field
-        /// Units: s
-        /// Comment: Offset from system time.</summary>
-        /// <param name="index">0 based index of time_offset</param>
-        /// <param name="timeOffset_">Nullable field value to be set</param>
-        public void SetTimeOffset(int index, uint? timeOffset_)
-        {
-            SetFieldValue(2, index, timeOffset_, Fit.SubfieldIndexMainField);
-        }
-        
-        
-        /// <summary>
-        ///
-        /// </summary>
-        /// <returns>returns number of elements in field TimeMode</returns>
-        public int GetNumTimeMode()
-        {
-            return GetNumFieldValues(4, Fit.SubfieldIndexMainField);
-        }
+		/// <summary>
+		///
+		/// </summary>
+		/// <returns>returns number of elements in field TimeOffset</returns>
+		public int GetNumTimeOffset()
+		{
+			return GetNumFieldValues(2, Fit.SubfieldIndexMainField);
+		}
 
-        ///<summary>
-        /// Retrieves the TimeMode field
-        /// Comment: Display mode for the time</summary>
-        /// <param name="index">0 based index of TimeMode element to retrieve</param>
-        /// <returns>Returns nullable TimeMode enum representing the TimeMode field</returns>
-        public TimeMode? GetTimeMode(int index)
-        {
-            object obj = GetFieldValue(4, index, Fit.SubfieldIndexMainField);
-            TimeMode? value = obj == null ? (TimeMode?)null : (TimeMode)obj;
-            return value;
-        }
+		///<summary>
+		/// Retrieves the TimeOffset field
+		/// Units: s
+		/// Comment: Offset from system time.</summary>
+		/// <param name="index">0 based index of TimeOffset element to retrieve</param>
+		/// <returns>Returns nullable uint representing the TimeOffset field</returns>
+		public uint? GetTimeOffset(int index)
+		{
+			Object val = GetFieldValue(2, index, Fit.SubfieldIndexMainField);
+			if (val == null)
+			{
+				return null;
+			}
 
-        /// <summary>
-        /// Set TimeMode field
-        /// Comment: Display mode for the time</summary>
-        /// <param name="index">0 based index of time_mode</param>
-        /// <param name="timeMode_">Nullable field value to be set</param>
-        public void SetTimeMode(int index, TimeMode? timeMode_)
-        {
-            SetFieldValue(4, index, timeMode_, Fit.SubfieldIndexMainField);
-        }
-        
-        
-        /// <summary>
-        ///
-        /// </summary>
-        /// <returns>returns number of elements in field TimeZoneOffset</returns>
-        public int GetNumTimeZoneOffset()
-        {
-            return GetNumFieldValues(5, Fit.SubfieldIndexMainField);
-        }
+			return (Convert.ToUInt32(val));
 
-        ///<summary>
-        /// Retrieves the TimeZoneOffset field
-        /// Units: hr
-        /// Comment: timezone offset in 1/4 hour increments</summary>
-        /// <param name="index">0 based index of TimeZoneOffset element to retrieve</param>
-        /// <returns>Returns nullable float representing the TimeZoneOffset field</returns>
-        public float? GetTimeZoneOffset(int index)
-        {
-            Object val = GetFieldValue(5, index, Fit.SubfieldIndexMainField);
-            if(val == null)
-            {
-                return null;
-            }
+		}
 
-            return (Convert.ToSingle(val));
-            
-        }
+		/// <summary>
+		/// Set TimeOffset field
+		/// Units: s
+		/// Comment: Offset from system time.</summary>
+		/// <param name="index">0 based index of time_offset</param>
+		/// <param name="timeOffset_">Nullable field value to be set</param>
+		public void SetTimeOffset(int index, uint? timeOffset_)
+		{
+			SetFieldValue(2, index, timeOffset_, Fit.SubfieldIndexMainField);
+		}
 
-        /// <summary>
-        /// Set TimeZoneOffset field
-        /// Units: hr
-        /// Comment: timezone offset in 1/4 hour increments</summary>
-        /// <param name="index">0 based index of time_zone_offset</param>
-        /// <param name="timeZoneOffset_">Nullable field value to be set</param>
-        public void SetTimeZoneOffset(int index, float? timeZoneOffset_)
-        {
-            SetFieldValue(5, index, timeZoneOffset_, Fit.SubfieldIndexMainField);
-        }
-        
-        ///<summary>
-        /// Retrieves the BacklightMode field
-        /// Comment: Mode for backlight</summary>
-        /// <returns>Returns nullable BacklightMode enum representing the BacklightMode field</returns>
-        public BacklightMode? GetBacklightMode()
-        {
-            object obj = GetFieldValue(12, 0, Fit.SubfieldIndexMainField);
-            BacklightMode? value = obj == null ? (BacklightMode?)null : (BacklightMode)obj;
-            return value;
-        }
 
-        /// <summary>
-        /// Set BacklightMode field
-        /// Comment: Mode for backlight</summary>
-        /// <param name="backlightMode_">Nullable field value to be set</param>
-        public void SetBacklightMode(BacklightMode? backlightMode_)
-        {
-            SetFieldValue(12, 0, backlightMode_, Fit.SubfieldIndexMainField);
-        }
-        
-        ///<summary>
-        /// Retrieves the ActivityTrackerEnabled field
-        /// Comment: Enabled state of the activity tracker functionality</summary>
-        /// <returns>Returns nullable Bool enum representing the ActivityTrackerEnabled field</returns>
-        public Bool? GetActivityTrackerEnabled()
-        {
-            object obj = GetFieldValue(36, 0, Fit.SubfieldIndexMainField);
-            Bool? value = obj == null ? (Bool?)null : (Bool)obj;
-            return value;
-        }
+		/// <summary>
+		///
+		/// </summary>
+		/// <returns>returns number of elements in field TimeMode</returns>
+		public int GetNumTimeMode()
+		{
+			return GetNumFieldValues(4, Fit.SubfieldIndexMainField);
+		}
 
-        /// <summary>
-        /// Set ActivityTrackerEnabled field
-        /// Comment: Enabled state of the activity tracker functionality</summary>
-        /// <param name="activityTrackerEnabled_">Nullable field value to be set</param>
-        public void SetActivityTrackerEnabled(Bool? activityTrackerEnabled_)
-        {
-            SetFieldValue(36, 0, activityTrackerEnabled_, Fit.SubfieldIndexMainField);
-        }
-        
-        ///<summary>
-        /// Retrieves the ClockTime field
-        /// Comment: UTC timestamp used to set the devices clock and date</summary>
-        /// <returns>Returns DateTime representing the ClockTime field</returns>
-        public DateTime GetClockTime()
-        {
-            Object val = GetFieldValue(39, 0, Fit.SubfieldIndexMainField);
-            if(val == null)
-            {
-                return null;
-            }
+		///<summary>
+		/// Retrieves the TimeMode field
+		/// Comment: Display mode for the time</summary>
+		/// <param name="index">0 based index of TimeMode element to retrieve</param>
+		/// <returns>Returns nullable TimeMode enum representing the TimeMode field</returns>
+		public TimeMode? GetTimeMode(int index)
+		{
+			object obj = GetFieldValue(4, index, Fit.SubfieldIndexMainField);
+			TimeMode? value = obj == null ? (TimeMode?)null : (TimeMode)obj;
+			return value;
+		}
 
-            return TimestampToDateTime(Convert.ToUInt32(val));
-            
-        }
+		/// <summary>
+		/// Set TimeMode field
+		/// Comment: Display mode for the time</summary>
+		/// <param name="index">0 based index of time_mode</param>
+		/// <param name="timeMode_">Nullable field value to be set</param>
+		public void SetTimeMode(int index, TimeMode? timeMode_)
+		{
+			SetFieldValue(4, index, timeMode_, Fit.SubfieldIndexMainField);
+		}
 
-        /// <summary>
-        /// Set ClockTime field
-        /// Comment: UTC timestamp used to set the devices clock and date</summary>
-        /// <param name="clockTime_">Nullable field value to be set</param>
-        public void SetClockTime(DateTime clockTime_)
-        {
-            SetFieldValue(39, 0, clockTime_.GetTimeStamp(), Fit.SubfieldIndexMainField);
-        }
-        
-        
-        /// <summary>
-        ///
-        /// </summary>
-        /// <returns>returns number of elements in field PagesEnabled</returns>
-        public int GetNumPagesEnabled()
-        {
-            return GetNumFieldValues(40, Fit.SubfieldIndexMainField);
-        }
 
-        ///<summary>
-        /// Retrieves the PagesEnabled field
-        /// Comment: Bitfield to configure enabled screens for each supported loop</summary>
-        /// <param name="index">0 based index of PagesEnabled element to retrieve</param>
-        /// <returns>Returns nullable ushort representing the PagesEnabled field</returns>
-        public ushort? GetPagesEnabled(int index)
-        {
-            Object val = GetFieldValue(40, index, Fit.SubfieldIndexMainField);
-            if(val == null)
-            {
-                return null;
-            }
+		/// <summary>
+		///
+		/// </summary>
+		/// <returns>returns number of elements in field TimeZoneOffset</returns>
+		public int GetNumTimeZoneOffset()
+		{
+			return GetNumFieldValues(5, Fit.SubfieldIndexMainField);
+		}
 
-            return (Convert.ToUInt16(val));
-            
-        }
+		///<summary>
+		/// Retrieves the TimeZoneOffset field
+		/// Units: hr
+		/// Comment: timezone offset in 1/4 hour increments</summary>
+		/// <param name="index">0 based index of TimeZoneOffset element to retrieve</param>
+		/// <returns>Returns nullable float representing the TimeZoneOffset field</returns>
+		public float? GetTimeZoneOffset(int index)
+		{
+			Object val = GetFieldValue(5, index, Fit.SubfieldIndexMainField);
+			if (val == null)
+			{
+				return null;
+			}
 
-        /// <summary>
-        /// Set PagesEnabled field
-        /// Comment: Bitfield to configure enabled screens for each supported loop</summary>
-        /// <param name="index">0 based index of pages_enabled</param>
-        /// <param name="pagesEnabled_">Nullable field value to be set</param>
-        public void SetPagesEnabled(int index, ushort? pagesEnabled_)
-        {
-            SetFieldValue(40, index, pagesEnabled_, Fit.SubfieldIndexMainField);
-        }
-        
-        ///<summary>
-        /// Retrieves the MoveAlertEnabled field
-        /// Comment: Enabled state of the move alert</summary>
-        /// <returns>Returns nullable Bool enum representing the MoveAlertEnabled field</returns>
-        public Bool? GetMoveAlertEnabled()
-        {
-            object obj = GetFieldValue(46, 0, Fit.SubfieldIndexMainField);
-            Bool? value = obj == null ? (Bool?)null : (Bool)obj;
-            return value;
-        }
+			return (Convert.ToSingle(val));
 
-        /// <summary>
-        /// Set MoveAlertEnabled field
-        /// Comment: Enabled state of the move alert</summary>
-        /// <param name="moveAlertEnabled_">Nullable field value to be set</param>
-        public void SetMoveAlertEnabled(Bool? moveAlertEnabled_)
-        {
-            SetFieldValue(46, 0, moveAlertEnabled_, Fit.SubfieldIndexMainField);
-        }
-        
-        ///<summary>
-        /// Retrieves the DateMode field
-        /// Comment: Display mode for the date</summary>
-        /// <returns>Returns nullable DateMode enum representing the DateMode field</returns>
-        public DateMode? GetDateMode()
-        {
-            object obj = GetFieldValue(47, 0, Fit.SubfieldIndexMainField);
-            DateMode? value = obj == null ? (DateMode?)null : (DateMode)obj;
-            return value;
-        }
+		}
 
-        /// <summary>
-        /// Set DateMode field
-        /// Comment: Display mode for the date</summary>
-        /// <param name="dateMode_">Nullable field value to be set</param>
-        public void SetDateMode(DateMode? dateMode_)
-        {
-            SetFieldValue(47, 0, dateMode_, Fit.SubfieldIndexMainField);
-        }
-        
-        ///<summary>
-        /// Retrieves the DisplayOrientation field</summary>
-        /// <returns>Returns nullable DisplayOrientation enum representing the DisplayOrientation field</returns>
-        public DisplayOrientation? GetDisplayOrientation()
-        {
-            object obj = GetFieldValue(55, 0, Fit.SubfieldIndexMainField);
-            DisplayOrientation? value = obj == null ? (DisplayOrientation?)null : (DisplayOrientation)obj;
-            return value;
-        }
+		/// <summary>
+		/// Set TimeZoneOffset field
+		/// Units: hr
+		/// Comment: timezone offset in 1/4 hour increments</summary>
+		/// <param name="index">0 based index of time_zone_offset</param>
+		/// <param name="timeZoneOffset_">Nullable field value to be set</param>
+		public void SetTimeZoneOffset(int index, float? timeZoneOffset_)
+		{
+			SetFieldValue(5, index, timeZoneOffset_, Fit.SubfieldIndexMainField);
+		}
 
-        /// <summary>
-        /// Set DisplayOrientation field</summary>
-        /// <param name="displayOrientation_">Nullable field value to be set</param>
-        public void SetDisplayOrientation(DisplayOrientation? displayOrientation_)
-        {
-            SetFieldValue(55, 0, displayOrientation_, Fit.SubfieldIndexMainField);
-        }
-        
-        ///<summary>
-        /// Retrieves the MountingSide field</summary>
-        /// <returns>Returns nullable Side enum representing the MountingSide field</returns>
-        public Side? GetMountingSide()
-        {
-            object obj = GetFieldValue(56, 0, Fit.SubfieldIndexMainField);
-            Side? value = obj == null ? (Side?)null : (Side)obj;
-            return value;
-        }
+		///<summary>
+		/// Retrieves the BacklightMode field
+		/// Comment: Mode for backlight</summary>
+		/// <returns>Returns nullable BacklightMode enum representing the BacklightMode field</returns>
+		public BacklightMode? BacklightMode
+		{
+			get
+			{
+				object obj = GetFieldValue(12, 0, Fit.SubfieldIndexMainField);
+				BacklightMode? value = obj == null ? (BacklightMode?)null : (BacklightMode)obj;
+				return value;
+			}
+			set
+			{
+				SetFieldValue(12, 0, value, Fit.SubfieldIndexMainField);
+			}
+		}
 
-        /// <summary>
-        /// Set MountingSide field</summary>
-        /// <param name="mountingSide_">Nullable field value to be set</param>
-        public void SetMountingSide(Side? mountingSide_)
-        {
-            SetFieldValue(56, 0, mountingSide_, Fit.SubfieldIndexMainField);
-        }
-        
-        
-        /// <summary>
-        ///
-        /// </summary>
-        /// <returns>returns number of elements in field DefaultPage</returns>
-        public int GetNumDefaultPage()
-        {
-            return GetNumFieldValues(57, Fit.SubfieldIndexMainField);
-        }
+		///<summary>
+		/// Retrieves the ActivityTrackerEnabled field
+		/// Comment: Enabled state of the activity tracker functionality</summary>
+		/// <returns>Returns nullable Bool enum representing the ActivityTrackerEnabled field</returns>
+		public Bool? ActivityTrackerEnabled
+		{
+			get
+			{
+				object obj = GetFieldValue(36, 0, Fit.SubfieldIndexMainField);
+				Bool? value = obj == null ? (Bool?)null : (Bool)obj;
+				return value;
+			}
+			set
+			{
+				SetFieldValue(36, 0, value, Fit.SubfieldIndexMainField);
+			}
+		}
 
-        ///<summary>
-        /// Retrieves the DefaultPage field
-        /// Comment: Bitfield to indicate one page as default for each supported loop</summary>
-        /// <param name="index">0 based index of DefaultPage element to retrieve</param>
-        /// <returns>Returns nullable ushort representing the DefaultPage field</returns>
-        public ushort? GetDefaultPage(int index)
-        {
-            Object val = GetFieldValue(57, index, Fit.SubfieldIndexMainField);
-            if(val == null)
-            {
-                return null;
-            }
+		///<summary>
+		/// Retrieves the ClockTime field
+		/// Comment: UTC timestamp used to set the devices clock and date</summary>
+		/// <returns>Returns DateTime representing the ClockTime field</returns>
+		public DateTime ClockTime
+		{
+			get
+			{
+				Object val = GetFieldValue(39, 0, Fit.SubfieldIndexMainField);
+				if (val == null)
+				{
+					return null;
+				}
 
-            return (Convert.ToUInt16(val));
-            
-        }
+				return TimestampToDateTime(Convert.ToUInt32(val));
 
-        /// <summary>
-        /// Set DefaultPage field
-        /// Comment: Bitfield to indicate one page as default for each supported loop</summary>
-        /// <param name="index">0 based index of default_page</param>
-        /// <param name="defaultPage_">Nullable field value to be set</param>
-        public void SetDefaultPage(int index, ushort? defaultPage_)
-        {
-            SetFieldValue(57, index, defaultPage_, Fit.SubfieldIndexMainField);
-        }
-        
-        ///<summary>
-        /// Retrieves the AutosyncMinSteps field
-        /// Units: steps
-        /// Comment: Minimum steps before an autosync can occur</summary>
-        /// <returns>Returns nullable ushort representing the AutosyncMinSteps field</returns>
-        public ushort? GetAutosyncMinSteps()
-        {
-            Object val = GetFieldValue(58, 0, Fit.SubfieldIndexMainField);
-            if(val == null)
-            {
-                return null;
-            }
+			}
+			set
+			{
+				SetFieldValue(39, 0, value.GetTimeStamp(), Fit.SubfieldIndexMainField);
+			}
+		}
 
-            return (Convert.ToUInt16(val));
-            
-        }
 
-        /// <summary>
-        /// Set AutosyncMinSteps field
-        /// Units: steps
-        /// Comment: Minimum steps before an autosync can occur</summary>
-        /// <param name="autosyncMinSteps_">Nullable field value to be set</param>
-        public void SetAutosyncMinSteps(ushort? autosyncMinSteps_)
-        {
-            SetFieldValue(58, 0, autosyncMinSteps_, Fit.SubfieldIndexMainField);
-        }
-        
-        ///<summary>
-        /// Retrieves the AutosyncMinTime field
-        /// Units: minutes
-        /// Comment: Minimum minutes before an autosync can occur</summary>
-        /// <returns>Returns nullable ushort representing the AutosyncMinTime field</returns>
-        public ushort? GetAutosyncMinTime()
-        {
-            Object val = GetFieldValue(59, 0, Fit.SubfieldIndexMainField);
-            if(val == null)
-            {
-                return null;
-            }
+		/// <summary>
+		///
+		/// </summary>
+		/// <returns>returns number of elements in field PagesEnabled</returns>
+		public int GetNumPagesEnabled()
+		{
+			return GetNumFieldValues(40, Fit.SubfieldIndexMainField);
+		}
 
-            return (Convert.ToUInt16(val));
-            
-        }
+		///<summary>
+		/// Retrieves the PagesEnabled field
+		/// Comment: Bitfield to configure enabled screens for each supported loop</summary>
+		/// <param name="index">0 based index of PagesEnabled element to retrieve</param>
+		/// <returns>Returns nullable ushort representing the PagesEnabled field</returns>
+		public ushort? GetPagesEnabled(int index)
+		{
+			Object val = GetFieldValue(40, index, Fit.SubfieldIndexMainField);
+			if (val == null)
+			{
+				return null;
+			}
 
-        /// <summary>
-        /// Set AutosyncMinTime field
-        /// Units: minutes
-        /// Comment: Minimum minutes before an autosync can occur</summary>
-        /// <param name="autosyncMinTime_">Nullable field value to be set</param>
-        public void SetAutosyncMinTime(ushort? autosyncMinTime_)
-        {
-            SetFieldValue(59, 0, autosyncMinTime_, Fit.SubfieldIndexMainField);
-        }
-        
-        ///<summary>
-        /// Retrieves the LactateThresholdAutodetectEnabled field
-        /// Comment: Enable auto-detect setting for the lactate threshold feature.</summary>
-        /// <returns>Returns nullable Bool enum representing the LactateThresholdAutodetectEnabled field</returns>
-        public Bool? GetLactateThresholdAutodetectEnabled()
-        {
-            object obj = GetFieldValue(80, 0, Fit.SubfieldIndexMainField);
-            Bool? value = obj == null ? (Bool?)null : (Bool)obj;
-            return value;
-        }
+			return (Convert.ToUInt16(val));
 
-        /// <summary>
-        /// Set LactateThresholdAutodetectEnabled field
-        /// Comment: Enable auto-detect setting for the lactate threshold feature.</summary>
-        /// <param name="lactateThresholdAutodetectEnabled_">Nullable field value to be set</param>
-        public void SetLactateThresholdAutodetectEnabled(Bool? lactateThresholdAutodetectEnabled_)
-        {
-            SetFieldValue(80, 0, lactateThresholdAutodetectEnabled_, Fit.SubfieldIndexMainField);
-        }
-        
-        ///<summary>
-        /// Retrieves the BleAutoUploadEnabled field
-        /// Comment: Automatically upload using BLE</summary>
-        /// <returns>Returns nullable Bool enum representing the BleAutoUploadEnabled field</returns>
-        public Bool? GetBleAutoUploadEnabled()
-        {
-            object obj = GetFieldValue(86, 0, Fit.SubfieldIndexMainField);
-            Bool? value = obj == null ? (Bool?)null : (Bool)obj;
-            return value;
-        }
+		}
 
-        /// <summary>
-        /// Set BleAutoUploadEnabled field
-        /// Comment: Automatically upload using BLE</summary>
-        /// <param name="bleAutoUploadEnabled_">Nullable field value to be set</param>
-        public void SetBleAutoUploadEnabled(Bool? bleAutoUploadEnabled_)
-        {
-            SetFieldValue(86, 0, bleAutoUploadEnabled_, Fit.SubfieldIndexMainField);
-        }
-        
-        ///<summary>
-        /// Retrieves the AutoSyncFrequency field
-        /// Comment: Helps to conserve battery by changing modes</summary>
-        /// <returns>Returns nullable AutoSyncFrequency enum representing the AutoSyncFrequency field</returns>
-        public AutoSyncFrequency? GetAutoSyncFrequency()
-        {
-            object obj = GetFieldValue(89, 0, Fit.SubfieldIndexMainField);
-            AutoSyncFrequency? value = obj == null ? (AutoSyncFrequency?)null : (AutoSyncFrequency)obj;
-            return value;
-        }
+		/// <summary>
+		/// Set PagesEnabled field
+		/// Comment: Bitfield to configure enabled screens for each supported loop</summary>
+		/// <param name="index">0 based index of pages_enabled</param>
+		/// <param name="pagesEnabled_">Nullable field value to be set</param>
+		public void SetPagesEnabled(int index, ushort? pagesEnabled_)
+		{
+			SetFieldValue(40, index, pagesEnabled_, Fit.SubfieldIndexMainField);
+		}
 
-        /// <summary>
-        /// Set AutoSyncFrequency field
-        /// Comment: Helps to conserve battery by changing modes</summary>
-        /// <param name="autoSyncFrequency_">Nullable field value to be set</param>
-        public void SetAutoSyncFrequency(AutoSyncFrequency? autoSyncFrequency_)
-        {
-            SetFieldValue(89, 0, autoSyncFrequency_, Fit.SubfieldIndexMainField);
-        }
-        
-        ///<summary>
-        /// Retrieves the AutoActivityDetect field
-        /// Comment: Allows setting specific activities auto-activity detect enabled/disabled settings</summary>
-        /// <returns>Returns nullable uint representing the AutoActivityDetect field</returns>
-        public uint? GetAutoActivityDetect()
-        {
-            Object val = GetFieldValue(90, 0, Fit.SubfieldIndexMainField);
-            if(val == null)
-            {
-                return null;
-            }
+		///<summary>
+		/// Retrieves the MoveAlertEnabled field
+		/// Comment: Enabled state of the move alert</summary>
+		/// <returns>Returns nullable Bool enum representing the MoveAlertEnabled field</returns>
+		public Bool? MoveAlertEnabled
+		{
+			get
+			{
+				object obj = GetFieldValue(46, 0, Fit.SubfieldIndexMainField);
+				Bool? value = obj == null ? (Bool?)null : (Bool)obj;
+				return value;
+			}
+			set
+			{
+				SetFieldValue(46, 0, value, Fit.SubfieldIndexMainField);
+			}
+		}
 
-            return (Convert.ToUInt32(val));
-            
-        }
+		///<summary>
+		/// Retrieves the DateMode field
+		/// Comment: Display mode for the date</summary>
+		/// <returns>Returns nullable DateMode enum representing the DateMode field</returns>
+		public DateMode? DateMode
+		{
+			get
+			{
+				object obj = GetFieldValue(47, 0, Fit.SubfieldIndexMainField);
+				DateMode? value = obj == null ? (DateMode?)null : (DateMode)obj;
+				return value;
+			}
+			set
+			{
+				SetFieldValue(47, 0, value, Fit.SubfieldIndexMainField);
+			}
+		}
 
-        /// <summary>
-        /// Set AutoActivityDetect field
-        /// Comment: Allows setting specific activities auto-activity detect enabled/disabled settings</summary>
-        /// <param name="autoActivityDetect_">Nullable field value to be set</param>
-        public void SetAutoActivityDetect(uint? autoActivityDetect_)
-        {
-            SetFieldValue(90, 0, autoActivityDetect_, Fit.SubfieldIndexMainField);
-        }
-        
-        ///<summary>
-        /// Retrieves the NumberOfScreens field
-        /// Comment: Number of screens configured to display</summary>
-        /// <returns>Returns nullable byte representing the NumberOfScreens field</returns>
-        public byte? GetNumberOfScreens()
-        {
-            Object val = GetFieldValue(94, 0, Fit.SubfieldIndexMainField);
-            if(val == null)
-            {
-                return null;
-            }
+		///<summary>
+		/// Retrieves the DisplayOrientation field</summary>
+		/// <returns>Returns nullable DisplayOrientation enum representing the DisplayOrientation field</returns>
+		public DisplayOrientation? DisplayOrientation
+		{
+			get
+			{
+				object obj = GetFieldValue(55, 0, Fit.SubfieldIndexMainField);
+				DisplayOrientation? value = obj == null ? (DisplayOrientation?)null : (DisplayOrientation)obj;
+				return value;
+			}
+			set
+			{
+				SetFieldValue(55, 0, value, Fit.SubfieldIndexMainField);
+			}
+		}
 
-            return (Convert.ToByte(val));
-            
-        }
+		///<summary>
+		/// Retrieves the MountingSide field</summary>
+		/// <returns>Returns nullable Side enum representing the MountingSide field</returns>
+		public Side? MountingSide
+		{
+			get
+			{
+				object obj = GetFieldValue(56, 0, Fit.SubfieldIndexMainField);
+				Side? value = obj == null ? (Side?)null : (Side)obj;
+				return value;
+			}
+			set
+			{
+				SetFieldValue(56, 0, value, Fit.SubfieldIndexMainField);
+			}
+		}
 
-        /// <summary>
-        /// Set NumberOfScreens field
-        /// Comment: Number of screens configured to display</summary>
-        /// <param name="numberOfScreens_">Nullable field value to be set</param>
-        public void SetNumberOfScreens(byte? numberOfScreens_)
-        {
-            SetFieldValue(94, 0, numberOfScreens_, Fit.SubfieldIndexMainField);
-        }
-        
-        ///<summary>
-        /// Retrieves the SmartNotificationDisplayOrientation field
-        /// Comment: Smart Notification display orientation</summary>
-        /// <returns>Returns nullable DisplayOrientation enum representing the SmartNotificationDisplayOrientation field</returns>
-        public DisplayOrientation? GetSmartNotificationDisplayOrientation()
-        {
-            object obj = GetFieldValue(95, 0, Fit.SubfieldIndexMainField);
-            DisplayOrientation? value = obj == null ? (DisplayOrientation?)null : (DisplayOrientation)obj;
-            return value;
-        }
 
-        /// <summary>
-        /// Set SmartNotificationDisplayOrientation field
-        /// Comment: Smart Notification display orientation</summary>
-        /// <param name="smartNotificationDisplayOrientation_">Nullable field value to be set</param>
-        public void SetSmartNotificationDisplayOrientation(DisplayOrientation? smartNotificationDisplayOrientation_)
-        {
-            SetFieldValue(95, 0, smartNotificationDisplayOrientation_, Fit.SubfieldIndexMainField);
-        }
-        
-        ///<summary>
-        /// Retrieves the TapInterface field</summary>
-        /// <returns>Returns nullable Switch enum representing the TapInterface field</returns>
-        public Switch? GetTapInterface()
-        {
-            object obj = GetFieldValue(134, 0, Fit.SubfieldIndexMainField);
-            Switch? value = obj == null ? (Switch?)null : (Switch)obj;
-            return value;
-        }
+		/// <summary>
+		///
+		/// </summary>
+		/// <returns>returns number of elements in field DefaultPage</returns>
+		public int GetNumDefaultPage()
+		{
+			return GetNumFieldValues(57, Fit.SubfieldIndexMainField);
+		}
 
-        /// <summary>
-        /// Set TapInterface field</summary>
-        /// <param name="tapInterface_">Nullable field value to be set</param>
-        public void SetTapInterface(Switch? tapInterface_)
-        {
-            SetFieldValue(134, 0, tapInterface_, Fit.SubfieldIndexMainField);
-        }
-        
-        ///<summary>
-        /// Retrieves the TapSensitivity field
-        /// Comment: Used to hold the tap threshold setting</summary>
-        /// <returns>Returns nullable TapSensitivity enum representing the TapSensitivity field</returns>
-        public TapSensitivity? GetTapSensitivity()
-        {
-            object obj = GetFieldValue(174, 0, Fit.SubfieldIndexMainField);
-            TapSensitivity? value = obj == null ? (TapSensitivity?)null : (TapSensitivity)obj;
-            return value;
-        }
+		///<summary>
+		/// Retrieves the DefaultPage field
+		/// Comment: Bitfield to indicate one page as default for each supported loop</summary>
+		/// <param name="index">0 based index of DefaultPage element to retrieve</param>
+		/// <returns>Returns nullable ushort representing the DefaultPage field</returns>
+		public ushort? GetDefaultPage(int index)
+		{
+			Object val = GetFieldValue(57, index, Fit.SubfieldIndexMainField);
+			if (val == null)
+			{
+				return null;
+			}
 
-        /// <summary>
-        /// Set TapSensitivity field
-        /// Comment: Used to hold the tap threshold setting</summary>
-        /// <param name="tapSensitivity_">Nullable field value to be set</param>
-        public void SetTapSensitivity(TapSensitivity? tapSensitivity_)
-        {
-            SetFieldValue(174, 0, tapSensitivity_, Fit.SubfieldIndexMainField);
-        }
-        
-        #endregion // Methods
-    } // Class
+			return (Convert.ToUInt16(val));
+
+		}
+
+		/// <summary>
+		/// Set DefaultPage field
+		/// Comment: Bitfield to indicate one page as default for each supported loop</summary>
+		/// <param name="index">0 based index of default_page</param>
+		/// <param name="defaultPage_">Nullable field value to be set</param>
+		public void SetDefaultPage(int index, ushort? defaultPage_)
+		{
+			SetFieldValue(57, index, defaultPage_, Fit.SubfieldIndexMainField);
+		}
+
+		///<summary>
+		/// Retrieves the AutosyncMinSteps field
+		/// Units: steps
+		/// Comment: Minimum steps before an autosync can occur</summary>
+		/// <returns>Returns nullable ushort representing the AutosyncMinSteps field</returns>
+		public ushort? AutosyncMinSteps
+		{
+			get
+			{
+				Object val = GetFieldValue(58, 0, Fit.SubfieldIndexMainField);
+				if (val == null)
+				{
+					return null;
+				}
+
+				return (Convert.ToUInt16(val));
+
+			}
+			set
+			{
+				SetFieldValue(58, 0, value, Fit.SubfieldIndexMainField);
+			}
+		}
+
+		///<summary>
+		/// Retrieves the AutosyncMinTime field
+		/// Units: minutes
+		/// Comment: Minimum minutes before an autosync can occur</summary>
+		/// <returns>Returns nullable ushort representing the AutosyncMinTime field</returns>
+		public ushort? AutosyncMinTime
+		{
+			get
+			{
+				Object val = GetFieldValue(59, 0, Fit.SubfieldIndexMainField);
+				if (val == null)
+				{
+					return null;
+				}
+
+				return (Convert.ToUInt16(val));
+
+			}
+			set
+			{
+				SetFieldValue(59, 0, value, Fit.SubfieldIndexMainField);
+			}
+		}
+
+		///<summary>
+		/// Retrieves the LactateThresholdAutodetectEnabled field
+		/// Comment: Enable auto-detect setting for the lactate threshold feature.</summary>
+		/// <returns>Returns nullable Bool enum representing the LactateThresholdAutodetectEnabled field</returns>
+		public Bool? LactateThresholdAutodetectEnabled
+		{
+			get
+			{
+				object obj = GetFieldValue(80, 0, Fit.SubfieldIndexMainField);
+				Bool? value = obj == null ? (Bool?)null : (Bool)obj;
+				return value;
+			}
+			set
+			{
+				SetFieldValue(80, 0, value, Fit.SubfieldIndexMainField);
+			}
+		}
+
+		///<summary>
+		/// Retrieves the BleAutoUploadEnabled field
+		/// Comment: Automatically upload using BLE</summary>
+		/// <returns>Returns nullable Bool enum representing the BleAutoUploadEnabled field</returns>
+		public Bool? BleAutoUploadEnabled
+		{
+			get
+			{
+				object obj = GetFieldValue(86, 0, Fit.SubfieldIndexMainField);
+				Bool? value = obj == null ? (Bool?)null : (Bool)obj;
+				return value;
+			}
+			set
+			{
+				SetFieldValue(86, 0, value, Fit.SubfieldIndexMainField);
+			}
+		}
+
+		///<summary>
+		/// Retrieves the AutoSyncFrequency field
+		/// Comment: Helps to conserve battery by changing modes</summary>
+		/// <returns>Returns nullable AutoSyncFrequency enum representing the AutoSyncFrequency field</returns>
+		public AutoSyncFrequency? AutoSyncFrequency
+		{
+			get
+			{
+				object obj = GetFieldValue(89, 0, Fit.SubfieldIndexMainField);
+				AutoSyncFrequency? value = obj == null ? (AutoSyncFrequency?)null : (AutoSyncFrequency)obj;
+				return value;
+			}
+			set
+			{
+				SetFieldValue(89, 0, value, Fit.SubfieldIndexMainField);
+			}
+		}
+
+		///<summary>
+		/// Retrieves the AutoActivityDetect field
+		/// Comment: Allows setting specific activities auto-activity detect enabled/disabled settings</summary>
+		/// <returns>Returns nullable uint representing the AutoActivityDetect field</returns>
+		public uint? AutoActivityDetect
+		{
+			get
+			{
+				Object val = GetFieldValue(90, 0, Fit.SubfieldIndexMainField);
+				if (val == null)
+				{
+					return null;
+				}
+
+				return (Convert.ToUInt32(val));
+
+			}
+			set
+			{
+				SetFieldValue(90, 0, value, Fit.SubfieldIndexMainField);
+			}
+		}
+
+		///<summary>
+		/// Retrieves the NumberOfScreens field
+		/// Comment: Number of screens configured to display</summary>
+		/// <returns>Returns nullable byte representing the NumberOfScreens field</returns>
+		public byte? NumberOfScreens
+		{
+			get
+			{
+				Object val = GetFieldValue(94, 0, Fit.SubfieldIndexMainField);
+				if (val == null)
+				{
+					return null;
+				}
+
+				return (Convert.ToByte(val));
+
+			}
+			set
+			{
+				SetFieldValue(94, 0, value, Fit.SubfieldIndexMainField);
+			}
+		}
+
+		///<summary>
+		/// Retrieves the SmartNotificationDisplayOrientation field
+		/// Comment: Smart Notification display orientation</summary>
+		/// <returns>Returns nullable DisplayOrientation enum representing the SmartNotificationDisplayOrientation field</returns>
+		public DisplayOrientation? SmartNotificationDisplayOrientation
+		{
+			get
+			{
+				object obj = GetFieldValue(95, 0, Fit.SubfieldIndexMainField);
+				DisplayOrientation? value = obj == null ? (DisplayOrientation?)null : (DisplayOrientation)obj;
+				return value;
+			}
+			set
+			{
+				SetFieldValue(95, 0, value, Fit.SubfieldIndexMainField);
+			}
+		}
+
+		///<summary>
+		/// Retrieves the TapInterface field</summary>
+		/// <returns>Returns nullable Switch enum representing the TapInterface field</returns>
+		public Switch? TapInterface
+		{
+			get
+			{
+				object obj = GetFieldValue(134, 0, Fit.SubfieldIndexMainField);
+				Switch? value = obj == null ? (Switch?)null : (Switch)obj;
+				return value;
+			}
+			set
+			{
+				SetFieldValue(134, 0, value, Fit.SubfieldIndexMainField);
+			}
+		}
+
+		///<summary>
+		/// Retrieves the TapSensitivity field
+		/// Comment: Used to hold the tap threshold setting</summary>
+		/// <returns>Returns nullable TapSensitivity enum representing the TapSensitivity field</returns>
+		public TapSensitivity? TapSensitivity
+		{
+			get
+			{
+				object obj = GetFieldValue(174, 0, Fit.SubfieldIndexMainField);
+				TapSensitivity? value = obj == null ? (TapSensitivity?)null : (TapSensitivity)obj;
+				return value;
+			}
+			set
+			{
+				SetFieldValue(174, 0, value, Fit.SubfieldIndexMainField);
+			}
+		}
+
+		#endregion // Methods
+	} // Class
 } // namespace

--- a/Dynastream/Fit/Profile/Mesgs/DiveAlarmMesg.cs
+++ b/Dynastream/Fit/Profile/Mesgs/DiveAlarmMesg.cs
@@ -21,349 +21,322 @@ using System.Linq;
 
 namespace Dynastream.Fit
 {
-    /// <summary>
-    /// Implements the DiveAlarm profile message.
-    /// </summary>
-    public class DiveAlarmMesg : Mesg
-    {
-        #region Fields
-        #endregion
+	/// <summary>
+	/// Implements the DiveAlarm profile message.
+	/// </summary>
+	public class DiveAlarmMesg : Mesg
+	{
+		#region Fields
+		#endregion
 
-        /// <summary>
-        /// Field Numbers for <see cref="DiveAlarmMesg"/>
-        /// </summary>
-        public sealed class FieldDefNum
-        {
-            public const byte MessageIndex = 254;
-            public const byte Depth = 0;
-            public const byte Time = 1;
-            public const byte Enabled = 2;
-            public const byte AlarmType = 3;
-            public const byte Sound = 4;
-            public const byte DiveTypes = 5;
-            public const byte Id = 6;
-            public const byte PopupEnabled = 7;
-            public const byte TriggerOnDescent = 8;
-            public const byte TriggerOnAscent = 9;
-            public const byte Repeating = 10;
-            public const byte Speed = 11;
-            public const byte Invalid = Fit.FieldNumInvalid;
-        }
+		/// <summary>
+		/// Field Numbers for <see cref="DiveAlarmMesg"/>
+		/// </summary>
+		public sealed class FieldDefNum
+		{
+			public const byte MessageIndex = 254;
+			public const byte Depth = 0;
+			public const byte Time = 1;
+			public const byte Enabled = 2;
+			public const byte AlarmType = 3;
+			public const byte Sound = 4;
+			public const byte DiveTypes = 5;
+			public const byte Id = 6;
+			public const byte PopupEnabled = 7;
+			public const byte TriggerOnDescent = 8;
+			public const byte TriggerOnAscent = 9;
+			public const byte Repeating = 10;
+			public const byte Speed = 11;
+			public const byte Invalid = Fit.FieldNumInvalid;
+		}
 
-        #region Constructors
-        public DiveAlarmMesg() : base(Profile.GetMesg(MesgNum.DiveAlarm))
-        {
-        }
+		#region Constructors
+		public DiveAlarmMesg() : base(Profile.GetMesg(MesgNum.DiveAlarm))
+		{
+		}
 
-        public DiveAlarmMesg(Mesg mesg) : base(mesg)
-        {
-        }
-        #endregion // Constructors
+		public DiveAlarmMesg(Mesg mesg) : base(mesg)
+		{
+		}
+		#endregion // Constructors
 
-        #region Methods
-        ///<summary>
-        /// Retrieves the MessageIndex field
-        /// Comment: Index of the alarm</summary>
-        /// <returns>Returns nullable ushort representing the MessageIndex field</returns>
-        public ushort? GetMessageIndex()
-        {
-            Object val = GetFieldValue(254, 0, Fit.SubfieldIndexMainField);
-            if(val == null)
-            {
-                return null;
-            }
+		#region Methods
+		///<summary>
+		/// Retrieves the MessageIndex field
+		/// Comment: Index of the alarm</summary>
+		/// <returns>Returns nullable ushort representing the MessageIndex field</returns>
+		public ushort? MessageIndex
+		{
+			get
+			{
+				Object val = GetFieldValue(254, 0, Fit.SubfieldIndexMainField);
+				if (val == null)
+				{
+					return null;
+				}
 
-            return (Convert.ToUInt16(val));
-            
-        }
+				return (Convert.ToUInt16(val));
 
-        /// <summary>
-        /// Set MessageIndex field
-        /// Comment: Index of the alarm</summary>
-        /// <param name="messageIndex_">Nullable field value to be set</param>
-        public void SetMessageIndex(ushort? messageIndex_)
-        {
-            SetFieldValue(254, 0, messageIndex_, Fit.SubfieldIndexMainField);
-        }
-        
-        ///<summary>
-        /// Retrieves the Depth field
-        /// Units: m
-        /// Comment: Depth setting (m) for depth type alarms</summary>
-        /// <returns>Returns nullable float representing the Depth field</returns>
-        public float? GetDepth()
-        {
-            Object val = GetFieldValue(0, 0, Fit.SubfieldIndexMainField);
-            if(val == null)
-            {
-                return null;
-            }
+			}
+			set
+			{
+				SetFieldValue(254, 0, value, Fit.SubfieldIndexMainField);
+			}
+		}
 
-            return (Convert.ToSingle(val));
-            
-        }
+		///<summary>
+		/// Retrieves the Depth field
+		/// Units: m
+		/// Comment: Depth setting (m) for depth type alarms</summary>
+		/// <returns>Returns nullable float representing the Depth field</returns>
+		public float? Depth
+		{
+			get
+			{
+				Object val = GetFieldValue(0, 0, Fit.SubfieldIndexMainField);
+				if (val == null)
+				{
+					return null;
+				}
 
-        /// <summary>
-        /// Set Depth field
-        /// Units: m
-        /// Comment: Depth setting (m) for depth type alarms</summary>
-        /// <param name="depth_">Nullable field value to be set</param>
-        public void SetDepth(float? depth_)
-        {
-            SetFieldValue(0, 0, depth_, Fit.SubfieldIndexMainField);
-        }
-        
-        ///<summary>
-        /// Retrieves the Time field
-        /// Units: s
-        /// Comment: Time setting (s) for time type alarms</summary>
-        /// <returns>Returns nullable int representing the Time field</returns>
-        public int? GetTime()
-        {
-            Object val = GetFieldValue(1, 0, Fit.SubfieldIndexMainField);
-            if(val == null)
-            {
-                return null;
-            }
+				return (Convert.ToSingle(val));
 
-            return (Convert.ToInt32(val));
-            
-        }
+			}
+			set
+			{
+				SetFieldValue(0, 0, value, Fit.SubfieldIndexMainField);
+			}
+		}
 
-        /// <summary>
-        /// Set Time field
-        /// Units: s
-        /// Comment: Time setting (s) for time type alarms</summary>
-        /// <param name="time_">Nullable field value to be set</param>
-        public void SetTime(int? time_)
-        {
-            SetFieldValue(1, 0, time_, Fit.SubfieldIndexMainField);
-        }
-        
-        ///<summary>
-        /// Retrieves the Enabled field
-        /// Comment: Enablement flag</summary>
-        /// <returns>Returns nullable Bool enum representing the Enabled field</returns>
-        public Bool? GetEnabled()
-        {
-            object obj = GetFieldValue(2, 0, Fit.SubfieldIndexMainField);
-            Bool? value = obj == null ? (Bool?)null : (Bool)obj;
-            return value;
-        }
+		///<summary>
+		/// Retrieves the Time field
+		/// Units: s
+		/// Comment: Time setting (s) for time type alarms</summary>
+		/// <returns>Returns nullable int representing the Time field</returns>
+		public int? Time
+		{
+			get
+			{
+				Object val = GetFieldValue(1, 0, Fit.SubfieldIndexMainField);
+				if (val == null)
+				{
+					return null;
+				}
 
-        /// <summary>
-        /// Set Enabled field
-        /// Comment: Enablement flag</summary>
-        /// <param name="enabled_">Nullable field value to be set</param>
-        public void SetEnabled(Bool? enabled_)
-        {
-            SetFieldValue(2, 0, enabled_, Fit.SubfieldIndexMainField);
-        }
-        
-        ///<summary>
-        /// Retrieves the AlarmType field
-        /// Comment: Alarm type setting</summary>
-        /// <returns>Returns nullable DiveAlarmType enum representing the AlarmType field</returns>
-        public DiveAlarmType? GetAlarmType()
-        {
-            object obj = GetFieldValue(3, 0, Fit.SubfieldIndexMainField);
-            DiveAlarmType? value = obj == null ? (DiveAlarmType?)null : (DiveAlarmType)obj;
-            return value;
-        }
+				return (Convert.ToInt32(val));
 
-        /// <summary>
-        /// Set AlarmType field
-        /// Comment: Alarm type setting</summary>
-        /// <param name="alarmType_">Nullable field value to be set</param>
-        public void SetAlarmType(DiveAlarmType? alarmType_)
-        {
-            SetFieldValue(3, 0, alarmType_, Fit.SubfieldIndexMainField);
-        }
-        
-        ///<summary>
-        /// Retrieves the Sound field
-        /// Comment: Tone and Vibe setting for the alarm</summary>
-        /// <returns>Returns nullable Tone enum representing the Sound field</returns>
-        public Tone? GetSound()
-        {
-            object obj = GetFieldValue(4, 0, Fit.SubfieldIndexMainField);
-            Tone? value = obj == null ? (Tone?)null : (Tone)obj;
-            return value;
-        }
+			}
+			set
+			{
+				SetFieldValue(1, 0, value, Fit.SubfieldIndexMainField);
+			}
+		}
 
-        /// <summary>
-        /// Set Sound field
-        /// Comment: Tone and Vibe setting for the alarm</summary>
-        /// <param name="sound_">Nullable field value to be set</param>
-        public void SetSound(Tone? sound_)
-        {
-            SetFieldValue(4, 0, sound_, Fit.SubfieldIndexMainField);
-        }
-        
-        
-        /// <summary>
-        ///
-        /// </summary>
-        /// <returns>returns number of elements in field DiveTypes</returns>
-        public int GetNumDiveTypes()
-        {
-            return GetNumFieldValues(5, Fit.SubfieldIndexMainField);
-        }
+		///<summary>
+		/// Retrieves the Enabled field
+		/// Comment: Enablement flag</summary>
+		/// <returns>Returns nullable Bool enum representing the Enabled field</returns>
+		public Bool? Enabled
+		{
+			get
+			{
+				object obj = GetFieldValue(2, 0, Fit.SubfieldIndexMainField);
+				Bool? value = obj == null ? (Bool?)null : (Bool)obj;
+				return value;
+			}
+			set
+			{
+				SetFieldValue(2, 0, value, Fit.SubfieldIndexMainField);
+			}
+		}
 
-        ///<summary>
-        /// Retrieves the DiveTypes field
-        /// Comment: Dive types the alarm will trigger on</summary>
-        /// <param name="index">0 based index of DiveTypes element to retrieve</param>
-        /// <returns>Returns nullable SubSport enum representing the DiveTypes field</returns>
-        public SubSport? GetDiveTypes(int index)
-        {
-            object obj = GetFieldValue(5, index, Fit.SubfieldIndexMainField);
-            SubSport? value = obj == null ? (SubSport?)null : (SubSport)obj;
-            return value;
-        }
+		///<summary>
+		/// Retrieves the AlarmType field
+		/// Comment: Alarm type setting</summary>
+		/// <returns>Returns nullable DiveAlarmType enum representing the AlarmType field</returns>
+		public DiveAlarmType? AlarmType
+		{
+			get
+			{
+				object obj = GetFieldValue(3, 0, Fit.SubfieldIndexMainField);
+				DiveAlarmType? value = obj == null ? (DiveAlarmType?)null : (DiveAlarmType)obj;
+				return value;
+			}
+			set
+			{
+				SetFieldValue(3, 0, value, Fit.SubfieldIndexMainField);
+			}
+		}
 
-        /// <summary>
-        /// Set DiveTypes field
-        /// Comment: Dive types the alarm will trigger on</summary>
-        /// <param name="index">0 based index of dive_types</param>
-        /// <param name="diveTypes_">Nullable field value to be set</param>
-        public void SetDiveTypes(int index, SubSport? diveTypes_)
-        {
-            SetFieldValue(5, index, diveTypes_, Fit.SubfieldIndexMainField);
-        }
-        
-        ///<summary>
-        /// Retrieves the Id field
-        /// Comment: Alarm ID</summary>
-        /// <returns>Returns nullable uint representing the Id field</returns>
-        public uint? GetId()
-        {
-            Object val = GetFieldValue(6, 0, Fit.SubfieldIndexMainField);
-            if(val == null)
-            {
-                return null;
-            }
+		///<summary>
+		/// Retrieves the Sound field
+		/// Comment: Tone and Vibe setting for the alarm</summary>
+		/// <returns>Returns nullable Tone enum representing the Sound field</returns>
+		public Tone? Sound
+		{
+			get
+			{
+				object obj = GetFieldValue(4, 0, Fit.SubfieldIndexMainField);
+				Tone? value = obj == null ? (Tone?)null : (Tone)obj;
+				return value;
+			}
+			set
+			{
+				SetFieldValue(4, 0, value, Fit.SubfieldIndexMainField);
+			}
+		}
 
-            return (Convert.ToUInt32(val));
-            
-        }
 
-        /// <summary>
-        /// Set Id field
-        /// Comment: Alarm ID</summary>
-        /// <param name="id_">Nullable field value to be set</param>
-        public void SetId(uint? id_)
-        {
-            SetFieldValue(6, 0, id_, Fit.SubfieldIndexMainField);
-        }
-        
-        ///<summary>
-        /// Retrieves the PopupEnabled field
-        /// Comment: Show a visible pop-up for this alarm</summary>
-        /// <returns>Returns nullable Bool enum representing the PopupEnabled field</returns>
-        public Bool? GetPopupEnabled()
-        {
-            object obj = GetFieldValue(7, 0, Fit.SubfieldIndexMainField);
-            Bool? value = obj == null ? (Bool?)null : (Bool)obj;
-            return value;
-        }
+		/// <summary>
+		///
+		/// </summary>
+		/// <returns>returns number of elements in field DiveTypes</returns>
+		public int GetNumDiveTypes()
+		{
+			return GetNumFieldValues(5, Fit.SubfieldIndexMainField);
+		}
 
-        /// <summary>
-        /// Set PopupEnabled field
-        /// Comment: Show a visible pop-up for this alarm</summary>
-        /// <param name="popupEnabled_">Nullable field value to be set</param>
-        public void SetPopupEnabled(Bool? popupEnabled_)
-        {
-            SetFieldValue(7, 0, popupEnabled_, Fit.SubfieldIndexMainField);
-        }
-        
-        ///<summary>
-        /// Retrieves the TriggerOnDescent field
-        /// Comment: Trigger the alarm on descent</summary>
-        /// <returns>Returns nullable Bool enum representing the TriggerOnDescent field</returns>
-        public Bool? GetTriggerOnDescent()
-        {
-            object obj = GetFieldValue(8, 0, Fit.SubfieldIndexMainField);
-            Bool? value = obj == null ? (Bool?)null : (Bool)obj;
-            return value;
-        }
+		///<summary>
+		/// Retrieves the DiveTypes field
+		/// Comment: Dive types the alarm will trigger on</summary>
+		/// <param name="index">0 based index of DiveTypes element to retrieve</param>
+		/// <returns>Returns nullable SubSport enum representing the DiveTypes field</returns>
+		public SubSport? GetDiveTypes(int index)
+		{
+			object obj = GetFieldValue(5, index, Fit.SubfieldIndexMainField);
+			SubSport? value = obj == null ? (SubSport?)null : (SubSport)obj;
+			return value;
+		}
 
-        /// <summary>
-        /// Set TriggerOnDescent field
-        /// Comment: Trigger the alarm on descent</summary>
-        /// <param name="triggerOnDescent_">Nullable field value to be set</param>
-        public void SetTriggerOnDescent(Bool? triggerOnDescent_)
-        {
-            SetFieldValue(8, 0, triggerOnDescent_, Fit.SubfieldIndexMainField);
-        }
-        
-        ///<summary>
-        /// Retrieves the TriggerOnAscent field
-        /// Comment: Trigger the alarm on ascent</summary>
-        /// <returns>Returns nullable Bool enum representing the TriggerOnAscent field</returns>
-        public Bool? GetTriggerOnAscent()
-        {
-            object obj = GetFieldValue(9, 0, Fit.SubfieldIndexMainField);
-            Bool? value = obj == null ? (Bool?)null : (Bool)obj;
-            return value;
-        }
+		/// <summary>
+		/// Set DiveTypes field
+		/// Comment: Dive types the alarm will trigger on</summary>
+		/// <param name="index">0 based index of dive_types</param>
+		/// <param name="diveTypes_">Nullable field value to be set</param>
+		public void SetDiveTypes(int index, SubSport? diveTypes_)
+		{
+			SetFieldValue(5, index, diveTypes_, Fit.SubfieldIndexMainField);
+		}
 
-        /// <summary>
-        /// Set TriggerOnAscent field
-        /// Comment: Trigger the alarm on ascent</summary>
-        /// <param name="triggerOnAscent_">Nullable field value to be set</param>
-        public void SetTriggerOnAscent(Bool? triggerOnAscent_)
-        {
-            SetFieldValue(9, 0, triggerOnAscent_, Fit.SubfieldIndexMainField);
-        }
-        
-        ///<summary>
-        /// Retrieves the Repeating field
-        /// Comment: Repeat alarm each time threshold is crossed?</summary>
-        /// <returns>Returns nullable Bool enum representing the Repeating field</returns>
-        public Bool? GetRepeating()
-        {
-            object obj = GetFieldValue(10, 0, Fit.SubfieldIndexMainField);
-            Bool? value = obj == null ? (Bool?)null : (Bool)obj;
-            return value;
-        }
+		///<summary>
+		/// Retrieves the Id field
+		/// Comment: Alarm ID</summary>
+		/// <returns>Returns nullable uint representing the Id field</returns>
+		public uint? Id
+		{
+			get
+			{
+				Object val = GetFieldValue(6, 0, Fit.SubfieldIndexMainField);
+				if (val == null)
+				{
+					return null;
+				}
 
-        /// <summary>
-        /// Set Repeating field
-        /// Comment: Repeat alarm each time threshold is crossed?</summary>
-        /// <param name="repeating_">Nullable field value to be set</param>
-        public void SetRepeating(Bool? repeating_)
-        {
-            SetFieldValue(10, 0, repeating_, Fit.SubfieldIndexMainField);
-        }
-        
-        ///<summary>
-        /// Retrieves the Speed field
-        /// Units: mps
-        /// Comment: Ascent/descent rate (mps) setting for speed type alarms</summary>
-        /// <returns>Returns nullable float representing the Speed field</returns>
-        public float? GetSpeed()
-        {
-            Object val = GetFieldValue(11, 0, Fit.SubfieldIndexMainField);
-            if(val == null)
-            {
-                return null;
-            }
+				return (Convert.ToUInt32(val));
 
-            return (Convert.ToSingle(val));
-            
-        }
+			}
+			set
+			{
+				SetFieldValue(6, 0, value, Fit.SubfieldIndexMainField);
+			}
+		}
 
-        /// <summary>
-        /// Set Speed field
-        /// Units: mps
-        /// Comment: Ascent/descent rate (mps) setting for speed type alarms</summary>
-        /// <param name="speed_">Nullable field value to be set</param>
-        public void SetSpeed(float? speed_)
-        {
-            SetFieldValue(11, 0, speed_, Fit.SubfieldIndexMainField);
-        }
-        
-        #endregion // Methods
-    } // Class
+		///<summary>
+		/// Retrieves the PopupEnabled field
+		/// Comment: Show a visible pop-up for this alarm</summary>
+		/// <returns>Returns nullable Bool enum representing the PopupEnabled field</returns>
+		public Bool? PopupEnabled
+		{
+			get
+			{
+				object obj = GetFieldValue(7, 0, Fit.SubfieldIndexMainField);
+				Bool? value = obj == null ? (Bool?)null : (Bool)obj;
+				return value;
+			}
+			set
+			{
+				SetFieldValue(7, 0, value, Fit.SubfieldIndexMainField);
+			}
+		}
+
+		///<summary>
+		/// Retrieves the TriggerOnDescent field
+		/// Comment: Trigger the alarm on descent</summary>
+		/// <returns>Returns nullable Bool enum representing the TriggerOnDescent field</returns>
+		public Bool? TriggerOnDescent
+		{
+			get
+			{
+				object obj = GetFieldValue(8, 0, Fit.SubfieldIndexMainField);
+				Bool? value = obj == null ? (Bool?)null : (Bool)obj;
+				return value;
+			}
+			set
+			{
+				SetFieldValue(8, 0, value, Fit.SubfieldIndexMainField);
+			}
+		}
+
+		///<summary>
+		/// Retrieves the TriggerOnAscent field
+		/// Comment: Trigger the alarm on ascent</summary>
+		/// <returns>Returns nullable Bool enum representing the TriggerOnAscent field</returns>
+		public Bool? TriggerOnAscent
+		{
+			get
+			{
+				object obj = GetFieldValue(9, 0, Fit.SubfieldIndexMainField);
+				Bool? value = obj == null ? (Bool?)null : (Bool)obj;
+				return value;
+			}
+			set
+			{
+				SetFieldValue(9, 0, value, Fit.SubfieldIndexMainField);
+			}
+		}
+
+		///<summary>
+		/// Retrieves the Repeating field
+		/// Comment: Repeat alarm each time threshold is crossed?</summary>
+		/// <returns>Returns nullable Bool enum representing the Repeating field</returns>
+		public Bool? Repeating
+		{
+			get
+			{
+				object obj = GetFieldValue(10, 0, Fit.SubfieldIndexMainField);
+				Bool? value = obj == null ? (Bool?)null : (Bool)obj;
+				return value;
+			}
+			set
+			{
+				SetFieldValue(10, 0, value, Fit.SubfieldIndexMainField);
+			}
+		}
+
+		///<summary>
+		/// Retrieves the Speed field
+		/// Units: mps
+		/// Comment: Ascent/descent rate (mps) setting for speed type alarms</summary>
+		/// <returns>Returns nullable float representing the Speed field</returns>
+		public float? Speed
+		{
+			get
+			{
+				Object val = GetFieldValue(11, 0, Fit.SubfieldIndexMainField);
+				if (val == null)
+				{
+					return null;
+				}
+
+				return (Convert.ToSingle(val));
+
+			}
+			set
+			{
+				SetFieldValue(11, 0, value, Fit.SubfieldIndexMainField);
+			}
+		}
+
+		#endregion // Methods
+	} // Class
 } // namespace

--- a/Dynastream/Fit/Profile/Mesgs/DiveApneaAlarmMesg.cs
+++ b/Dynastream/Fit/Profile/Mesgs/DiveApneaAlarmMesg.cs
@@ -21,349 +21,322 @@ using System.Linq;
 
 namespace Dynastream.Fit
 {
-    /// <summary>
-    /// Implements the DiveApneaAlarm profile message.
-    /// </summary>
-    public class DiveApneaAlarmMesg : Mesg
-    {
-        #region Fields
-        #endregion
+	/// <summary>
+	/// Implements the DiveApneaAlarm profile message.
+	/// </summary>
+	public class DiveApneaAlarmMesg : Mesg
+	{
+		#region Fields
+		#endregion
 
-        /// <summary>
-        /// Field Numbers for <see cref="DiveApneaAlarmMesg"/>
-        /// </summary>
-        public sealed class FieldDefNum
-        {
-            public const byte MessageIndex = 254;
-            public const byte Depth = 0;
-            public const byte Time = 1;
-            public const byte Enabled = 2;
-            public const byte AlarmType = 3;
-            public const byte Sound = 4;
-            public const byte DiveTypes = 5;
-            public const byte Id = 6;
-            public const byte PopupEnabled = 7;
-            public const byte TriggerOnDescent = 8;
-            public const byte TriggerOnAscent = 9;
-            public const byte Repeating = 10;
-            public const byte Speed = 11;
-            public const byte Invalid = Fit.FieldNumInvalid;
-        }
+		/// <summary>
+		/// Field Numbers for <see cref="DiveApneaAlarmMesg"/>
+		/// </summary>
+		public sealed class FieldDefNum
+		{
+			public const byte MessageIndex = 254;
+			public const byte Depth = 0;
+			public const byte Time = 1;
+			public const byte Enabled = 2;
+			public const byte AlarmType = 3;
+			public const byte Sound = 4;
+			public const byte DiveTypes = 5;
+			public const byte Id = 6;
+			public const byte PopupEnabled = 7;
+			public const byte TriggerOnDescent = 8;
+			public const byte TriggerOnAscent = 9;
+			public const byte Repeating = 10;
+			public const byte Speed = 11;
+			public const byte Invalid = Fit.FieldNumInvalid;
+		}
 
-        #region Constructors
-        public DiveApneaAlarmMesg() : base(Profile.GetMesg(MesgNum.DiveApneaAlarm))
-        {
-        }
+		#region Constructors
+		public DiveApneaAlarmMesg() : base(Profile.GetMesg(MesgNum.DiveApneaAlarm))
+		{
+		}
 
-        public DiveApneaAlarmMesg(Mesg mesg) : base(mesg)
-        {
-        }
-        #endregion // Constructors
+		public DiveApneaAlarmMesg(Mesg mesg) : base(mesg)
+		{
+		}
+		#endregion // Constructors
 
-        #region Methods
-        ///<summary>
-        /// Retrieves the MessageIndex field
-        /// Comment: Index of the alarm</summary>
-        /// <returns>Returns nullable ushort representing the MessageIndex field</returns>
-        public ushort? GetMessageIndex()
-        {
-            Object val = GetFieldValue(254, 0, Fit.SubfieldIndexMainField);
-            if(val == null)
-            {
-                return null;
-            }
+		#region Methods
+		///<summary>
+		/// Retrieves the MessageIndex field
+		/// Comment: Index of the alarm</summary>
+		/// <returns>Returns nullable ushort representing the MessageIndex field</returns>
+		public ushort? MessageIndex
+		{
+			get
+			{
+				Object val = GetFieldValue(254, 0, Fit.SubfieldIndexMainField);
+				if (val == null)
+				{
+					return null;
+				}
 
-            return (Convert.ToUInt16(val));
-            
-        }
+				return (Convert.ToUInt16(val));
 
-        /// <summary>
-        /// Set MessageIndex field
-        /// Comment: Index of the alarm</summary>
-        /// <param name="messageIndex_">Nullable field value to be set</param>
-        public void SetMessageIndex(ushort? messageIndex_)
-        {
-            SetFieldValue(254, 0, messageIndex_, Fit.SubfieldIndexMainField);
-        }
-        
-        ///<summary>
-        /// Retrieves the Depth field
-        /// Units: m
-        /// Comment: Depth setting (m) for depth type alarms</summary>
-        /// <returns>Returns nullable float representing the Depth field</returns>
-        public float? GetDepth()
-        {
-            Object val = GetFieldValue(0, 0, Fit.SubfieldIndexMainField);
-            if(val == null)
-            {
-                return null;
-            }
+			}
+			set
+			{
+				SetFieldValue(254, 0, value, Fit.SubfieldIndexMainField);
+			}
+		}
 
-            return (Convert.ToSingle(val));
-            
-        }
+		///<summary>
+		/// Retrieves the Depth field
+		/// Units: m
+		/// Comment: Depth setting (m) for depth type alarms</summary>
+		/// <returns>Returns nullable float representing the Depth field</returns>
+		public float? Depth
+		{
+			get
+			{
+				Object val = GetFieldValue(0, 0, Fit.SubfieldIndexMainField);
+				if (val == null)
+				{
+					return null;
+				}
 
-        /// <summary>
-        /// Set Depth field
-        /// Units: m
-        /// Comment: Depth setting (m) for depth type alarms</summary>
-        /// <param name="depth_">Nullable field value to be set</param>
-        public void SetDepth(float? depth_)
-        {
-            SetFieldValue(0, 0, depth_, Fit.SubfieldIndexMainField);
-        }
-        
-        ///<summary>
-        /// Retrieves the Time field
-        /// Units: s
-        /// Comment: Time setting (s) for time type alarms</summary>
-        /// <returns>Returns nullable int representing the Time field</returns>
-        public int? GetTime()
-        {
-            Object val = GetFieldValue(1, 0, Fit.SubfieldIndexMainField);
-            if(val == null)
-            {
-                return null;
-            }
+				return (Convert.ToSingle(val));
 
-            return (Convert.ToInt32(val));
-            
-        }
+			}
+			set
+			{
+				SetFieldValue(0, 0, value, Fit.SubfieldIndexMainField);
+			}
+		}
 
-        /// <summary>
-        /// Set Time field
-        /// Units: s
-        /// Comment: Time setting (s) for time type alarms</summary>
-        /// <param name="time_">Nullable field value to be set</param>
-        public void SetTime(int? time_)
-        {
-            SetFieldValue(1, 0, time_, Fit.SubfieldIndexMainField);
-        }
-        
-        ///<summary>
-        /// Retrieves the Enabled field
-        /// Comment: Enablement flag</summary>
-        /// <returns>Returns nullable Bool enum representing the Enabled field</returns>
-        public Bool? GetEnabled()
-        {
-            object obj = GetFieldValue(2, 0, Fit.SubfieldIndexMainField);
-            Bool? value = obj == null ? (Bool?)null : (Bool)obj;
-            return value;
-        }
+		///<summary>
+		/// Retrieves the Time field
+		/// Units: s
+		/// Comment: Time setting (s) for time type alarms</summary>
+		/// <returns>Returns nullable int representing the Time field</returns>
+		public int? Time
+		{
+			get
+			{
+				Object val = GetFieldValue(1, 0, Fit.SubfieldIndexMainField);
+				if (val == null)
+				{
+					return null;
+				}
 
-        /// <summary>
-        /// Set Enabled field
-        /// Comment: Enablement flag</summary>
-        /// <param name="enabled_">Nullable field value to be set</param>
-        public void SetEnabled(Bool? enabled_)
-        {
-            SetFieldValue(2, 0, enabled_, Fit.SubfieldIndexMainField);
-        }
-        
-        ///<summary>
-        /// Retrieves the AlarmType field
-        /// Comment: Alarm type setting</summary>
-        /// <returns>Returns nullable DiveAlarmType enum representing the AlarmType field</returns>
-        public DiveAlarmType? GetAlarmType()
-        {
-            object obj = GetFieldValue(3, 0, Fit.SubfieldIndexMainField);
-            DiveAlarmType? value = obj == null ? (DiveAlarmType?)null : (DiveAlarmType)obj;
-            return value;
-        }
+				return (Convert.ToInt32(val));
 
-        /// <summary>
-        /// Set AlarmType field
-        /// Comment: Alarm type setting</summary>
-        /// <param name="alarmType_">Nullable field value to be set</param>
-        public void SetAlarmType(DiveAlarmType? alarmType_)
-        {
-            SetFieldValue(3, 0, alarmType_, Fit.SubfieldIndexMainField);
-        }
-        
-        ///<summary>
-        /// Retrieves the Sound field
-        /// Comment: Tone and Vibe setting for the alarm.</summary>
-        /// <returns>Returns nullable Tone enum representing the Sound field</returns>
-        public Tone? GetSound()
-        {
-            object obj = GetFieldValue(4, 0, Fit.SubfieldIndexMainField);
-            Tone? value = obj == null ? (Tone?)null : (Tone)obj;
-            return value;
-        }
+			}
+			set
+			{
+				SetFieldValue(1, 0, value, Fit.SubfieldIndexMainField);
+			}
+		}
 
-        /// <summary>
-        /// Set Sound field
-        /// Comment: Tone and Vibe setting for the alarm.</summary>
-        /// <param name="sound_">Nullable field value to be set</param>
-        public void SetSound(Tone? sound_)
-        {
-            SetFieldValue(4, 0, sound_, Fit.SubfieldIndexMainField);
-        }
-        
-        
-        /// <summary>
-        ///
-        /// </summary>
-        /// <returns>returns number of elements in field DiveTypes</returns>
-        public int GetNumDiveTypes()
-        {
-            return GetNumFieldValues(5, Fit.SubfieldIndexMainField);
-        }
+		///<summary>
+		/// Retrieves the Enabled field
+		/// Comment: Enablement flag</summary>
+		/// <returns>Returns nullable Bool enum representing the Enabled field</returns>
+		public Bool? Enabled
+		{
+			get
+			{
+				object obj = GetFieldValue(2, 0, Fit.SubfieldIndexMainField);
+				Bool? value = obj == null ? (Bool?)null : (Bool)obj;
+				return value;
+			}
+			set
+			{
+				SetFieldValue(2, 0, value, Fit.SubfieldIndexMainField);
+			}
+		}
 
-        ///<summary>
-        /// Retrieves the DiveTypes field
-        /// Comment: Dive types the alarm will trigger on</summary>
-        /// <param name="index">0 based index of DiveTypes element to retrieve</param>
-        /// <returns>Returns nullable SubSport enum representing the DiveTypes field</returns>
-        public SubSport? GetDiveTypes(int index)
-        {
-            object obj = GetFieldValue(5, index, Fit.SubfieldIndexMainField);
-            SubSport? value = obj == null ? (SubSport?)null : (SubSport)obj;
-            return value;
-        }
+		///<summary>
+		/// Retrieves the AlarmType field
+		/// Comment: Alarm type setting</summary>
+		/// <returns>Returns nullable DiveAlarmType enum representing the AlarmType field</returns>
+		public DiveAlarmType? AlarmType
+		{
+			get
+			{
+				object obj = GetFieldValue(3, 0, Fit.SubfieldIndexMainField);
+				DiveAlarmType? value = obj == null ? (DiveAlarmType?)null : (DiveAlarmType)obj;
+				return value;
+			}
+			set
+			{
+				SetFieldValue(3, 0, value, Fit.SubfieldIndexMainField);
+			}
+		}
 
-        /// <summary>
-        /// Set DiveTypes field
-        /// Comment: Dive types the alarm will trigger on</summary>
-        /// <param name="index">0 based index of dive_types</param>
-        /// <param name="diveTypes_">Nullable field value to be set</param>
-        public void SetDiveTypes(int index, SubSport? diveTypes_)
-        {
-            SetFieldValue(5, index, diveTypes_, Fit.SubfieldIndexMainField);
-        }
-        
-        ///<summary>
-        /// Retrieves the Id field
-        /// Comment: Alarm ID</summary>
-        /// <returns>Returns nullable uint representing the Id field</returns>
-        public uint? GetId()
-        {
-            Object val = GetFieldValue(6, 0, Fit.SubfieldIndexMainField);
-            if(val == null)
-            {
-                return null;
-            }
+		///<summary>
+		/// Retrieves the Sound field
+		/// Comment: Tone and Vibe setting for the alarm.</summary>
+		/// <returns>Returns nullable Tone enum representing the Sound field</returns>
+		public Tone? Sound
+		{
+			get
+			{
+				object obj = GetFieldValue(4, 0, Fit.SubfieldIndexMainField);
+				Tone? value = obj == null ? (Tone?)null : (Tone)obj;
+				return value;
+			}
+			set
+			{
+				SetFieldValue(4, 0, value, Fit.SubfieldIndexMainField);
+			}
+		}
 
-            return (Convert.ToUInt32(val));
-            
-        }
 
-        /// <summary>
-        /// Set Id field
-        /// Comment: Alarm ID</summary>
-        /// <param name="id_">Nullable field value to be set</param>
-        public void SetId(uint? id_)
-        {
-            SetFieldValue(6, 0, id_, Fit.SubfieldIndexMainField);
-        }
-        
-        ///<summary>
-        /// Retrieves the PopupEnabled field
-        /// Comment: Show a visible pop-up for this alarm</summary>
-        /// <returns>Returns nullable Bool enum representing the PopupEnabled field</returns>
-        public Bool? GetPopupEnabled()
-        {
-            object obj = GetFieldValue(7, 0, Fit.SubfieldIndexMainField);
-            Bool? value = obj == null ? (Bool?)null : (Bool)obj;
-            return value;
-        }
+		/// <summary>
+		///
+		/// </summary>
+		/// <returns>returns number of elements in field DiveTypes</returns>
+		public int GetNumDiveTypes()
+		{
+			return GetNumFieldValues(5, Fit.SubfieldIndexMainField);
+		}
 
-        /// <summary>
-        /// Set PopupEnabled field
-        /// Comment: Show a visible pop-up for this alarm</summary>
-        /// <param name="popupEnabled_">Nullable field value to be set</param>
-        public void SetPopupEnabled(Bool? popupEnabled_)
-        {
-            SetFieldValue(7, 0, popupEnabled_, Fit.SubfieldIndexMainField);
-        }
-        
-        ///<summary>
-        /// Retrieves the TriggerOnDescent field
-        /// Comment: Trigger the alarm on descent</summary>
-        /// <returns>Returns nullable Bool enum representing the TriggerOnDescent field</returns>
-        public Bool? GetTriggerOnDescent()
-        {
-            object obj = GetFieldValue(8, 0, Fit.SubfieldIndexMainField);
-            Bool? value = obj == null ? (Bool?)null : (Bool)obj;
-            return value;
-        }
+		///<summary>
+		/// Retrieves the DiveTypes field
+		/// Comment: Dive types the alarm will trigger on</summary>
+		/// <param name="index">0 based index of DiveTypes element to retrieve</param>
+		/// <returns>Returns nullable SubSport enum representing the DiveTypes field</returns>
+		public SubSport? GetDiveTypes(int index)
+		{
+			object obj = GetFieldValue(5, index, Fit.SubfieldIndexMainField);
+			SubSport? value = obj == null ? (SubSport?)null : (SubSport)obj;
+			return value;
+		}
 
-        /// <summary>
-        /// Set TriggerOnDescent field
-        /// Comment: Trigger the alarm on descent</summary>
-        /// <param name="triggerOnDescent_">Nullable field value to be set</param>
-        public void SetTriggerOnDescent(Bool? triggerOnDescent_)
-        {
-            SetFieldValue(8, 0, triggerOnDescent_, Fit.SubfieldIndexMainField);
-        }
-        
-        ///<summary>
-        /// Retrieves the TriggerOnAscent field
-        /// Comment: Trigger the alarm on ascent</summary>
-        /// <returns>Returns nullable Bool enum representing the TriggerOnAscent field</returns>
-        public Bool? GetTriggerOnAscent()
-        {
-            object obj = GetFieldValue(9, 0, Fit.SubfieldIndexMainField);
-            Bool? value = obj == null ? (Bool?)null : (Bool)obj;
-            return value;
-        }
+		/// <summary>
+		/// Set DiveTypes field
+		/// Comment: Dive types the alarm will trigger on</summary>
+		/// <param name="index">0 based index of dive_types</param>
+		/// <param name="diveTypes_">Nullable field value to be set</param>
+		public void SetDiveTypes(int index, SubSport? diveTypes_)
+		{
+			SetFieldValue(5, index, diveTypes_, Fit.SubfieldIndexMainField);
+		}
 
-        /// <summary>
-        /// Set TriggerOnAscent field
-        /// Comment: Trigger the alarm on ascent</summary>
-        /// <param name="triggerOnAscent_">Nullable field value to be set</param>
-        public void SetTriggerOnAscent(Bool? triggerOnAscent_)
-        {
-            SetFieldValue(9, 0, triggerOnAscent_, Fit.SubfieldIndexMainField);
-        }
-        
-        ///<summary>
-        /// Retrieves the Repeating field
-        /// Comment: Repeat alarm each time threshold is crossed?</summary>
-        /// <returns>Returns nullable Bool enum representing the Repeating field</returns>
-        public Bool? GetRepeating()
-        {
-            object obj = GetFieldValue(10, 0, Fit.SubfieldIndexMainField);
-            Bool? value = obj == null ? (Bool?)null : (Bool)obj;
-            return value;
-        }
+		///<summary>
+		/// Retrieves the Id field
+		/// Comment: Alarm ID</summary>
+		/// <returns>Returns nullable uint representing the Id field</returns>
+		public uint? Id
+		{
+			get
+			{
+				Object val = GetFieldValue(6, 0, Fit.SubfieldIndexMainField);
+				if (val == null)
+				{
+					return null;
+				}
 
-        /// <summary>
-        /// Set Repeating field
-        /// Comment: Repeat alarm each time threshold is crossed?</summary>
-        /// <param name="repeating_">Nullable field value to be set</param>
-        public void SetRepeating(Bool? repeating_)
-        {
-            SetFieldValue(10, 0, repeating_, Fit.SubfieldIndexMainField);
-        }
-        
-        ///<summary>
-        /// Retrieves the Speed field
-        /// Units: mps
-        /// Comment: Ascent/descent rate (mps) setting for speed type alarms</summary>
-        /// <returns>Returns nullable float representing the Speed field</returns>
-        public float? GetSpeed()
-        {
-            Object val = GetFieldValue(11, 0, Fit.SubfieldIndexMainField);
-            if(val == null)
-            {
-                return null;
-            }
+				return (Convert.ToUInt32(val));
 
-            return (Convert.ToSingle(val));
-            
-        }
+			}
+			set
+			{
+				SetFieldValue(6, 0, value, Fit.SubfieldIndexMainField);
+			}
+		}
 
-        /// <summary>
-        /// Set Speed field
-        /// Units: mps
-        /// Comment: Ascent/descent rate (mps) setting for speed type alarms</summary>
-        /// <param name="speed_">Nullable field value to be set</param>
-        public void SetSpeed(float? speed_)
-        {
-            SetFieldValue(11, 0, speed_, Fit.SubfieldIndexMainField);
-        }
-        
-        #endregion // Methods
-    } // Class
+		///<summary>
+		/// Retrieves the PopupEnabled field
+		/// Comment: Show a visible pop-up for this alarm</summary>
+		/// <returns>Returns nullable Bool enum representing the PopupEnabled field</returns>
+		public Bool? PopupEnabled
+		{
+			get
+			{
+				object obj = GetFieldValue(7, 0, Fit.SubfieldIndexMainField);
+				Bool? value = obj == null ? (Bool?)null : (Bool)obj;
+				return value;
+			}
+			set
+			{
+				SetFieldValue(7, 0, value, Fit.SubfieldIndexMainField);
+			}
+		}
+
+		///<summary>
+		/// Retrieves the TriggerOnDescent field
+		/// Comment: Trigger the alarm on descent</summary>
+		/// <returns>Returns nullable Bool enum representing the TriggerOnDescent field</returns>
+		public Bool? TriggerOnDescent
+		{
+			get
+			{
+				object obj = GetFieldValue(8, 0, Fit.SubfieldIndexMainField);
+				Bool? value = obj == null ? (Bool?)null : (Bool)obj;
+				return value;
+			}
+			set
+			{
+				SetFieldValue(8, 0, value, Fit.SubfieldIndexMainField);
+			}
+		}
+
+		///<summary>
+		/// Retrieves the TriggerOnAscent field
+		/// Comment: Trigger the alarm on ascent</summary>
+		/// <returns>Returns nullable Bool enum representing the TriggerOnAscent field</returns>
+		public Bool? TriggerOnAscent
+		{
+			get
+			{
+				object obj = GetFieldValue(9, 0, Fit.SubfieldIndexMainField);
+				Bool? value = obj == null ? (Bool?)null : (Bool)obj;
+				return value;
+			}
+			set
+			{
+				SetFieldValue(9, 0, value, Fit.SubfieldIndexMainField);
+			}
+		}
+
+		///<summary>
+		/// Retrieves the Repeating field
+		/// Comment: Repeat alarm each time threshold is crossed?</summary>
+		/// <returns>Returns nullable Bool enum representing the Repeating field</returns>
+		public Bool? Repeating
+		{
+			get
+			{
+				object obj = GetFieldValue(10, 0, Fit.SubfieldIndexMainField);
+				Bool? value = obj == null ? (Bool?)null : (Bool)obj;
+				return value;
+			}
+			set
+			{
+				SetFieldValue(10, 0, value, Fit.SubfieldIndexMainField);
+			}
+		}
+
+		///<summary>
+		/// Retrieves the Speed field
+		/// Units: mps
+		/// Comment: Ascent/descent rate (mps) setting for speed type alarms</summary>
+		/// <returns>Returns nullable float representing the Speed field</returns>
+		public float? Speed
+		{
+			get
+			{
+				Object val = GetFieldValue(11, 0, Fit.SubfieldIndexMainField);
+				if (val == null)
+				{
+					return null;
+				}
+
+				return (Convert.ToSingle(val));
+
+			}
+			set
+			{
+				SetFieldValue(11, 0, value, Fit.SubfieldIndexMainField);
+			}
+		}
+
+		#endregion // Methods
+	} // Class
 } // namespace

--- a/Dynastream/Fit/Profile/Mesgs/DiveGasMesg.cs
+++ b/Dynastream/Fit/Profile/Mesgs/DiveGasMesg.cs
@@ -21,147 +21,140 @@ using System.Linq;
 
 namespace Dynastream.Fit
 {
-    /// <summary>
-    /// Implements the DiveGas profile message.
-    /// </summary>
-    public class DiveGasMesg : Mesg
-    {
-        #region Fields
-        #endregion
+	/// <summary>
+	/// Implements the DiveGas profile message.
+	/// </summary>
+	public class DiveGasMesg : Mesg
+	{
+		#region Fields
+		#endregion
 
-        /// <summary>
-        /// Field Numbers for <see cref="DiveGasMesg"/>
-        /// </summary>
-        public sealed class FieldDefNum
-        {
-            public const byte MessageIndex = 254;
-            public const byte HeliumContent = 0;
-            public const byte OxygenContent = 1;
-            public const byte Status = 2;
-            public const byte Mode = 3;
-            public const byte Invalid = Fit.FieldNumInvalid;
-        }
+		/// <summary>
+		/// Field Numbers for <see cref="DiveGasMesg"/>
+		/// </summary>
+		public sealed class FieldDefNum
+		{
+			public const byte MessageIndex = 254;
+			public const byte HeliumContent = 0;
+			public const byte OxygenContent = 1;
+			public const byte Status = 2;
+			public const byte Mode = 3;
+			public const byte Invalid = Fit.FieldNumInvalid;
+		}
 
-        #region Constructors
-        public DiveGasMesg() : base(Profile.GetMesg(MesgNum.DiveGas))
-        {
-        }
+		#region Constructors
+		public DiveGasMesg() : base(Profile.GetMesg(MesgNum.DiveGas))
+		{
+		}
 
-        public DiveGasMesg(Mesg mesg) : base(mesg)
-        {
-        }
-        #endregion // Constructors
+		public DiveGasMesg(Mesg mesg) : base(mesg)
+		{
+		}
+		#endregion // Constructors
 
-        #region Methods
-        ///<summary>
-        /// Retrieves the MessageIndex field</summary>
-        /// <returns>Returns nullable ushort representing the MessageIndex field</returns>
-        public ushort? GetMessageIndex()
-        {
-            Object val = GetFieldValue(254, 0, Fit.SubfieldIndexMainField);
-            if(val == null)
-            {
-                return null;
-            }
+		#region Methods
+		///<summary>
+		/// Retrieves the MessageIndex field</summary>
+		/// <returns>Returns nullable ushort representing the MessageIndex field</returns>
+		public ushort? MessageIndex
+		{
+			get
+			{
+				Object val = GetFieldValue(254, 0, Fit.SubfieldIndexMainField);
+				if (val == null)
+				{
+					return null;
+				}
 
-            return (Convert.ToUInt16(val));
-            
-        }
+				return (Convert.ToUInt16(val));
 
-        /// <summary>
-        /// Set MessageIndex field</summary>
-        /// <param name="messageIndex_">Nullable field value to be set</param>
-        public void SetMessageIndex(ushort? messageIndex_)
-        {
-            SetFieldValue(254, 0, messageIndex_, Fit.SubfieldIndexMainField);
-        }
-        
-        ///<summary>
-        /// Retrieves the HeliumContent field
-        /// Units: percent</summary>
-        /// <returns>Returns nullable byte representing the HeliumContent field</returns>
-        public byte? GetHeliumContent()
-        {
-            Object val = GetFieldValue(0, 0, Fit.SubfieldIndexMainField);
-            if(val == null)
-            {
-                return null;
-            }
+			}
+			set
+			{
+				SetFieldValue(254, 0, value, Fit.SubfieldIndexMainField);
+			}
+		}
 
-            return (Convert.ToByte(val));
-            
-        }
+		///<summary>
+		/// Retrieves the HeliumContent field
+		/// Units: percent</summary>
+		/// <returns>Returns nullable byte representing the HeliumContent field</returns>
+		public byte? HeliumContent
+		{
+			get
+			{
+				Object val = GetFieldValue(0, 0, Fit.SubfieldIndexMainField);
+				if (val == null)
+				{
+					return null;
+				}
 
-        /// <summary>
-        /// Set HeliumContent field
-        /// Units: percent</summary>
-        /// <param name="heliumContent_">Nullable field value to be set</param>
-        public void SetHeliumContent(byte? heliumContent_)
-        {
-            SetFieldValue(0, 0, heliumContent_, Fit.SubfieldIndexMainField);
-        }
-        
-        ///<summary>
-        /// Retrieves the OxygenContent field
-        /// Units: percent</summary>
-        /// <returns>Returns nullable byte representing the OxygenContent field</returns>
-        public byte? GetOxygenContent()
-        {
-            Object val = GetFieldValue(1, 0, Fit.SubfieldIndexMainField);
-            if(val == null)
-            {
-                return null;
-            }
+				return (Convert.ToByte(val));
 
-            return (Convert.ToByte(val));
-            
-        }
+			}
+			set
+			{
+				SetFieldValue(0, 0, value, Fit.SubfieldIndexMainField);
+			}
+		}
 
-        /// <summary>
-        /// Set OxygenContent field
-        /// Units: percent</summary>
-        /// <param name="oxygenContent_">Nullable field value to be set</param>
-        public void SetOxygenContent(byte? oxygenContent_)
-        {
-            SetFieldValue(1, 0, oxygenContent_, Fit.SubfieldIndexMainField);
-        }
-        
-        ///<summary>
-        /// Retrieves the Status field</summary>
-        /// <returns>Returns nullable DiveGasStatus enum representing the Status field</returns>
-        public DiveGasStatus? GetStatus()
-        {
-            object obj = GetFieldValue(2, 0, Fit.SubfieldIndexMainField);
-            DiveGasStatus? value = obj == null ? (DiveGasStatus?)null : (DiveGasStatus)obj;
-            return value;
-        }
+		///<summary>
+		/// Retrieves the OxygenContent field
+		/// Units: percent</summary>
+		/// <returns>Returns nullable byte representing the OxygenContent field</returns>
+		public byte? OxygenContent
+		{
+			get
+			{
+				Object val = GetFieldValue(1, 0, Fit.SubfieldIndexMainField);
+				if (val == null)
+				{
+					return null;
+				}
 
-        /// <summary>
-        /// Set Status field</summary>
-        /// <param name="status_">Nullable field value to be set</param>
-        public void SetStatus(DiveGasStatus? status_)
-        {
-            SetFieldValue(2, 0, status_, Fit.SubfieldIndexMainField);
-        }
-        
-        ///<summary>
-        /// Retrieves the Mode field</summary>
-        /// <returns>Returns nullable DiveGasMode enum representing the Mode field</returns>
-        public DiveGasMode? GetMode()
-        {
-            object obj = GetFieldValue(3, 0, Fit.SubfieldIndexMainField);
-            DiveGasMode? value = obj == null ? (DiveGasMode?)null : (DiveGasMode)obj;
-            return value;
-        }
+				return (Convert.ToByte(val));
 
-        /// <summary>
-        /// Set Mode field</summary>
-        /// <param name="mode_">Nullable field value to be set</param>
-        public void SetMode(DiveGasMode? mode_)
-        {
-            SetFieldValue(3, 0, mode_, Fit.SubfieldIndexMainField);
-        }
-        
-        #endregion // Methods
-    } // Class
+			}
+			set
+			{
+				SetFieldValue(1, 0, value, Fit.SubfieldIndexMainField);
+			}
+		}
+
+		///<summary>
+		/// Retrieves the Status field</summary>
+		/// <returns>Returns nullable DiveGasStatus enum representing the Status field</returns>
+		public DiveGasStatus? Status
+		{
+			get
+			{
+				object obj = GetFieldValue(2, 0, Fit.SubfieldIndexMainField);
+				DiveGasStatus? value = obj == null ? (DiveGasStatus?)null : (DiveGasStatus)obj;
+				return value;
+			}
+			set
+			{
+				SetFieldValue(2, 0, value, Fit.SubfieldIndexMainField);
+			}
+		}
+
+		///<summary>
+		/// Retrieves the Mode field</summary>
+		/// <returns>Returns nullable DiveGasMode enum representing the Mode field</returns>
+		public DiveGasMode? Mode
+		{
+			get
+			{
+				object obj = GetFieldValue(3, 0, Fit.SubfieldIndexMainField);
+				DiveGasMode? value = obj == null ? (DiveGasMode?)null : (DiveGasMode)obj;
+				return value;
+			}
+			set
+			{
+				SetFieldValue(3, 0, value, Fit.SubfieldIndexMainField);
+			}
+		}
+
+		#endregion // Methods
+	} // Class
 } // namespace

--- a/Dynastream/Fit/Profile/Mesgs/DiveSettingsMesg.cs
+++ b/Dynastream/Fit/Profile/Mesgs/DiveSettingsMesg.cs
@@ -21,942 +21,873 @@ using System.Linq;
 
 namespace Dynastream.Fit
 {
-    /// <summary>
-    /// Implements the DiveSettings profile message.
-    /// </summary>
-    public class DiveSettingsMesg : Mesg
-    {
-        #region Fields
-        static class HeartRateSourceSubfield
-        {
-            public static ushort HeartRateAntplusDeviceType = 0;
-            public static ushort HeartRateLocalDeviceType = 1;
-            public static ushort Subfields = 2;
-            public static ushort Active = Fit.SubfieldIndexActiveSubfield;
-            public static ushort MainField = Fit.SubfieldIndexMainField;
-        }
-        #endregion
-
-        /// <summary>
-        /// Field Numbers for <see cref="DiveSettingsMesg"/>
-        /// </summary>
-        public sealed class FieldDefNum
-        {
-            public const byte Timestamp = 253;
-            public const byte MessageIndex = 254;
-            public const byte Name = 0;
-            public const byte Model = 1;
-            public const byte GfLow = 2;
-            public const byte GfHigh = 3;
-            public const byte WaterType = 4;
-            public const byte WaterDensity = 5;
-            public const byte Po2Warn = 6;
-            public const byte Po2Critical = 7;
-            public const byte Po2Deco = 8;
-            public const byte SafetyStopEnabled = 9;
-            public const byte BottomDepth = 10;
-            public const byte BottomTime = 11;
-            public const byte ApneaCountdownEnabled = 12;
-            public const byte ApneaCountdownTime = 13;
-            public const byte BacklightMode = 14;
-            public const byte BacklightBrightness = 15;
-            public const byte BacklightTimeout = 16;
-            public const byte RepeatDiveInterval = 17;
-            public const byte SafetyStopTime = 18;
-            public const byte HeartRateSourceType = 19;
-            public const byte HeartRateSource = 20;
-            public const byte TravelGas = 21;
-            public const byte CcrLowSetpointSwitchMode = 22;
-            public const byte CcrLowSetpoint = 23;
-            public const byte CcrLowSetpointDepth = 24;
-            public const byte CcrHighSetpointSwitchMode = 25;
-            public const byte CcrHighSetpoint = 26;
-            public const byte CcrHighSetpointDepth = 27;
-            public const byte GasConsumptionDisplay = 29;
-            public const byte UpKeyEnabled = 30;
-            public const byte DiveSounds = 35;
-            public const byte LastStopMultiple = 36;
-            public const byte NoFlyTimeMode = 37;
-            public const byte Invalid = Fit.FieldNumInvalid;
-        }
-
-        #region Constructors
-        public DiveSettingsMesg() : base(Profile.GetMesg(MesgNum.DiveSettings))
-        {
-        }
-
-        public DiveSettingsMesg(Mesg mesg) : base(mesg)
-        {
-        }
-        #endregion // Constructors
-
-        #region Methods
-        ///<summary>
-        /// Retrieves the Timestamp field</summary>
-        /// <returns>Returns DateTime representing the Timestamp field</returns>
-        public DateTime GetTimestamp()
-        {
-            Object val = GetFieldValue(253, 0, Fit.SubfieldIndexMainField);
-            if(val == null)
-            {
-                return null;
-            }
-
-            return TimestampToDateTime(Convert.ToUInt32(val));
-            
-        }
-
-        /// <summary>
-        /// Set Timestamp field</summary>
-        /// <param name="timestamp_">Nullable field value to be set</param>
-        public void SetTimestamp(DateTime timestamp_)
-        {
-            SetFieldValue(253, 0, timestamp_.GetTimeStamp(), Fit.SubfieldIndexMainField);
-        }
-        
-        ///<summary>
-        /// Retrieves the MessageIndex field</summary>
-        /// <returns>Returns nullable ushort representing the MessageIndex field</returns>
-        public ushort? GetMessageIndex()
-        {
-            Object val = GetFieldValue(254, 0, Fit.SubfieldIndexMainField);
-            if(val == null)
-            {
-                return null;
-            }
-
-            return (Convert.ToUInt16(val));
-            
-        }
-
-        /// <summary>
-        /// Set MessageIndex field</summary>
-        /// <param name="messageIndex_">Nullable field value to be set</param>
-        public void SetMessageIndex(ushort? messageIndex_)
-        {
-            SetFieldValue(254, 0, messageIndex_, Fit.SubfieldIndexMainField);
-        }
-        
-        ///<summary>
-        /// Retrieves the Name field</summary>
-        /// <returns>Returns byte[] representing the Name field</returns>
-        public byte[] GetName()
-        {
-            byte[] data = (byte[])GetFieldValue(0, 0, Fit.SubfieldIndexMainField);
-            return data.Take(data.Length - 1).ToArray();
-        }
-
-        ///<summary>
-        /// Retrieves the Name field</summary>
-        /// <returns>Returns String representing the Name field</returns>
-        public String GetNameAsString()
-        {
-            byte[] data = (byte[])GetFieldValue(0, 0, Fit.SubfieldIndexMainField);
-            return data != null ? Encoding.UTF8.GetString(data, 0, data.Length - 1) : null;
-        }
-
-        ///<summary>
-        /// Set Name field</summary>
-        /// <param name="name_"> field value to be set</param>
-        public void SetName(String name_)
-        {
-            byte[] data = Encoding.UTF8.GetBytes(name_);
-            byte[] zdata = new byte[data.Length + 1];
-            data.CopyTo(zdata, 0);
-            SetFieldValue(0, 0, zdata, Fit.SubfieldIndexMainField);
-        }
-
-        
-        /// <summary>
-        /// Set Name field</summary>
-        /// <param name="name_">field value to be set</param>
-        public void SetName(byte[] name_)
-        {
-            SetFieldValue(0, 0, name_, Fit.SubfieldIndexMainField);
-        }
-        
-        ///<summary>
-        /// Retrieves the Model field</summary>
-        /// <returns>Returns nullable TissueModelType enum representing the Model field</returns>
-        public TissueModelType? GetModel()
-        {
-            object obj = GetFieldValue(1, 0, Fit.SubfieldIndexMainField);
-            TissueModelType? value = obj == null ? (TissueModelType?)null : (TissueModelType)obj;
-            return value;
-        }
-
-        /// <summary>
-        /// Set Model field</summary>
-        /// <param name="model_">Nullable field value to be set</param>
-        public void SetModel(TissueModelType? model_)
-        {
-            SetFieldValue(1, 0, model_, Fit.SubfieldIndexMainField);
-        }
-        
-        ///<summary>
-        /// Retrieves the GfLow field
-        /// Units: percent</summary>
-        /// <returns>Returns nullable byte representing the GfLow field</returns>
-        public byte? GetGfLow()
-        {
-            Object val = GetFieldValue(2, 0, Fit.SubfieldIndexMainField);
-            if(val == null)
-            {
-                return null;
-            }
-
-            return (Convert.ToByte(val));
-            
-        }
-
-        /// <summary>
-        /// Set GfLow field
-        /// Units: percent</summary>
-        /// <param name="gfLow_">Nullable field value to be set</param>
-        public void SetGfLow(byte? gfLow_)
-        {
-            SetFieldValue(2, 0, gfLow_, Fit.SubfieldIndexMainField);
-        }
-        
-        ///<summary>
-        /// Retrieves the GfHigh field
-        /// Units: percent</summary>
-        /// <returns>Returns nullable byte representing the GfHigh field</returns>
-        public byte? GetGfHigh()
-        {
-            Object val = GetFieldValue(3, 0, Fit.SubfieldIndexMainField);
-            if(val == null)
-            {
-                return null;
-            }
-
-            return (Convert.ToByte(val));
-            
-        }
-
-        /// <summary>
-        /// Set GfHigh field
-        /// Units: percent</summary>
-        /// <param name="gfHigh_">Nullable field value to be set</param>
-        public void SetGfHigh(byte? gfHigh_)
-        {
-            SetFieldValue(3, 0, gfHigh_, Fit.SubfieldIndexMainField);
-        }
-        
-        ///<summary>
-        /// Retrieves the WaterType field</summary>
-        /// <returns>Returns nullable WaterType enum representing the WaterType field</returns>
-        public WaterType? GetWaterType()
-        {
-            object obj = GetFieldValue(4, 0, Fit.SubfieldIndexMainField);
-            WaterType? value = obj == null ? (WaterType?)null : (WaterType)obj;
-            return value;
-        }
-
-        /// <summary>
-        /// Set WaterType field</summary>
-        /// <param name="waterType_">Nullable field value to be set</param>
-        public void SetWaterType(WaterType? waterType_)
-        {
-            SetFieldValue(4, 0, waterType_, Fit.SubfieldIndexMainField);
-        }
-        
-        ///<summary>
-        /// Retrieves the WaterDensity field
-        /// Units: kg/m^3
-        /// Comment: Fresh water is usually 1000; salt water is usually 1025</summary>
-        /// <returns>Returns nullable float representing the WaterDensity field</returns>
-        public float? GetWaterDensity()
-        {
-            Object val = GetFieldValue(5, 0, Fit.SubfieldIndexMainField);
-            if(val == null)
-            {
-                return null;
-            }
-
-            return (Convert.ToSingle(val));
-            
-        }
-
-        /// <summary>
-        /// Set WaterDensity field
-        /// Units: kg/m^3
-        /// Comment: Fresh water is usually 1000; salt water is usually 1025</summary>
-        /// <param name="waterDensity_">Nullable field value to be set</param>
-        public void SetWaterDensity(float? waterDensity_)
-        {
-            SetFieldValue(5, 0, waterDensity_, Fit.SubfieldIndexMainField);
-        }
-        
-        ///<summary>
-        /// Retrieves the Po2Warn field
-        /// Units: percent
-        /// Comment: Typically 1.40</summary>
-        /// <returns>Returns nullable float representing the Po2Warn field</returns>
-        public float? GetPo2Warn()
-        {
-            Object val = GetFieldValue(6, 0, Fit.SubfieldIndexMainField);
-            if(val == null)
-            {
-                return null;
-            }
-
-            return (Convert.ToSingle(val));
-            
-        }
-
-        /// <summary>
-        /// Set Po2Warn field
-        /// Units: percent
-        /// Comment: Typically 1.40</summary>
-        /// <param name="po2Warn_">Nullable field value to be set</param>
-        public void SetPo2Warn(float? po2Warn_)
-        {
-            SetFieldValue(6, 0, po2Warn_, Fit.SubfieldIndexMainField);
-        }
-        
-        ///<summary>
-        /// Retrieves the Po2Critical field
-        /// Units: percent
-        /// Comment: Typically 1.60</summary>
-        /// <returns>Returns nullable float representing the Po2Critical field</returns>
-        public float? GetPo2Critical()
-        {
-            Object val = GetFieldValue(7, 0, Fit.SubfieldIndexMainField);
-            if(val == null)
-            {
-                return null;
-            }
-
-            return (Convert.ToSingle(val));
-            
-        }
-
-        /// <summary>
-        /// Set Po2Critical field
-        /// Units: percent
-        /// Comment: Typically 1.60</summary>
-        /// <param name="po2Critical_">Nullable field value to be set</param>
-        public void SetPo2Critical(float? po2Critical_)
-        {
-            SetFieldValue(7, 0, po2Critical_, Fit.SubfieldIndexMainField);
-        }
-        
-        ///<summary>
-        /// Retrieves the Po2Deco field
-        /// Units: percent</summary>
-        /// <returns>Returns nullable float representing the Po2Deco field</returns>
-        public float? GetPo2Deco()
-        {
-            Object val = GetFieldValue(8, 0, Fit.SubfieldIndexMainField);
-            if(val == null)
-            {
-                return null;
-            }
-
-            return (Convert.ToSingle(val));
-            
-        }
-
-        /// <summary>
-        /// Set Po2Deco field
-        /// Units: percent</summary>
-        /// <param name="po2Deco_">Nullable field value to be set</param>
-        public void SetPo2Deco(float? po2Deco_)
-        {
-            SetFieldValue(8, 0, po2Deco_, Fit.SubfieldIndexMainField);
-        }
-        
-        ///<summary>
-        /// Retrieves the SafetyStopEnabled field</summary>
-        /// <returns>Returns nullable Bool enum representing the SafetyStopEnabled field</returns>
-        public Bool? GetSafetyStopEnabled()
-        {
-            object obj = GetFieldValue(9, 0, Fit.SubfieldIndexMainField);
-            Bool? value = obj == null ? (Bool?)null : (Bool)obj;
-            return value;
-        }
-
-        /// <summary>
-        /// Set SafetyStopEnabled field</summary>
-        /// <param name="safetyStopEnabled_">Nullable field value to be set</param>
-        public void SetSafetyStopEnabled(Bool? safetyStopEnabled_)
-        {
-            SetFieldValue(9, 0, safetyStopEnabled_, Fit.SubfieldIndexMainField);
-        }
-        
-        ///<summary>
-        /// Retrieves the BottomDepth field</summary>
-        /// <returns>Returns nullable float representing the BottomDepth field</returns>
-        public float? GetBottomDepth()
-        {
-            Object val = GetFieldValue(10, 0, Fit.SubfieldIndexMainField);
-            if(val == null)
-            {
-                return null;
-            }
-
-            return (Convert.ToSingle(val));
-            
-        }
-
-        /// <summary>
-        /// Set BottomDepth field</summary>
-        /// <param name="bottomDepth_">Nullable field value to be set</param>
-        public void SetBottomDepth(float? bottomDepth_)
-        {
-            SetFieldValue(10, 0, bottomDepth_, Fit.SubfieldIndexMainField);
-        }
-        
-        ///<summary>
-        /// Retrieves the BottomTime field</summary>
-        /// <returns>Returns nullable uint representing the BottomTime field</returns>
-        public uint? GetBottomTime()
-        {
-            Object val = GetFieldValue(11, 0, Fit.SubfieldIndexMainField);
-            if(val == null)
-            {
-                return null;
-            }
-
-            return (Convert.ToUInt32(val));
-            
-        }
-
-        /// <summary>
-        /// Set BottomTime field</summary>
-        /// <param name="bottomTime_">Nullable field value to be set</param>
-        public void SetBottomTime(uint? bottomTime_)
-        {
-            SetFieldValue(11, 0, bottomTime_, Fit.SubfieldIndexMainField);
-        }
-        
-        ///<summary>
-        /// Retrieves the ApneaCountdownEnabled field</summary>
-        /// <returns>Returns nullable Bool enum representing the ApneaCountdownEnabled field</returns>
-        public Bool? GetApneaCountdownEnabled()
-        {
-            object obj = GetFieldValue(12, 0, Fit.SubfieldIndexMainField);
-            Bool? value = obj == null ? (Bool?)null : (Bool)obj;
-            return value;
-        }
-
-        /// <summary>
-        /// Set ApneaCountdownEnabled field</summary>
-        /// <param name="apneaCountdownEnabled_">Nullable field value to be set</param>
-        public void SetApneaCountdownEnabled(Bool? apneaCountdownEnabled_)
-        {
-            SetFieldValue(12, 0, apneaCountdownEnabled_, Fit.SubfieldIndexMainField);
-        }
-        
-        ///<summary>
-        /// Retrieves the ApneaCountdownTime field</summary>
-        /// <returns>Returns nullable uint representing the ApneaCountdownTime field</returns>
-        public uint? GetApneaCountdownTime()
-        {
-            Object val = GetFieldValue(13, 0, Fit.SubfieldIndexMainField);
-            if(val == null)
-            {
-                return null;
-            }
-
-            return (Convert.ToUInt32(val));
-            
-        }
-
-        /// <summary>
-        /// Set ApneaCountdownTime field</summary>
-        /// <param name="apneaCountdownTime_">Nullable field value to be set</param>
-        public void SetApneaCountdownTime(uint? apneaCountdownTime_)
-        {
-            SetFieldValue(13, 0, apneaCountdownTime_, Fit.SubfieldIndexMainField);
-        }
-        
-        ///<summary>
-        /// Retrieves the BacklightMode field</summary>
-        /// <returns>Returns nullable DiveBacklightMode enum representing the BacklightMode field</returns>
-        public DiveBacklightMode? GetBacklightMode()
-        {
-            object obj = GetFieldValue(14, 0, Fit.SubfieldIndexMainField);
-            DiveBacklightMode? value = obj == null ? (DiveBacklightMode?)null : (DiveBacklightMode)obj;
-            return value;
-        }
-
-        /// <summary>
-        /// Set BacklightMode field</summary>
-        /// <param name="backlightMode_">Nullable field value to be set</param>
-        public void SetBacklightMode(DiveBacklightMode? backlightMode_)
-        {
-            SetFieldValue(14, 0, backlightMode_, Fit.SubfieldIndexMainField);
-        }
-        
-        ///<summary>
-        /// Retrieves the BacklightBrightness field</summary>
-        /// <returns>Returns nullable byte representing the BacklightBrightness field</returns>
-        public byte? GetBacklightBrightness()
-        {
-            Object val = GetFieldValue(15, 0, Fit.SubfieldIndexMainField);
-            if(val == null)
-            {
-                return null;
-            }
-
-            return (Convert.ToByte(val));
-            
-        }
-
-        /// <summary>
-        /// Set BacklightBrightness field</summary>
-        /// <param name="backlightBrightness_">Nullable field value to be set</param>
-        public void SetBacklightBrightness(byte? backlightBrightness_)
-        {
-            SetFieldValue(15, 0, backlightBrightness_, Fit.SubfieldIndexMainField);
-        }
-        
-        ///<summary>
-        /// Retrieves the BacklightTimeout field</summary>
-        /// <returns>Returns nullable byte representing the BacklightTimeout field</returns>
-        public byte? GetBacklightTimeout()
-        {
-            Object val = GetFieldValue(16, 0, Fit.SubfieldIndexMainField);
-            if(val == null)
-            {
-                return null;
-            }
-
-            return (Convert.ToByte(val));
-            
-        }
-
-        /// <summary>
-        /// Set BacklightTimeout field</summary>
-        /// <param name="backlightTimeout_">Nullable field value to be set</param>
-        public void SetBacklightTimeout(byte? backlightTimeout_)
-        {
-            SetFieldValue(16, 0, backlightTimeout_, Fit.SubfieldIndexMainField);
-        }
-        
-        ///<summary>
-        /// Retrieves the RepeatDiveInterval field
-        /// Units: s
-        /// Comment: Time between surfacing and ending the activity</summary>
-        /// <returns>Returns nullable ushort representing the RepeatDiveInterval field</returns>
-        public ushort? GetRepeatDiveInterval()
-        {
-            Object val = GetFieldValue(17, 0, Fit.SubfieldIndexMainField);
-            if(val == null)
-            {
-                return null;
-            }
-
-            return (Convert.ToUInt16(val));
-            
-        }
-
-        /// <summary>
-        /// Set RepeatDiveInterval field
-        /// Units: s
-        /// Comment: Time between surfacing and ending the activity</summary>
-        /// <param name="repeatDiveInterval_">Nullable field value to be set</param>
-        public void SetRepeatDiveInterval(ushort? repeatDiveInterval_)
-        {
-            SetFieldValue(17, 0, repeatDiveInterval_, Fit.SubfieldIndexMainField);
-        }
-        
-        ///<summary>
-        /// Retrieves the SafetyStopTime field
-        /// Units: s
-        /// Comment: Time at safety stop (if enabled)</summary>
-        /// <returns>Returns nullable ushort representing the SafetyStopTime field</returns>
-        public ushort? GetSafetyStopTime()
-        {
-            Object val = GetFieldValue(18, 0, Fit.SubfieldIndexMainField);
-            if(val == null)
-            {
-                return null;
-            }
-
-            return (Convert.ToUInt16(val));
-            
-        }
-
-        /// <summary>
-        /// Set SafetyStopTime field
-        /// Units: s
-        /// Comment: Time at safety stop (if enabled)</summary>
-        /// <param name="safetyStopTime_">Nullable field value to be set</param>
-        public void SetSafetyStopTime(ushort? safetyStopTime_)
-        {
-            SetFieldValue(18, 0, safetyStopTime_, Fit.SubfieldIndexMainField);
-        }
-        
-        ///<summary>
-        /// Retrieves the HeartRateSourceType field</summary>
-        /// <returns>Returns nullable SourceType enum representing the HeartRateSourceType field</returns>
-        public SourceType? GetHeartRateSourceType()
-        {
-            object obj = GetFieldValue(19, 0, Fit.SubfieldIndexMainField);
-            SourceType? value = obj == null ? (SourceType?)null : (SourceType)obj;
-            return value;
-        }
-
-        /// <summary>
-        /// Set HeartRateSourceType field</summary>
-        /// <param name="heartRateSourceType_">Nullable field value to be set</param>
-        public void SetHeartRateSourceType(SourceType? heartRateSourceType_)
-        {
-            SetFieldValue(19, 0, heartRateSourceType_, Fit.SubfieldIndexMainField);
-        }
-        
-        ///<summary>
-        /// Retrieves the HeartRateSource field</summary>
-        /// <returns>Returns nullable byte representing the HeartRateSource field</returns>
-        public byte? GetHeartRateSource()
-        {
-            Object val = GetFieldValue(20, 0, Fit.SubfieldIndexMainField);
-            if(val == null)
-            {
-                return null;
-            }
-
-            return (Convert.ToByte(val));
-            
-        }
-
-        /// <summary>
-        /// Set HeartRateSource field</summary>
-        /// <param name="heartRateSource_">Nullable field value to be set</param>
-        public void SetHeartRateSource(byte? heartRateSource_)
-        {
-            SetFieldValue(20, 0, heartRateSource_, Fit.SubfieldIndexMainField);
-        }
-        
-
-        /// <summary>
-        /// Retrieves the HeartRateAntplusDeviceType subfield</summary>
-        /// <returns>Nullable byte representing the HeartRateAntplusDeviceType subfield</returns>
-        public byte? GetHeartRateAntplusDeviceType()
-        {
-            Object val = GetFieldValue(20, 0, HeartRateSourceSubfield.HeartRateAntplusDeviceType);
-            if(val == null)
-            {
-                return null;
-            }
-
-            return (Convert.ToByte(val));
-            
-        }
-
-        /// <summary>
-        ///
-        /// Set HeartRateAntplusDeviceType subfield</summary>
-        /// <param name="heartRateAntplusDeviceType">Subfield value to be set</param>
-        public void SetHeartRateAntplusDeviceType(byte? heartRateAntplusDeviceType)
-        {
-            SetFieldValue(20, 0, heartRateAntplusDeviceType, HeartRateSourceSubfield.HeartRateAntplusDeviceType);
-        }
-
-        /// <summary>
-        /// Retrieves the HeartRateLocalDeviceType subfield</summary>
-        /// <returns>Nullable byte representing the HeartRateLocalDeviceType subfield</returns>
-        public byte? GetHeartRateLocalDeviceType()
-        {
-            Object val = GetFieldValue(20, 0, HeartRateSourceSubfield.HeartRateLocalDeviceType);
-            if(val == null)
-            {
-                return null;
-            }
-
-            return (Convert.ToByte(val));
-            
-        }
-
-        /// <summary>
-        ///
-        /// Set HeartRateLocalDeviceType subfield</summary>
-        /// <param name="heartRateLocalDeviceType">Subfield value to be set</param>
-        public void SetHeartRateLocalDeviceType(byte? heartRateLocalDeviceType)
-        {
-            SetFieldValue(20, 0, heartRateLocalDeviceType, HeartRateSourceSubfield.HeartRateLocalDeviceType);
-        }
-        ///<summary>
-        /// Retrieves the TravelGas field
-        /// Comment: Index of travel dive_gas message</summary>
-        /// <returns>Returns nullable ushort representing the TravelGas field</returns>
-        public ushort? GetTravelGas()
-        {
-            Object val = GetFieldValue(21, 0, Fit.SubfieldIndexMainField);
-            if(val == null)
-            {
-                return null;
-            }
-
-            return (Convert.ToUInt16(val));
-            
-        }
-
-        /// <summary>
-        /// Set TravelGas field
-        /// Comment: Index of travel dive_gas message</summary>
-        /// <param name="travelGas_">Nullable field value to be set</param>
-        public void SetTravelGas(ushort? travelGas_)
-        {
-            SetFieldValue(21, 0, travelGas_, Fit.SubfieldIndexMainField);
-        }
-        
-        ///<summary>
-        /// Retrieves the CcrLowSetpointSwitchMode field
-        /// Comment: If low PO2 should be switched to automatically</summary>
-        /// <returns>Returns nullable CcrSetpointSwitchMode enum representing the CcrLowSetpointSwitchMode field</returns>
-        public CcrSetpointSwitchMode? GetCcrLowSetpointSwitchMode()
-        {
-            object obj = GetFieldValue(22, 0, Fit.SubfieldIndexMainField);
-            CcrSetpointSwitchMode? value = obj == null ? (CcrSetpointSwitchMode?)null : (CcrSetpointSwitchMode)obj;
-            return value;
-        }
-
-        /// <summary>
-        /// Set CcrLowSetpointSwitchMode field
-        /// Comment: If low PO2 should be switched to automatically</summary>
-        /// <param name="ccrLowSetpointSwitchMode_">Nullable field value to be set</param>
-        public void SetCcrLowSetpointSwitchMode(CcrSetpointSwitchMode? ccrLowSetpointSwitchMode_)
-        {
-            SetFieldValue(22, 0, ccrLowSetpointSwitchMode_, Fit.SubfieldIndexMainField);
-        }
-        
-        ///<summary>
-        /// Retrieves the CcrLowSetpoint field
-        /// Units: percent
-        /// Comment: Target PO2 when using low setpoint</summary>
-        /// <returns>Returns nullable float representing the CcrLowSetpoint field</returns>
-        public float? GetCcrLowSetpoint()
-        {
-            Object val = GetFieldValue(23, 0, Fit.SubfieldIndexMainField);
-            if(val == null)
-            {
-                return null;
-            }
-
-            return (Convert.ToSingle(val));
-            
-        }
-
-        /// <summary>
-        /// Set CcrLowSetpoint field
-        /// Units: percent
-        /// Comment: Target PO2 when using low setpoint</summary>
-        /// <param name="ccrLowSetpoint_">Nullable field value to be set</param>
-        public void SetCcrLowSetpoint(float? ccrLowSetpoint_)
-        {
-            SetFieldValue(23, 0, ccrLowSetpoint_, Fit.SubfieldIndexMainField);
-        }
-        
-        ///<summary>
-        /// Retrieves the CcrLowSetpointDepth field
-        /// Units: m
-        /// Comment: Depth to switch to low setpoint in automatic mode</summary>
-        /// <returns>Returns nullable float representing the CcrLowSetpointDepth field</returns>
-        public float? GetCcrLowSetpointDepth()
-        {
-            Object val = GetFieldValue(24, 0, Fit.SubfieldIndexMainField);
-            if(val == null)
-            {
-                return null;
-            }
-
-            return (Convert.ToSingle(val));
-            
-        }
-
-        /// <summary>
-        /// Set CcrLowSetpointDepth field
-        /// Units: m
-        /// Comment: Depth to switch to low setpoint in automatic mode</summary>
-        /// <param name="ccrLowSetpointDepth_">Nullable field value to be set</param>
-        public void SetCcrLowSetpointDepth(float? ccrLowSetpointDepth_)
-        {
-            SetFieldValue(24, 0, ccrLowSetpointDepth_, Fit.SubfieldIndexMainField);
-        }
-        
-        ///<summary>
-        /// Retrieves the CcrHighSetpointSwitchMode field
-        /// Comment: If high PO2 should be switched to automatically</summary>
-        /// <returns>Returns nullable CcrSetpointSwitchMode enum representing the CcrHighSetpointSwitchMode field</returns>
-        public CcrSetpointSwitchMode? GetCcrHighSetpointSwitchMode()
-        {
-            object obj = GetFieldValue(25, 0, Fit.SubfieldIndexMainField);
-            CcrSetpointSwitchMode? value = obj == null ? (CcrSetpointSwitchMode?)null : (CcrSetpointSwitchMode)obj;
-            return value;
-        }
-
-        /// <summary>
-        /// Set CcrHighSetpointSwitchMode field
-        /// Comment: If high PO2 should be switched to automatically</summary>
-        /// <param name="ccrHighSetpointSwitchMode_">Nullable field value to be set</param>
-        public void SetCcrHighSetpointSwitchMode(CcrSetpointSwitchMode? ccrHighSetpointSwitchMode_)
-        {
-            SetFieldValue(25, 0, ccrHighSetpointSwitchMode_, Fit.SubfieldIndexMainField);
-        }
-        
-        ///<summary>
-        /// Retrieves the CcrHighSetpoint field
-        /// Units: percent
-        /// Comment: Target PO2 when using high setpoint</summary>
-        /// <returns>Returns nullable float representing the CcrHighSetpoint field</returns>
-        public float? GetCcrHighSetpoint()
-        {
-            Object val = GetFieldValue(26, 0, Fit.SubfieldIndexMainField);
-            if(val == null)
-            {
-                return null;
-            }
-
-            return (Convert.ToSingle(val));
-            
-        }
-
-        /// <summary>
-        /// Set CcrHighSetpoint field
-        /// Units: percent
-        /// Comment: Target PO2 when using high setpoint</summary>
-        /// <param name="ccrHighSetpoint_">Nullable field value to be set</param>
-        public void SetCcrHighSetpoint(float? ccrHighSetpoint_)
-        {
-            SetFieldValue(26, 0, ccrHighSetpoint_, Fit.SubfieldIndexMainField);
-        }
-        
-        ///<summary>
-        /// Retrieves the CcrHighSetpointDepth field
-        /// Units: m
-        /// Comment: Depth to switch to high setpoint in automatic mode</summary>
-        /// <returns>Returns nullable float representing the CcrHighSetpointDepth field</returns>
-        public float? GetCcrHighSetpointDepth()
-        {
-            Object val = GetFieldValue(27, 0, Fit.SubfieldIndexMainField);
-            if(val == null)
-            {
-                return null;
-            }
-
-            return (Convert.ToSingle(val));
-            
-        }
-
-        /// <summary>
-        /// Set CcrHighSetpointDepth field
-        /// Units: m
-        /// Comment: Depth to switch to high setpoint in automatic mode</summary>
-        /// <param name="ccrHighSetpointDepth_">Nullable field value to be set</param>
-        public void SetCcrHighSetpointDepth(float? ccrHighSetpointDepth_)
-        {
-            SetFieldValue(27, 0, ccrHighSetpointDepth_, Fit.SubfieldIndexMainField);
-        }
-        
-        ///<summary>
-        /// Retrieves the GasConsumptionDisplay field
-        /// Comment: Type of gas consumption rate to display. Some values are only valid if tank volume is known.</summary>
-        /// <returns>Returns nullable GasConsumptionRateType enum representing the GasConsumptionDisplay field</returns>
-        public GasConsumptionRateType? GetGasConsumptionDisplay()
-        {
-            object obj = GetFieldValue(29, 0, Fit.SubfieldIndexMainField);
-            GasConsumptionRateType? value = obj == null ? (GasConsumptionRateType?)null : (GasConsumptionRateType)obj;
-            return value;
-        }
-
-        /// <summary>
-        /// Set GasConsumptionDisplay field
-        /// Comment: Type of gas consumption rate to display. Some values are only valid if tank volume is known.</summary>
-        /// <param name="gasConsumptionDisplay_">Nullable field value to be set</param>
-        public void SetGasConsumptionDisplay(GasConsumptionRateType? gasConsumptionDisplay_)
-        {
-            SetFieldValue(29, 0, gasConsumptionDisplay_, Fit.SubfieldIndexMainField);
-        }
-        
-        ///<summary>
-        /// Retrieves the UpKeyEnabled field
-        /// Comment: Indicates whether the up key is enabled during dives</summary>
-        /// <returns>Returns nullable Bool enum representing the UpKeyEnabled field</returns>
-        public Bool? GetUpKeyEnabled()
-        {
-            object obj = GetFieldValue(30, 0, Fit.SubfieldIndexMainField);
-            Bool? value = obj == null ? (Bool?)null : (Bool)obj;
-            return value;
-        }
-
-        /// <summary>
-        /// Set UpKeyEnabled field
-        /// Comment: Indicates whether the up key is enabled during dives</summary>
-        /// <param name="upKeyEnabled_">Nullable field value to be set</param>
-        public void SetUpKeyEnabled(Bool? upKeyEnabled_)
-        {
-            SetFieldValue(30, 0, upKeyEnabled_, Fit.SubfieldIndexMainField);
-        }
-        
-        ///<summary>
-        /// Retrieves the DiveSounds field
-        /// Comment: Sounds and vibration enabled or disabled in-dive</summary>
-        /// <returns>Returns nullable Tone enum representing the DiveSounds field</returns>
-        public Tone? GetDiveSounds()
-        {
-            object obj = GetFieldValue(35, 0, Fit.SubfieldIndexMainField);
-            Tone? value = obj == null ? (Tone?)null : (Tone)obj;
-            return value;
-        }
-
-        /// <summary>
-        /// Set DiveSounds field
-        /// Comment: Sounds and vibration enabled or disabled in-dive</summary>
-        /// <param name="diveSounds_">Nullable field value to be set</param>
-        public void SetDiveSounds(Tone? diveSounds_)
-        {
-            SetFieldValue(35, 0, diveSounds_, Fit.SubfieldIndexMainField);
-        }
-        
-        ///<summary>
-        /// Retrieves the LastStopMultiple field
-        /// Comment: Usually 1.0/1.5/2.0 representing 3/4.5/6m or 10/15/20ft</summary>
-        /// <returns>Returns nullable float representing the LastStopMultiple field</returns>
-        public float? GetLastStopMultiple()
-        {
-            Object val = GetFieldValue(36, 0, Fit.SubfieldIndexMainField);
-            if(val == null)
-            {
-                return null;
-            }
-
-            return (Convert.ToSingle(val));
-            
-        }
-
-        /// <summary>
-        /// Set LastStopMultiple field
-        /// Comment: Usually 1.0/1.5/2.0 representing 3/4.5/6m or 10/15/20ft</summary>
-        /// <param name="lastStopMultiple_">Nullable field value to be set</param>
-        public void SetLastStopMultiple(float? lastStopMultiple_)
-        {
-            SetFieldValue(36, 0, lastStopMultiple_, Fit.SubfieldIndexMainField);
-        }
-        
-        ///<summary>
-        /// Retrieves the NoFlyTimeMode field
-        /// Comment: Indicates which guidelines to use for no-fly surface interval.</summary>
-        /// <returns>Returns nullable NoFlyTimeMode enum representing the NoFlyTimeMode field</returns>
-        public NoFlyTimeMode? GetNoFlyTimeMode()
-        {
-            object obj = GetFieldValue(37, 0, Fit.SubfieldIndexMainField);
-            NoFlyTimeMode? value = obj == null ? (NoFlyTimeMode?)null : (NoFlyTimeMode)obj;
-            return value;
-        }
-
-        /// <summary>
-        /// Set NoFlyTimeMode field
-        /// Comment: Indicates which guidelines to use for no-fly surface interval.</summary>
-        /// <param name="noFlyTimeMode_">Nullable field value to be set</param>
-        public void SetNoFlyTimeMode(NoFlyTimeMode? noFlyTimeMode_)
-        {
-            SetFieldValue(37, 0, noFlyTimeMode_, Fit.SubfieldIndexMainField);
-        }
-        
-        #endregion // Methods
-    } // Class
+	/// <summary>
+	/// Implements the DiveSettings profile message.
+	/// </summary>
+	public class DiveSettingsMesg : Mesg
+	{
+		#region Fields
+		static class HeartRateSourceSubfield
+		{
+			public static ushort HeartRateAntplusDeviceType = 0;
+			public static ushort HeartRateLocalDeviceType = 1;
+			public static ushort Subfields = 2;
+			public static ushort Active = Fit.SubfieldIndexActiveSubfield;
+			public static ushort MainField = Fit.SubfieldIndexMainField;
+		}
+		#endregion
+
+		/// <summary>
+		/// Field Numbers for <see cref="DiveSettingsMesg"/>
+		/// </summary>
+		public sealed class FieldDefNum
+		{
+			public const byte Timestamp = 253;
+			public const byte MessageIndex = 254;
+			public const byte Name = 0;
+			public const byte Model = 1;
+			public const byte GfLow = 2;
+			public const byte GfHigh = 3;
+			public const byte WaterType = 4;
+			public const byte WaterDensity = 5;
+			public const byte Po2Warn = 6;
+			public const byte Po2Critical = 7;
+			public const byte Po2Deco = 8;
+			public const byte SafetyStopEnabled = 9;
+			public const byte BottomDepth = 10;
+			public const byte BottomTime = 11;
+			public const byte ApneaCountdownEnabled = 12;
+			public const byte ApneaCountdownTime = 13;
+			public const byte BacklightMode = 14;
+			public const byte BacklightBrightness = 15;
+			public const byte BacklightTimeout = 16;
+			public const byte RepeatDiveInterval = 17;
+			public const byte SafetyStopTime = 18;
+			public const byte HeartRateSourceType = 19;
+			public const byte HeartRateSource = 20;
+			public const byte TravelGas = 21;
+			public const byte CcrLowSetpointSwitchMode = 22;
+			public const byte CcrLowSetpoint = 23;
+			public const byte CcrLowSetpointDepth = 24;
+			public const byte CcrHighSetpointSwitchMode = 25;
+			public const byte CcrHighSetpoint = 26;
+			public const byte CcrHighSetpointDepth = 27;
+			public const byte GasConsumptionDisplay = 29;
+			public const byte UpKeyEnabled = 30;
+			public const byte DiveSounds = 35;
+			public const byte LastStopMultiple = 36;
+			public const byte NoFlyTimeMode = 37;
+			public const byte Invalid = Fit.FieldNumInvalid;
+		}
+
+		#region Constructors
+		public DiveSettingsMesg() : base(Profile.GetMesg(MesgNum.DiveSettings))
+		{
+		}
+
+		public DiveSettingsMesg(Mesg mesg) : base(mesg)
+		{
+		}
+		#endregion // Constructors
+
+		#region Methods
+		///<summary>
+		/// Retrieves the Timestamp field</summary>
+		/// <returns>Returns DateTime representing the Timestamp field</returns>
+		public DateTime Timestamp
+		{
+			get
+			{
+				Object val = GetFieldValue(253, 0, Fit.SubfieldIndexMainField);
+				if (val == null)
+				{
+					return null;
+				}
+
+				return TimestampToDateTime(Convert.ToUInt32(val));
+
+			}
+			set
+			{
+				SetFieldValue(253, 0, value.GetTimeStamp(), Fit.SubfieldIndexMainField);
+			}
+		}
+
+		///<summary>
+		/// Retrieves the MessageIndex field</summary>
+		/// <returns>Returns nullable ushort representing the MessageIndex field</returns>
+		public ushort? MessageIndex
+		{
+			get
+			{
+				Object val = GetFieldValue(254, 0, Fit.SubfieldIndexMainField);
+				if (val == null)
+				{
+					return null;
+				}
+
+				return (Convert.ToUInt16(val));
+
+			}
+			set
+			{
+				SetFieldValue(254, 0, value, Fit.SubfieldIndexMainField);
+			}
+		}
+
+		///<summary>
+		/// Retrieves the Name field</summary>
+		/// <returns>Returns byte[] representing the Name field</returns>
+		public byte[] Name
+		{
+			get
+			{
+				byte[] data = (byte[])GetFieldValue(0, 0, Fit.SubfieldIndexMainField);
+				return data.Take(data.Length - 1).ToArray();
+			}
+			set
+			{
+				SetFieldValue(0, 0, value, Fit.SubfieldIndexMainField);
+			}
+		}
+
+		///<summary>
+		/// Retrieves the Name field</summary>
+		/// <returns>Returns String representing the Name field</returns>
+		public String GetNameAsString()
+		{
+			byte[] data = (byte[])GetFieldValue(0, 0, Fit.SubfieldIndexMainField);
+			return data != null ? Encoding.UTF8.GetString(data, 0, data.Length - 1) : null;
+		}
+
+		///<summary>
+		/// Set Name field</summary>
+		/// <param name="name_"> field value to be set</param>
+		public void SetName(String name_)
+		{
+			byte[] data = Encoding.UTF8.GetBytes(name_);
+			byte[] zdata = new byte[data.Length + 1];
+			data.CopyTo(zdata, 0);
+			SetFieldValue(0, 0, zdata, Fit.SubfieldIndexMainField);
+		}
+
+		///<summary>
+		/// Retrieves the Model field</summary>
+		/// <returns>Returns nullable TissueModelType enum representing the Model field</returns>
+		public TissueModelType? Model
+		{
+			get
+			{
+				object obj = GetFieldValue(1, 0, Fit.SubfieldIndexMainField);
+				TissueModelType? value = obj == null ? (TissueModelType?)null : (TissueModelType)obj;
+				return value;
+			}
+			set
+			{
+				SetFieldValue(1, 0, value, Fit.SubfieldIndexMainField);
+			}
+		}
+
+		///<summary>
+		/// Retrieves the GfLow field
+		/// Units: percent</summary>
+		/// <returns>Returns nullable byte representing the GfLow field</returns>
+		public byte? GfLow
+		{
+			get
+			{
+				Object val = GetFieldValue(2, 0, Fit.SubfieldIndexMainField);
+				if (val == null)
+				{
+					return null;
+				}
+
+				return (Convert.ToByte(val));
+
+			}
+			set
+			{
+				SetFieldValue(2, 0, value, Fit.SubfieldIndexMainField);
+			}
+		}
+
+		///<summary>
+		/// Retrieves the GfHigh field
+		/// Units: percent</summary>
+		/// <returns>Returns nullable byte representing the GfHigh field</returns>
+		public byte? GfHigh
+		{
+			get
+			{
+				Object val = GetFieldValue(3, 0, Fit.SubfieldIndexMainField);
+				if (val == null)
+				{
+					return null;
+				}
+
+				return (Convert.ToByte(val));
+
+			}
+			set
+			{
+				SetFieldValue(3, 0, value, Fit.SubfieldIndexMainField);
+			}
+		}
+
+		///<summary>
+		/// Retrieves the WaterType field</summary>
+		/// <returns>Returns nullable WaterType enum representing the WaterType field</returns>
+		public WaterType? WaterType
+		{
+			get
+			{
+				object obj = GetFieldValue(4, 0, Fit.SubfieldIndexMainField);
+				WaterType? value = obj == null ? (WaterType?)null : (WaterType)obj;
+				return value;
+			}
+			set
+			{
+				SetFieldValue(4, 0, value, Fit.SubfieldIndexMainField);
+			}
+		}
+
+		///<summary>
+		/// Retrieves the WaterDensity field
+		/// Units: kg/m^3
+		/// Comment: Fresh water is usually 1000; salt water is usually 1025</summary>
+		/// <returns>Returns nullable float representing the WaterDensity field</returns>
+		public float? WaterDensity
+		{
+			get
+			{
+				Object val = GetFieldValue(5, 0, Fit.SubfieldIndexMainField);
+				if (val == null)
+				{
+					return null;
+				}
+
+				return (Convert.ToSingle(val));
+
+			}
+			set
+			{
+				SetFieldValue(5, 0, value, Fit.SubfieldIndexMainField);
+			}
+		}
+
+		///<summary>
+		/// Retrieves the Po2Warn field
+		/// Units: percent
+		/// Comment: Typically 1.40</summary>
+		/// <returns>Returns nullable float representing the Po2Warn field</returns>
+		public float? Po2Warn
+		{
+			get
+			{
+				Object val = GetFieldValue(6, 0, Fit.SubfieldIndexMainField);
+				if (val == null)
+				{
+					return null;
+				}
+
+				return (Convert.ToSingle(val));
+
+			}
+			set
+			{
+				SetFieldValue(6, 0, value, Fit.SubfieldIndexMainField);
+			}
+		}
+
+		///<summary>
+		/// Retrieves the Po2Critical field
+		/// Units: percent
+		/// Comment: Typically 1.60</summary>
+		/// <returns>Returns nullable float representing the Po2Critical field</returns>
+		public float? Po2Critical
+		{
+			get
+			{
+				Object val = GetFieldValue(7, 0, Fit.SubfieldIndexMainField);
+				if (val == null)
+				{
+					return null;
+				}
+
+				return (Convert.ToSingle(val));
+
+			}
+			set
+			{
+				SetFieldValue(7, 0, value, Fit.SubfieldIndexMainField);
+			}
+		}
+
+		///<summary>
+		/// Retrieves the Po2Deco field
+		/// Units: percent</summary>
+		/// <returns>Returns nullable float representing the Po2Deco field</returns>
+		public float? Po2Deco
+		{
+			get
+			{
+				Object val = GetFieldValue(8, 0, Fit.SubfieldIndexMainField);
+				if (val == null)
+				{
+					return null;
+				}
+
+				return (Convert.ToSingle(val));
+
+			}
+			set
+			{
+				SetFieldValue(8, 0, value, Fit.SubfieldIndexMainField);
+			}
+		}
+
+		///<summary>
+		/// Retrieves the SafetyStopEnabled field</summary>
+		/// <returns>Returns nullable Bool enum representing the SafetyStopEnabled field</returns>
+		public Bool? SafetyStopEnabled
+		{
+			get
+			{
+				object obj = GetFieldValue(9, 0, Fit.SubfieldIndexMainField);
+				Bool? value = obj == null ? (Bool?)null : (Bool)obj;
+				return value;
+			}
+			set
+			{
+				SetFieldValue(9, 0, value, Fit.SubfieldIndexMainField);
+			}
+		}
+
+		///<summary>
+		/// Retrieves the BottomDepth field</summary>
+		/// <returns>Returns nullable float representing the BottomDepth field</returns>
+		public float? BottomDepth
+		{
+			get
+			{
+				Object val = GetFieldValue(10, 0, Fit.SubfieldIndexMainField);
+				if (val == null)
+				{
+					return null;
+				}
+
+				return (Convert.ToSingle(val));
+
+			}
+			set
+			{
+				SetFieldValue(10, 0, value, Fit.SubfieldIndexMainField);
+			}
+		}
+
+		///<summary>
+		/// Retrieves the BottomTime field</summary>
+		/// <returns>Returns nullable uint representing the BottomTime field</returns>
+		public uint? BottomTime
+		{
+			get
+			{
+				Object val = GetFieldValue(11, 0, Fit.SubfieldIndexMainField);
+				if (val == null)
+				{
+					return null;
+				}
+
+				return (Convert.ToUInt32(val));
+
+			}
+			set
+			{
+				SetFieldValue(11, 0, value, Fit.SubfieldIndexMainField);
+			}
+		}
+
+		///<summary>
+		/// Retrieves the ApneaCountdownEnabled field</summary>
+		/// <returns>Returns nullable Bool enum representing the ApneaCountdownEnabled field</returns>
+		public Bool? ApneaCountdownEnabled
+		{
+			get
+			{
+				object obj = GetFieldValue(12, 0, Fit.SubfieldIndexMainField);
+				Bool? value = obj == null ? (Bool?)null : (Bool)obj;
+				return value;
+			}
+			set
+			{
+				SetFieldValue(12, 0, value, Fit.SubfieldIndexMainField);
+			}
+		}
+
+		///<summary>
+		/// Retrieves the ApneaCountdownTime field</summary>
+		/// <returns>Returns nullable uint representing the ApneaCountdownTime field</returns>
+		public uint? ApneaCountdownTime
+		{
+			get
+			{
+				Object val = GetFieldValue(13, 0, Fit.SubfieldIndexMainField);
+				if (val == null)
+				{
+					return null;
+				}
+
+				return (Convert.ToUInt32(val));
+
+			}
+			set
+			{
+				SetFieldValue(13, 0, value, Fit.SubfieldIndexMainField);
+			}
+		}
+
+		///<summary>
+		/// Retrieves the BacklightMode field</summary>
+		/// <returns>Returns nullable DiveBacklightMode enum representing the BacklightMode field</returns>
+		public DiveBacklightMode? BacklightMode
+		{
+			get
+			{
+				object obj = GetFieldValue(14, 0, Fit.SubfieldIndexMainField);
+				DiveBacklightMode? value = obj == null ? (DiveBacklightMode?)null : (DiveBacklightMode)obj;
+				return value;
+			}
+			set
+			{
+				SetFieldValue(14, 0, value, Fit.SubfieldIndexMainField);
+			}
+		}
+
+		///<summary>
+		/// Retrieves the BacklightBrightness field</summary>
+		/// <returns>Returns nullable byte representing the BacklightBrightness field</returns>
+		public byte? BacklightBrightness
+		{
+			get
+			{
+				Object val = GetFieldValue(15, 0, Fit.SubfieldIndexMainField);
+				if (val == null)
+				{
+					return null;
+				}
+
+				return (Convert.ToByte(val));
+
+			}
+			set
+			{
+				SetFieldValue(15, 0, value, Fit.SubfieldIndexMainField);
+			}
+		}
+
+		///<summary>
+		/// Retrieves the BacklightTimeout field</summary>
+		/// <returns>Returns nullable byte representing the BacklightTimeout field</returns>
+		public byte? BacklightTimeout
+		{
+			get
+			{
+				Object val = GetFieldValue(16, 0, Fit.SubfieldIndexMainField);
+				if (val == null)
+				{
+					return null;
+				}
+
+				return (Convert.ToByte(val));
+
+			}
+			set
+			{
+				SetFieldValue(16, 0, value, Fit.SubfieldIndexMainField);
+			}
+		}
+
+		///<summary>
+		/// Retrieves the RepeatDiveInterval field
+		/// Units: s
+		/// Comment: Time between surfacing and ending the activity</summary>
+		/// <returns>Returns nullable ushort representing the RepeatDiveInterval field</returns>
+		public ushort? RepeatDiveInterval
+		{
+			get
+			{
+				Object val = GetFieldValue(17, 0, Fit.SubfieldIndexMainField);
+				if (val == null)
+				{
+					return null;
+				}
+
+				return (Convert.ToUInt16(val));
+
+			}
+			set
+			{
+				SetFieldValue(17, 0, value, Fit.SubfieldIndexMainField);
+			}
+		}
+
+		///<summary>
+		/// Retrieves the SafetyStopTime field
+		/// Units: s
+		/// Comment: Time at safety stop (if enabled)</summary>
+		/// <returns>Returns nullable ushort representing the SafetyStopTime field</returns>
+		public ushort? SafetyStopTime
+		{
+			get
+			{
+				Object val = GetFieldValue(18, 0, Fit.SubfieldIndexMainField);
+				if (val == null)
+				{
+					return null;
+				}
+
+				return (Convert.ToUInt16(val));
+
+			}
+			set
+			{
+				SetFieldValue(18, 0, value, Fit.SubfieldIndexMainField);
+			}
+		}
+
+		///<summary>
+		/// Retrieves the HeartRateSourceType field</summary>
+		/// <returns>Returns nullable SourceType enum representing the HeartRateSourceType field</returns>
+		public SourceType? HeartRateSourceType
+		{
+			get
+			{
+				object obj = GetFieldValue(19, 0, Fit.SubfieldIndexMainField);
+				SourceType? value = obj == null ? (SourceType?)null : (SourceType)obj;
+				return value;
+			}
+			set
+			{
+				SetFieldValue(19, 0, value, Fit.SubfieldIndexMainField);
+			}
+		}
+
+		///<summary>
+		/// Retrieves the HeartRateSource field</summary>
+		/// <returns>Returns nullable byte representing the HeartRateSource field</returns>
+		public byte? HeartRateSource
+		{
+			get
+			{
+				Object val = GetFieldValue(20, 0, Fit.SubfieldIndexMainField);
+				if (val == null)
+				{
+					return null;
+				}
+
+				return (Convert.ToByte(val));
+
+			}
+			set
+			{
+				SetFieldValue(20, 0, value, Fit.SubfieldIndexMainField);
+			}
+		}
+
+
+		/// <summary>
+		/// Retrieves the HeartRateAntplusDeviceType subfield</summary>
+		/// <returns>Nullable byte representing the HeartRateAntplusDeviceType subfield</returns>
+		public byte? HeartRateAntplusDeviceType
+		{
+			get
+			{
+				Object val = GetFieldValue(20, 0, HeartRateSourceSubfield.HeartRateAntplusDeviceType);
+				if (val == null)
+				{
+					return null;
+				}
+
+				return (Convert.ToByte(val));
+
+			}
+			set
+			{
+				SetFieldValue(20, 0, value, HeartRateSourceSubfield.HeartRateAntplusDeviceType);
+			}
+		}
+
+		/// <summary>
+		/// Retrieves the HeartRateLocalDeviceType subfield</summary>
+		/// <returns>Nullable byte representing the HeartRateLocalDeviceType subfield</returns>
+		public byte? HeartRateLocalDeviceType
+		{
+			get
+			{
+				Object val = GetFieldValue(20, 0, HeartRateSourceSubfield.HeartRateLocalDeviceType);
+				if (val == null)
+				{
+					return null;
+				}
+
+				return (Convert.ToByte(val));
+
+			}
+			set
+			{
+				SetFieldValue(20, 0, value, HeartRateSourceSubfield.HeartRateLocalDeviceType);
+			}
+		}
+		///<summary>
+		/// Retrieves the TravelGas field
+		/// Comment: Index of travel dive_gas message</summary>
+		/// <returns>Returns nullable ushort representing the TravelGas field</returns>
+		public ushort? TravelGas
+		{
+			get
+			{
+				Object val = GetFieldValue(21, 0, Fit.SubfieldIndexMainField);
+				if (val == null)
+				{
+					return null;
+				}
+
+				return (Convert.ToUInt16(val));
+
+			}
+			set
+			{
+				SetFieldValue(21, 0, value, Fit.SubfieldIndexMainField);
+			}
+		}
+
+		///<summary>
+		/// Retrieves the CcrLowSetpointSwitchMode field
+		/// Comment: If low PO2 should be switched to automatically</summary>
+		/// <returns>Returns nullable CcrSetpointSwitchMode enum representing the CcrLowSetpointSwitchMode field</returns>
+		public CcrSetpointSwitchMode? CcrLowSetpointSwitchMode
+		{
+			get
+			{
+				object obj = GetFieldValue(22, 0, Fit.SubfieldIndexMainField);
+				CcrSetpointSwitchMode? value = obj == null ? (CcrSetpointSwitchMode?)null : (CcrSetpointSwitchMode)obj;
+				return value;
+			}
+			set
+			{
+				SetFieldValue(22, 0, value, Fit.SubfieldIndexMainField);
+			}
+		}
+
+		///<summary>
+		/// Retrieves the CcrLowSetpoint field
+		/// Units: percent
+		/// Comment: Target PO2 when using low setpoint</summary>
+		/// <returns>Returns nullable float representing the CcrLowSetpoint field</returns>
+		public float? CcrLowSetpoint
+		{
+			get
+			{
+				Object val = GetFieldValue(23, 0, Fit.SubfieldIndexMainField);
+				if (val == null)
+				{
+					return null;
+				}
+
+				return (Convert.ToSingle(val));
+
+			}
+			set
+			{
+				SetFieldValue(23, 0, value, Fit.SubfieldIndexMainField);
+			}
+		}
+
+		///<summary>
+		/// Retrieves the CcrLowSetpointDepth field
+		/// Units: m
+		/// Comment: Depth to switch to low setpoint in automatic mode</summary>
+		/// <returns>Returns nullable float representing the CcrLowSetpointDepth field</returns>
+		public float? CcrLowSetpointDepth
+		{
+			get
+			{
+				Object val = GetFieldValue(24, 0, Fit.SubfieldIndexMainField);
+				if (val == null)
+				{
+					return null;
+				}
+
+				return (Convert.ToSingle(val));
+
+			}
+			set
+			{
+				SetFieldValue(24, 0, value, Fit.SubfieldIndexMainField);
+			}
+		}
+
+		///<summary>
+		/// Retrieves the CcrHighSetpointSwitchMode field
+		/// Comment: If high PO2 should be switched to automatically</summary>
+		/// <returns>Returns nullable CcrSetpointSwitchMode enum representing the CcrHighSetpointSwitchMode field</returns>
+		public CcrSetpointSwitchMode? CcrHighSetpointSwitchMode
+		{
+			get
+			{
+				object obj = GetFieldValue(25, 0, Fit.SubfieldIndexMainField);
+				CcrSetpointSwitchMode? value = obj == null ? (CcrSetpointSwitchMode?)null : (CcrSetpointSwitchMode)obj;
+				return value;
+			}
+			set
+			{
+				SetFieldValue(25, 0, value, Fit.SubfieldIndexMainField);
+			}
+		}
+
+		///<summary>
+		/// Retrieves the CcrHighSetpoint field
+		/// Units: percent
+		/// Comment: Target PO2 when using high setpoint</summary>
+		/// <returns>Returns nullable float representing the CcrHighSetpoint field</returns>
+		public float? CcrHighSetpoint
+		{
+			get
+			{
+				Object val = GetFieldValue(26, 0, Fit.SubfieldIndexMainField);
+				if (val == null)
+				{
+					return null;
+				}
+
+				return (Convert.ToSingle(val));
+
+			}
+			set
+			{
+				SetFieldValue(26, 0, value, Fit.SubfieldIndexMainField);
+			}
+		}
+
+		///<summary>
+		/// Retrieves the CcrHighSetpointDepth field
+		/// Units: m
+		/// Comment: Depth to switch to high setpoint in automatic mode</summary>
+		/// <returns>Returns nullable float representing the CcrHighSetpointDepth field</returns>
+		public float? CcrHighSetpointDepth
+		{
+			get
+			{
+				Object val = GetFieldValue(27, 0, Fit.SubfieldIndexMainField);
+				if (val == null)
+				{
+					return null;
+				}
+
+				return (Convert.ToSingle(val));
+
+			}
+			set
+			{
+				SetFieldValue(27, 0, value, Fit.SubfieldIndexMainField);
+			}
+		}
+
+		///<summary>
+		/// Retrieves the GasConsumptionDisplay field
+		/// Comment: Type of gas consumption rate to display. Some values are only valid if tank volume is known.</summary>
+		/// <returns>Returns nullable GasConsumptionRateType enum representing the GasConsumptionDisplay field</returns>
+		public GasConsumptionRateType? GasConsumptionDisplay
+		{
+			get
+			{
+				object obj = GetFieldValue(29, 0, Fit.SubfieldIndexMainField);
+				GasConsumptionRateType? value = obj == null ? (GasConsumptionRateType?)null : (GasConsumptionRateType)obj;
+				return value;
+			}
+			set
+			{
+				SetFieldValue(29, 0, value, Fit.SubfieldIndexMainField);
+			}
+		}
+
+		///<summary>
+		/// Retrieves the UpKeyEnabled field
+		/// Comment: Indicates whether the up key is enabled during dives</summary>
+		/// <returns>Returns nullable Bool enum representing the UpKeyEnabled field</returns>
+		public Bool? UpKeyEnabled
+		{
+			get
+			{
+				object obj = GetFieldValue(30, 0, Fit.SubfieldIndexMainField);
+				Bool? value = obj == null ? (Bool?)null : (Bool)obj;
+				return value;
+			}
+			set
+			{
+				SetFieldValue(30, 0, value, Fit.SubfieldIndexMainField);
+			}
+		}
+
+		///<summary>
+		/// Retrieves the DiveSounds field
+		/// Comment: Sounds and vibration enabled or disabled in-dive</summary>
+		/// <returns>Returns nullable Tone enum representing the DiveSounds field</returns>
+		public Tone? DiveSounds
+		{
+			get
+			{
+				object obj = GetFieldValue(35, 0, Fit.SubfieldIndexMainField);
+				Tone? value = obj == null ? (Tone?)null : (Tone)obj;
+				return value;
+			}
+			set
+			{
+				SetFieldValue(35, 0, value, Fit.SubfieldIndexMainField);
+			}
+		}
+
+		///<summary>
+		/// Retrieves the LastStopMultiple field
+		/// Comment: Usually 1.0/1.5/2.0 representing 3/4.5/6m or 10/15/20ft</summary>
+		/// <returns>Returns nullable float representing the LastStopMultiple field</returns>
+		public float? LastStopMultiple
+		{
+			get
+			{
+				Object val = GetFieldValue(36, 0, Fit.SubfieldIndexMainField);
+				if (val == null)
+				{
+					return null;
+				}
+
+				return (Convert.ToSingle(val));
+
+			}
+			set
+			{
+				SetFieldValue(36, 0, value, Fit.SubfieldIndexMainField);
+			}
+		}
+
+		///<summary>
+		/// Retrieves the NoFlyTimeMode field
+		/// Comment: Indicates which guidelines to use for no-fly surface interval.</summary>
+		/// <returns>Returns nullable NoFlyTimeMode enum representing the NoFlyTimeMode field</returns>
+		public NoFlyTimeMode? NoFlyTimeMode
+		{
+			get
+			{
+				object obj = GetFieldValue(37, 0, Fit.SubfieldIndexMainField);
+				NoFlyTimeMode? value = obj == null ? (NoFlyTimeMode?)null : (NoFlyTimeMode)obj;
+				return value;
+			}
+			set
+			{
+				SetFieldValue(37, 0, value, Fit.SubfieldIndexMainField);
+			}
+		}
+
+		#endregion // Methods
+	} // Class
 } // namespace

--- a/Dynastream/Fit/Profile/Mesgs/DiveSummaryMesg.cs
+++ b/Dynastream/Fit/Profile/Mesgs/DiveSummaryMesg.cs
@@ -21,651 +21,595 @@ using System.Linq;
 
 namespace Dynastream.Fit
 {
-    /// <summary>
-    /// Implements the DiveSummary profile message.
-    /// </summary>
-    public class DiveSummaryMesg : Mesg
-    {
-        #region Fields
-        #endregion
+	/// <summary>
+	/// Implements the DiveSummary profile message.
+	/// </summary>
+	public class DiveSummaryMesg : Mesg
+	{
+		#region Fields
+		#endregion
 
-        /// <summary>
-        /// Field Numbers for <see cref="DiveSummaryMesg"/>
-        /// </summary>
-        public sealed class FieldDefNum
-        {
-            public const byte Timestamp = 253;
-            public const byte ReferenceMesg = 0;
-            public const byte ReferenceIndex = 1;
-            public const byte AvgDepth = 2;
-            public const byte MaxDepth = 3;
-            public const byte SurfaceInterval = 4;
-            public const byte StartCns = 5;
-            public const byte EndCns = 6;
-            public const byte StartN2 = 7;
-            public const byte EndN2 = 8;
-            public const byte O2Toxicity = 9;
-            public const byte DiveNumber = 10;
-            public const byte BottomTime = 11;
-            public const byte AvgPressureSac = 12;
-            public const byte AvgVolumeSac = 13;
-            public const byte AvgRmv = 14;
-            public const byte DescentTime = 15;
-            public const byte AscentTime = 16;
-            public const byte AvgAscentRate = 17;
-            public const byte AvgDescentRate = 22;
-            public const byte MaxAscentRate = 23;
-            public const byte MaxDescentRate = 24;
-            public const byte HangTime = 25;
-            public const byte Invalid = Fit.FieldNumInvalid;
-        }
+		/// <summary>
+		/// Field Numbers for <see cref="DiveSummaryMesg"/>
+		/// </summary>
+		public sealed class FieldDefNum
+		{
+			public const byte Timestamp = 253;
+			public const byte ReferenceMesg = 0;
+			public const byte ReferenceIndex = 1;
+			public const byte AvgDepth = 2;
+			public const byte MaxDepth = 3;
+			public const byte SurfaceInterval = 4;
+			public const byte StartCns = 5;
+			public const byte EndCns = 6;
+			public const byte StartN2 = 7;
+			public const byte EndN2 = 8;
+			public const byte O2Toxicity = 9;
+			public const byte DiveNumber = 10;
+			public const byte BottomTime = 11;
+			public const byte AvgPressureSac = 12;
+			public const byte AvgVolumeSac = 13;
+			public const byte AvgRmv = 14;
+			public const byte DescentTime = 15;
+			public const byte AscentTime = 16;
+			public const byte AvgAscentRate = 17;
+			public const byte AvgDescentRate = 22;
+			public const byte MaxAscentRate = 23;
+			public const byte MaxDescentRate = 24;
+			public const byte HangTime = 25;
+			public const byte Invalid = Fit.FieldNumInvalid;
+		}
 
-        #region Constructors
-        public DiveSummaryMesg() : base(Profile.GetMesg(MesgNum.DiveSummary))
-        {
-        }
+		#region Constructors
+		public DiveSummaryMesg() : base(Profile.GetMesg(MesgNum.DiveSummary))
+		{
+		}
 
-        public DiveSummaryMesg(Mesg mesg) : base(mesg)
-        {
-        }
-        #endregion // Constructors
+		public DiveSummaryMesg(Mesg mesg) : base(mesg)
+		{
+		}
+		#endregion // Constructors
 
-        #region Methods
-        ///<summary>
-        /// Retrieves the Timestamp field
-        /// Units: s</summary>
-        /// <returns>Returns DateTime representing the Timestamp field</returns>
-        public DateTime GetTimestamp()
-        {
-            Object val = GetFieldValue(253, 0, Fit.SubfieldIndexMainField);
-            if(val == null)
-            {
-                return null;
-            }
+		#region Methods
+		///<summary>
+		/// Retrieves the Timestamp field
+		/// Units: s</summary>
+		/// <returns>Returns DateTime representing the Timestamp field</returns>
+		public DateTime Timestamp
+		{
+			get
+			{
+				Object val = GetFieldValue(253, 0, Fit.SubfieldIndexMainField);
+				if (val == null)
+				{
+					return null;
+				}
 
-            return TimestampToDateTime(Convert.ToUInt32(val));
-            
-        }
+				return TimestampToDateTime(Convert.ToUInt32(val));
 
-        /// <summary>
-        /// Set Timestamp field
-        /// Units: s</summary>
-        /// <param name="timestamp_">Nullable field value to be set</param>
-        public void SetTimestamp(DateTime timestamp_)
-        {
-            SetFieldValue(253, 0, timestamp_.GetTimeStamp(), Fit.SubfieldIndexMainField);
-        }
-        
-        ///<summary>
-        /// Retrieves the ReferenceMesg field</summary>
-        /// <returns>Returns nullable ushort representing the ReferenceMesg field</returns>
-        public ushort? GetReferenceMesg()
-        {
-            Object val = GetFieldValue(0, 0, Fit.SubfieldIndexMainField);
-            if(val == null)
-            {
-                return null;
-            }
+			}
+			set
+			{
+				SetFieldValue(253, 0, value.GetTimeStamp(), Fit.SubfieldIndexMainField);
+			}
+		}
 
-            return (Convert.ToUInt16(val));
-            
-        }
+		///<summary>
+		/// Retrieves the ReferenceMesg field</summary>
+		/// <returns>Returns nullable ushort representing the ReferenceMesg field</returns>
+		public ushort? ReferenceMesg
+		{
+			get
+			{
+				Object val = GetFieldValue(0, 0, Fit.SubfieldIndexMainField);
+				if (val == null)
+				{
+					return null;
+				}
 
-        /// <summary>
-        /// Set ReferenceMesg field</summary>
-        /// <param name="referenceMesg_">Nullable field value to be set</param>
-        public void SetReferenceMesg(ushort? referenceMesg_)
-        {
-            SetFieldValue(0, 0, referenceMesg_, Fit.SubfieldIndexMainField);
-        }
-        
-        ///<summary>
-        /// Retrieves the ReferenceIndex field</summary>
-        /// <returns>Returns nullable ushort representing the ReferenceIndex field</returns>
-        public ushort? GetReferenceIndex()
-        {
-            Object val = GetFieldValue(1, 0, Fit.SubfieldIndexMainField);
-            if(val == null)
-            {
-                return null;
-            }
+				return (Convert.ToUInt16(val));
 
-            return (Convert.ToUInt16(val));
-            
-        }
+			}
+			set
+			{
+				SetFieldValue(0, 0, value, Fit.SubfieldIndexMainField);
+			}
+		}
 
-        /// <summary>
-        /// Set ReferenceIndex field</summary>
-        /// <param name="referenceIndex_">Nullable field value to be set</param>
-        public void SetReferenceIndex(ushort? referenceIndex_)
-        {
-            SetFieldValue(1, 0, referenceIndex_, Fit.SubfieldIndexMainField);
-        }
-        
-        ///<summary>
-        /// Retrieves the AvgDepth field
-        /// Units: m
-        /// Comment: 0 if above water</summary>
-        /// <returns>Returns nullable float representing the AvgDepth field</returns>
-        public float? GetAvgDepth()
-        {
-            Object val = GetFieldValue(2, 0, Fit.SubfieldIndexMainField);
-            if(val == null)
-            {
-                return null;
-            }
+		///<summary>
+		/// Retrieves the ReferenceIndex field</summary>
+		/// <returns>Returns nullable ushort representing the ReferenceIndex field</returns>
+		public ushort? ReferenceIndex
+		{
+			get
+			{
+				Object val = GetFieldValue(1, 0, Fit.SubfieldIndexMainField);
+				if (val == null)
+				{
+					return null;
+				}
 
-            return (Convert.ToSingle(val));
-            
-        }
+				return (Convert.ToUInt16(val));
 
-        /// <summary>
-        /// Set AvgDepth field
-        /// Units: m
-        /// Comment: 0 if above water</summary>
-        /// <param name="avgDepth_">Nullable field value to be set</param>
-        public void SetAvgDepth(float? avgDepth_)
-        {
-            SetFieldValue(2, 0, avgDepth_, Fit.SubfieldIndexMainField);
-        }
-        
-        ///<summary>
-        /// Retrieves the MaxDepth field
-        /// Units: m
-        /// Comment: 0 if above water</summary>
-        /// <returns>Returns nullable float representing the MaxDepth field</returns>
-        public float? GetMaxDepth()
-        {
-            Object val = GetFieldValue(3, 0, Fit.SubfieldIndexMainField);
-            if(val == null)
-            {
-                return null;
-            }
+			}
+			set
+			{
+				SetFieldValue(1, 0, value, Fit.SubfieldIndexMainField);
+			}
+		}
 
-            return (Convert.ToSingle(val));
-            
-        }
+		///<summary>
+		/// Retrieves the AvgDepth field
+		/// Units: m
+		/// Comment: 0 if above water</summary>
+		/// <returns>Returns nullable float representing the AvgDepth field</returns>
+		public float? AvgDepth
+		{
+			get
+			{
+				Object val = GetFieldValue(2, 0, Fit.SubfieldIndexMainField);
+				if (val == null)
+				{
+					return null;
+				}
 
-        /// <summary>
-        /// Set MaxDepth field
-        /// Units: m
-        /// Comment: 0 if above water</summary>
-        /// <param name="maxDepth_">Nullable field value to be set</param>
-        public void SetMaxDepth(float? maxDepth_)
-        {
-            SetFieldValue(3, 0, maxDepth_, Fit.SubfieldIndexMainField);
-        }
-        
-        ///<summary>
-        /// Retrieves the SurfaceInterval field
-        /// Units: s
-        /// Comment: Time since end of last dive</summary>
-        /// <returns>Returns nullable uint representing the SurfaceInterval field</returns>
-        public uint? GetSurfaceInterval()
-        {
-            Object val = GetFieldValue(4, 0, Fit.SubfieldIndexMainField);
-            if(val == null)
-            {
-                return null;
-            }
+				return (Convert.ToSingle(val));
 
-            return (Convert.ToUInt32(val));
-            
-        }
+			}
+			set
+			{
+				SetFieldValue(2, 0, value, Fit.SubfieldIndexMainField);
+			}
+		}
 
-        /// <summary>
-        /// Set SurfaceInterval field
-        /// Units: s
-        /// Comment: Time since end of last dive</summary>
-        /// <param name="surfaceInterval_">Nullable field value to be set</param>
-        public void SetSurfaceInterval(uint? surfaceInterval_)
-        {
-            SetFieldValue(4, 0, surfaceInterval_, Fit.SubfieldIndexMainField);
-        }
-        
-        ///<summary>
-        /// Retrieves the StartCns field
-        /// Units: percent</summary>
-        /// <returns>Returns nullable byte representing the StartCns field</returns>
-        public byte? GetStartCns()
-        {
-            Object val = GetFieldValue(5, 0, Fit.SubfieldIndexMainField);
-            if(val == null)
-            {
-                return null;
-            }
+		///<summary>
+		/// Retrieves the MaxDepth field
+		/// Units: m
+		/// Comment: 0 if above water</summary>
+		/// <returns>Returns nullable float representing the MaxDepth field</returns>
+		public float? MaxDepth
+		{
+			get
+			{
+				Object val = GetFieldValue(3, 0, Fit.SubfieldIndexMainField);
+				if (val == null)
+				{
+					return null;
+				}
 
-            return (Convert.ToByte(val));
-            
-        }
+				return (Convert.ToSingle(val));
 
-        /// <summary>
-        /// Set StartCns field
-        /// Units: percent</summary>
-        /// <param name="startCns_">Nullable field value to be set</param>
-        public void SetStartCns(byte? startCns_)
-        {
-            SetFieldValue(5, 0, startCns_, Fit.SubfieldIndexMainField);
-        }
-        
-        ///<summary>
-        /// Retrieves the EndCns field
-        /// Units: percent</summary>
-        /// <returns>Returns nullable byte representing the EndCns field</returns>
-        public byte? GetEndCns()
-        {
-            Object val = GetFieldValue(6, 0, Fit.SubfieldIndexMainField);
-            if(val == null)
-            {
-                return null;
-            }
+			}
+			set
+			{
+				SetFieldValue(3, 0, value, Fit.SubfieldIndexMainField);
+			}
+		}
 
-            return (Convert.ToByte(val));
-            
-        }
+		///<summary>
+		/// Retrieves the SurfaceInterval field
+		/// Units: s
+		/// Comment: Time since end of last dive</summary>
+		/// <returns>Returns nullable uint representing the SurfaceInterval field</returns>
+		public uint? SurfaceInterval
+		{
+			get
+			{
+				Object val = GetFieldValue(4, 0, Fit.SubfieldIndexMainField);
+				if (val == null)
+				{
+					return null;
+				}
 
-        /// <summary>
-        /// Set EndCns field
-        /// Units: percent</summary>
-        /// <param name="endCns_">Nullable field value to be set</param>
-        public void SetEndCns(byte? endCns_)
-        {
-            SetFieldValue(6, 0, endCns_, Fit.SubfieldIndexMainField);
-        }
-        
-        ///<summary>
-        /// Retrieves the StartN2 field
-        /// Units: percent</summary>
-        /// <returns>Returns nullable ushort representing the StartN2 field</returns>
-        public ushort? GetStartN2()
-        {
-            Object val = GetFieldValue(7, 0, Fit.SubfieldIndexMainField);
-            if(val == null)
-            {
-                return null;
-            }
+				return (Convert.ToUInt32(val));
 
-            return (Convert.ToUInt16(val));
-            
-        }
+			}
+			set
+			{
+				SetFieldValue(4, 0, value, Fit.SubfieldIndexMainField);
+			}
+		}
 
-        /// <summary>
-        /// Set StartN2 field
-        /// Units: percent</summary>
-        /// <param name="startN2_">Nullable field value to be set</param>
-        public void SetStartN2(ushort? startN2_)
-        {
-            SetFieldValue(7, 0, startN2_, Fit.SubfieldIndexMainField);
-        }
-        
-        ///<summary>
-        /// Retrieves the EndN2 field
-        /// Units: percent</summary>
-        /// <returns>Returns nullable ushort representing the EndN2 field</returns>
-        public ushort? GetEndN2()
-        {
-            Object val = GetFieldValue(8, 0, Fit.SubfieldIndexMainField);
-            if(val == null)
-            {
-                return null;
-            }
+		///<summary>
+		/// Retrieves the StartCns field
+		/// Units: percent</summary>
+		/// <returns>Returns nullable byte representing the StartCns field</returns>
+		public byte? StartCns
+		{
+			get
+			{
+				Object val = GetFieldValue(5, 0, Fit.SubfieldIndexMainField);
+				if (val == null)
+				{
+					return null;
+				}
 
-            return (Convert.ToUInt16(val));
-            
-        }
+				return (Convert.ToByte(val));
 
-        /// <summary>
-        /// Set EndN2 field
-        /// Units: percent</summary>
-        /// <param name="endN2_">Nullable field value to be set</param>
-        public void SetEndN2(ushort? endN2_)
-        {
-            SetFieldValue(8, 0, endN2_, Fit.SubfieldIndexMainField);
-        }
-        
-        ///<summary>
-        /// Retrieves the O2Toxicity field
-        /// Units: OTUs</summary>
-        /// <returns>Returns nullable ushort representing the O2Toxicity field</returns>
-        public ushort? GetO2Toxicity()
-        {
-            Object val = GetFieldValue(9, 0, Fit.SubfieldIndexMainField);
-            if(val == null)
-            {
-                return null;
-            }
+			}
+			set
+			{
+				SetFieldValue(5, 0, value, Fit.SubfieldIndexMainField);
+			}
+		}
 
-            return (Convert.ToUInt16(val));
-            
-        }
+		///<summary>
+		/// Retrieves the EndCns field
+		/// Units: percent</summary>
+		/// <returns>Returns nullable byte representing the EndCns field</returns>
+		public byte? EndCns
+		{
+			get
+			{
+				Object val = GetFieldValue(6, 0, Fit.SubfieldIndexMainField);
+				if (val == null)
+				{
+					return null;
+				}
 
-        /// <summary>
-        /// Set O2Toxicity field
-        /// Units: OTUs</summary>
-        /// <param name="o2Toxicity_">Nullable field value to be set</param>
-        public void SetO2Toxicity(ushort? o2Toxicity_)
-        {
-            SetFieldValue(9, 0, o2Toxicity_, Fit.SubfieldIndexMainField);
-        }
-        
-        ///<summary>
-        /// Retrieves the DiveNumber field</summary>
-        /// <returns>Returns nullable uint representing the DiveNumber field</returns>
-        public uint? GetDiveNumber()
-        {
-            Object val = GetFieldValue(10, 0, Fit.SubfieldIndexMainField);
-            if(val == null)
-            {
-                return null;
-            }
+				return (Convert.ToByte(val));
 
-            return (Convert.ToUInt32(val));
-            
-        }
+			}
+			set
+			{
+				SetFieldValue(6, 0, value, Fit.SubfieldIndexMainField);
+			}
+		}
 
-        /// <summary>
-        /// Set DiveNumber field</summary>
-        /// <param name="diveNumber_">Nullable field value to be set</param>
-        public void SetDiveNumber(uint? diveNumber_)
-        {
-            SetFieldValue(10, 0, diveNumber_, Fit.SubfieldIndexMainField);
-        }
-        
-        ///<summary>
-        /// Retrieves the BottomTime field
-        /// Units: s</summary>
-        /// <returns>Returns nullable float representing the BottomTime field</returns>
-        public float? GetBottomTime()
-        {
-            Object val = GetFieldValue(11, 0, Fit.SubfieldIndexMainField);
-            if(val == null)
-            {
-                return null;
-            }
+		///<summary>
+		/// Retrieves the StartN2 field
+		/// Units: percent</summary>
+		/// <returns>Returns nullable ushort representing the StartN2 field</returns>
+		public ushort? StartN2
+		{
+			get
+			{
+				Object val = GetFieldValue(7, 0, Fit.SubfieldIndexMainField);
+				if (val == null)
+				{
+					return null;
+				}
 
-            return (Convert.ToSingle(val));
-            
-        }
+				return (Convert.ToUInt16(val));
 
-        /// <summary>
-        /// Set BottomTime field
-        /// Units: s</summary>
-        /// <param name="bottomTime_">Nullable field value to be set</param>
-        public void SetBottomTime(float? bottomTime_)
-        {
-            SetFieldValue(11, 0, bottomTime_, Fit.SubfieldIndexMainField);
-        }
-        
-        ///<summary>
-        /// Retrieves the AvgPressureSac field
-        /// Units: bar/min
-        /// Comment: Average pressure-based surface air consumption</summary>
-        /// <returns>Returns nullable float representing the AvgPressureSac field</returns>
-        public float? GetAvgPressureSac()
-        {
-            Object val = GetFieldValue(12, 0, Fit.SubfieldIndexMainField);
-            if(val == null)
-            {
-                return null;
-            }
+			}
+			set
+			{
+				SetFieldValue(7, 0, value, Fit.SubfieldIndexMainField);
+			}
+		}
 
-            return (Convert.ToSingle(val));
-            
-        }
+		///<summary>
+		/// Retrieves the EndN2 field
+		/// Units: percent</summary>
+		/// <returns>Returns nullable ushort representing the EndN2 field</returns>
+		public ushort? EndN2
+		{
+			get
+			{
+				Object val = GetFieldValue(8, 0, Fit.SubfieldIndexMainField);
+				if (val == null)
+				{
+					return null;
+				}
 
-        /// <summary>
-        /// Set AvgPressureSac field
-        /// Units: bar/min
-        /// Comment: Average pressure-based surface air consumption</summary>
-        /// <param name="avgPressureSac_">Nullable field value to be set</param>
-        public void SetAvgPressureSac(float? avgPressureSac_)
-        {
-            SetFieldValue(12, 0, avgPressureSac_, Fit.SubfieldIndexMainField);
-        }
-        
-        ///<summary>
-        /// Retrieves the AvgVolumeSac field
-        /// Units: L/min
-        /// Comment: Average volumetric surface air consumption</summary>
-        /// <returns>Returns nullable float representing the AvgVolumeSac field</returns>
-        public float? GetAvgVolumeSac()
-        {
-            Object val = GetFieldValue(13, 0, Fit.SubfieldIndexMainField);
-            if(val == null)
-            {
-                return null;
-            }
+				return (Convert.ToUInt16(val));
 
-            return (Convert.ToSingle(val));
-            
-        }
+			}
+			set
+			{
+				SetFieldValue(8, 0, value, Fit.SubfieldIndexMainField);
+			}
+		}
 
-        /// <summary>
-        /// Set AvgVolumeSac field
-        /// Units: L/min
-        /// Comment: Average volumetric surface air consumption</summary>
-        /// <param name="avgVolumeSac_">Nullable field value to be set</param>
-        public void SetAvgVolumeSac(float? avgVolumeSac_)
-        {
-            SetFieldValue(13, 0, avgVolumeSac_, Fit.SubfieldIndexMainField);
-        }
-        
-        ///<summary>
-        /// Retrieves the AvgRmv field
-        /// Units: L/min
-        /// Comment: Average respiratory minute volume</summary>
-        /// <returns>Returns nullable float representing the AvgRmv field</returns>
-        public float? GetAvgRmv()
-        {
-            Object val = GetFieldValue(14, 0, Fit.SubfieldIndexMainField);
-            if(val == null)
-            {
-                return null;
-            }
+		///<summary>
+		/// Retrieves the O2Toxicity field
+		/// Units: OTUs</summary>
+		/// <returns>Returns nullable ushort representing the O2Toxicity field</returns>
+		public ushort? O2Toxicity
+		{
+			get
+			{
+				Object val = GetFieldValue(9, 0, Fit.SubfieldIndexMainField);
+				if (val == null)
+				{
+					return null;
+				}
 
-            return (Convert.ToSingle(val));
-            
-        }
+				return (Convert.ToUInt16(val));
 
-        /// <summary>
-        /// Set AvgRmv field
-        /// Units: L/min
-        /// Comment: Average respiratory minute volume</summary>
-        /// <param name="avgRmv_">Nullable field value to be set</param>
-        public void SetAvgRmv(float? avgRmv_)
-        {
-            SetFieldValue(14, 0, avgRmv_, Fit.SubfieldIndexMainField);
-        }
-        
-        ///<summary>
-        /// Retrieves the DescentTime field
-        /// Units: s
-        /// Comment: Time to reach deepest level stop</summary>
-        /// <returns>Returns nullable float representing the DescentTime field</returns>
-        public float? GetDescentTime()
-        {
-            Object val = GetFieldValue(15, 0, Fit.SubfieldIndexMainField);
-            if(val == null)
-            {
-                return null;
-            }
+			}
+			set
+			{
+				SetFieldValue(9, 0, value, Fit.SubfieldIndexMainField);
+			}
+		}
 
-            return (Convert.ToSingle(val));
-            
-        }
+		///<summary>
+		/// Retrieves the DiveNumber field</summary>
+		/// <returns>Returns nullable uint representing the DiveNumber field</returns>
+		public uint? DiveNumber
+		{
+			get
+			{
+				Object val = GetFieldValue(10, 0, Fit.SubfieldIndexMainField);
+				if (val == null)
+				{
+					return null;
+				}
 
-        /// <summary>
-        /// Set DescentTime field
-        /// Units: s
-        /// Comment: Time to reach deepest level stop</summary>
-        /// <param name="descentTime_">Nullable field value to be set</param>
-        public void SetDescentTime(float? descentTime_)
-        {
-            SetFieldValue(15, 0, descentTime_, Fit.SubfieldIndexMainField);
-        }
-        
-        ///<summary>
-        /// Retrieves the AscentTime field
-        /// Units: s
-        /// Comment: Time after leaving bottom until reaching surface</summary>
-        /// <returns>Returns nullable float representing the AscentTime field</returns>
-        public float? GetAscentTime()
-        {
-            Object val = GetFieldValue(16, 0, Fit.SubfieldIndexMainField);
-            if(val == null)
-            {
-                return null;
-            }
+				return (Convert.ToUInt32(val));
 
-            return (Convert.ToSingle(val));
-            
-        }
+			}
+			set
+			{
+				SetFieldValue(10, 0, value, Fit.SubfieldIndexMainField);
+			}
+		}
 
-        /// <summary>
-        /// Set AscentTime field
-        /// Units: s
-        /// Comment: Time after leaving bottom until reaching surface</summary>
-        /// <param name="ascentTime_">Nullable field value to be set</param>
-        public void SetAscentTime(float? ascentTime_)
-        {
-            SetFieldValue(16, 0, ascentTime_, Fit.SubfieldIndexMainField);
-        }
-        
-        ///<summary>
-        /// Retrieves the AvgAscentRate field
-        /// Units: m/s
-        /// Comment: Average ascent rate, not including descents or stops</summary>
-        /// <returns>Returns nullable float representing the AvgAscentRate field</returns>
-        public float? GetAvgAscentRate()
-        {
-            Object val = GetFieldValue(17, 0, Fit.SubfieldIndexMainField);
-            if(val == null)
-            {
-                return null;
-            }
+		///<summary>
+		/// Retrieves the BottomTime field
+		/// Units: s</summary>
+		/// <returns>Returns nullable float representing the BottomTime field</returns>
+		public float? BottomTime
+		{
+			get
+			{
+				Object val = GetFieldValue(11, 0, Fit.SubfieldIndexMainField);
+				if (val == null)
+				{
+					return null;
+				}
 
-            return (Convert.ToSingle(val));
-            
-        }
+				return (Convert.ToSingle(val));
 
-        /// <summary>
-        /// Set AvgAscentRate field
-        /// Units: m/s
-        /// Comment: Average ascent rate, not including descents or stops</summary>
-        /// <param name="avgAscentRate_">Nullable field value to be set</param>
-        public void SetAvgAscentRate(float? avgAscentRate_)
-        {
-            SetFieldValue(17, 0, avgAscentRate_, Fit.SubfieldIndexMainField);
-        }
-        
-        ///<summary>
-        /// Retrieves the AvgDescentRate field
-        /// Units: m/s
-        /// Comment: Average descent rate, not including ascents or stops</summary>
-        /// <returns>Returns nullable float representing the AvgDescentRate field</returns>
-        public float? GetAvgDescentRate()
-        {
-            Object val = GetFieldValue(22, 0, Fit.SubfieldIndexMainField);
-            if(val == null)
-            {
-                return null;
-            }
+			}
+			set
+			{
+				SetFieldValue(11, 0, value, Fit.SubfieldIndexMainField);
+			}
+		}
 
-            return (Convert.ToSingle(val));
-            
-        }
+		///<summary>
+		/// Retrieves the AvgPressureSac field
+		/// Units: bar/min
+		/// Comment: Average pressure-based surface air consumption</summary>
+		/// <returns>Returns nullable float representing the AvgPressureSac field</returns>
+		public float? AvgPressureSac
+		{
+			get
+			{
+				Object val = GetFieldValue(12, 0, Fit.SubfieldIndexMainField);
+				if (val == null)
+				{
+					return null;
+				}
 
-        /// <summary>
-        /// Set AvgDescentRate field
-        /// Units: m/s
-        /// Comment: Average descent rate, not including ascents or stops</summary>
-        /// <param name="avgDescentRate_">Nullable field value to be set</param>
-        public void SetAvgDescentRate(float? avgDescentRate_)
-        {
-            SetFieldValue(22, 0, avgDescentRate_, Fit.SubfieldIndexMainField);
-        }
-        
-        ///<summary>
-        /// Retrieves the MaxAscentRate field
-        /// Units: m/s
-        /// Comment: Maximum ascent rate</summary>
-        /// <returns>Returns nullable float representing the MaxAscentRate field</returns>
-        public float? GetMaxAscentRate()
-        {
-            Object val = GetFieldValue(23, 0, Fit.SubfieldIndexMainField);
-            if(val == null)
-            {
-                return null;
-            }
+				return (Convert.ToSingle(val));
 
-            return (Convert.ToSingle(val));
-            
-        }
+			}
+			set
+			{
+				SetFieldValue(12, 0, value, Fit.SubfieldIndexMainField);
+			}
+		}
 
-        /// <summary>
-        /// Set MaxAscentRate field
-        /// Units: m/s
-        /// Comment: Maximum ascent rate</summary>
-        /// <param name="maxAscentRate_">Nullable field value to be set</param>
-        public void SetMaxAscentRate(float? maxAscentRate_)
-        {
-            SetFieldValue(23, 0, maxAscentRate_, Fit.SubfieldIndexMainField);
-        }
-        
-        ///<summary>
-        /// Retrieves the MaxDescentRate field
-        /// Units: m/s
-        /// Comment: Maximum descent rate</summary>
-        /// <returns>Returns nullable float representing the MaxDescentRate field</returns>
-        public float? GetMaxDescentRate()
-        {
-            Object val = GetFieldValue(24, 0, Fit.SubfieldIndexMainField);
-            if(val == null)
-            {
-                return null;
-            }
+		///<summary>
+		/// Retrieves the AvgVolumeSac field
+		/// Units: L/min
+		/// Comment: Average volumetric surface air consumption</summary>
+		/// <returns>Returns nullable float representing the AvgVolumeSac field</returns>
+		public float? AvgVolumeSac
+		{
+			get
+			{
+				Object val = GetFieldValue(13, 0, Fit.SubfieldIndexMainField);
+				if (val == null)
+				{
+					return null;
+				}
 
-            return (Convert.ToSingle(val));
-            
-        }
+				return (Convert.ToSingle(val));
 
-        /// <summary>
-        /// Set MaxDescentRate field
-        /// Units: m/s
-        /// Comment: Maximum descent rate</summary>
-        /// <param name="maxDescentRate_">Nullable field value to be set</param>
-        public void SetMaxDescentRate(float? maxDescentRate_)
-        {
-            SetFieldValue(24, 0, maxDescentRate_, Fit.SubfieldIndexMainField);
-        }
-        
-        ///<summary>
-        /// Retrieves the HangTime field
-        /// Units: s
-        /// Comment: Time spent neither ascending nor descending</summary>
-        /// <returns>Returns nullable float representing the HangTime field</returns>
-        public float? GetHangTime()
-        {
-            Object val = GetFieldValue(25, 0, Fit.SubfieldIndexMainField);
-            if(val == null)
-            {
-                return null;
-            }
+			}
+			set
+			{
+				SetFieldValue(13, 0, value, Fit.SubfieldIndexMainField);
+			}
+		}
 
-            return (Convert.ToSingle(val));
-            
-        }
+		///<summary>
+		/// Retrieves the AvgRmv field
+		/// Units: L/min
+		/// Comment: Average respiratory minute volume</summary>
+		/// <returns>Returns nullable float representing the AvgRmv field</returns>
+		public float? AvgRmv
+		{
+			get
+			{
+				Object val = GetFieldValue(14, 0, Fit.SubfieldIndexMainField);
+				if (val == null)
+				{
+					return null;
+				}
 
-        /// <summary>
-        /// Set HangTime field
-        /// Units: s
-        /// Comment: Time spent neither ascending nor descending</summary>
-        /// <param name="hangTime_">Nullable field value to be set</param>
-        public void SetHangTime(float? hangTime_)
-        {
-            SetFieldValue(25, 0, hangTime_, Fit.SubfieldIndexMainField);
-        }
-        
-        #endregion // Methods
-    } // Class
+				return (Convert.ToSingle(val));
+
+			}
+			set
+			{
+				SetFieldValue(14, 0, value, Fit.SubfieldIndexMainField);
+			}
+		}
+
+		///<summary>
+		/// Retrieves the DescentTime field
+		/// Units: s
+		/// Comment: Time to reach deepest level stop</summary>
+		/// <returns>Returns nullable float representing the DescentTime field</returns>
+		public float? DescentTime
+		{
+			get
+			{
+				Object val = GetFieldValue(15, 0, Fit.SubfieldIndexMainField);
+				if (val == null)
+				{
+					return null;
+				}
+
+				return (Convert.ToSingle(val));
+
+			}
+			set
+			{
+				SetFieldValue(15, 0, value, Fit.SubfieldIndexMainField);
+			}
+		}
+
+		///<summary>
+		/// Retrieves the AscentTime field
+		/// Units: s
+		/// Comment: Time after leaving bottom until reaching surface</summary>
+		/// <returns>Returns nullable float representing the AscentTime field</returns>
+		public float? AscentTime
+		{
+			get
+			{
+				Object val = GetFieldValue(16, 0, Fit.SubfieldIndexMainField);
+				if (val == null)
+				{
+					return null;
+				}
+
+				return (Convert.ToSingle(val));
+
+			}
+			set
+			{
+				SetFieldValue(16, 0, value, Fit.SubfieldIndexMainField);
+			}
+		}
+
+		///<summary>
+		/// Retrieves the AvgAscentRate field
+		/// Units: m/s
+		/// Comment: Average ascent rate, not including descents or stops</summary>
+		/// <returns>Returns nullable float representing the AvgAscentRate field</returns>
+		public float? AvgAscentRate
+		{
+			get
+			{
+				Object val = GetFieldValue(17, 0, Fit.SubfieldIndexMainField);
+				if (val == null)
+				{
+					return null;
+				}
+
+				return (Convert.ToSingle(val));
+
+			}
+			set
+			{
+				SetFieldValue(17, 0, value, Fit.SubfieldIndexMainField);
+			}
+		}
+
+		///<summary>
+		/// Retrieves the AvgDescentRate field
+		/// Units: m/s
+		/// Comment: Average descent rate, not including ascents or stops</summary>
+		/// <returns>Returns nullable float representing the AvgDescentRate field</returns>
+		public float? AvgDescentRate
+		{
+			get
+			{
+				Object val = GetFieldValue(22, 0, Fit.SubfieldIndexMainField);
+				if (val == null)
+				{
+					return null;
+				}
+
+				return (Convert.ToSingle(val));
+
+			}
+			set
+			{
+				SetFieldValue(22, 0, value, Fit.SubfieldIndexMainField);
+			}
+		}
+
+		///<summary>
+		/// Retrieves the MaxAscentRate field
+		/// Units: m/s
+		/// Comment: Maximum ascent rate</summary>
+		/// <returns>Returns nullable float representing the MaxAscentRate field</returns>
+		public float? MaxAscentRate
+		{
+			get
+			{
+				Object val = GetFieldValue(23, 0, Fit.SubfieldIndexMainField);
+				if (val == null)
+				{
+					return null;
+				}
+
+				return (Convert.ToSingle(val));
+
+			}
+			set
+			{
+				SetFieldValue(23, 0, value, Fit.SubfieldIndexMainField);
+			}
+		}
+
+		///<summary>
+		/// Retrieves the MaxDescentRate field
+		/// Units: m/s
+		/// Comment: Maximum descent rate</summary>
+		/// <returns>Returns nullable float representing the MaxDescentRate field</returns>
+		public float? MaxDescentRate
+		{
+			get
+			{
+				Object val = GetFieldValue(24, 0, Fit.SubfieldIndexMainField);
+				if (val == null)
+				{
+					return null;
+				}
+
+				return (Convert.ToSingle(val));
+
+			}
+			set
+			{
+				SetFieldValue(24, 0, value, Fit.SubfieldIndexMainField);
+			}
+		}
+
+		///<summary>
+		/// Retrieves the HangTime field
+		/// Units: s
+		/// Comment: Time spent neither ascending nor descending</summary>
+		/// <returns>Returns nullable float representing the HangTime field</returns>
+		public float? HangTime
+		{
+			get
+			{
+				Object val = GetFieldValue(25, 0, Fit.SubfieldIndexMainField);
+				if (val == null)
+				{
+					return null;
+				}
+
+				return (Convert.ToSingle(val));
+
+			}
+			set
+			{
+				SetFieldValue(25, 0, value, Fit.SubfieldIndexMainField);
+			}
+		}
+
+		#endregion // Methods
+	} // Class
 } // namespace

--- a/Dynastream/Fit/Profile/Mesgs/EventMesg.cs
+++ b/Dynastream/Fit/Profile/Mesgs/EventMesg.cs
@@ -21,1121 +21,1029 @@ using System.Linq;
 
 namespace Dynastream.Fit
 {
-    /// <summary>
-    /// Implements the Event profile message.
-    /// </summary>
-    public class EventMesg : Mesg
-    {
-        #region Fields
-        static class DataSubfield
-        {
-            public static ushort TimerTrigger = 0;
-            public static ushort CoursePointIndex = 1;
-            public static ushort BatteryLevel = 2;
-            public static ushort VirtualPartnerSpeed = 3;
-            public static ushort HrHighAlert = 4;
-            public static ushort HrLowAlert = 5;
-            public static ushort SpeedHighAlert = 6;
-            public static ushort SpeedLowAlert = 7;
-            public static ushort CadHighAlert = 8;
-            public static ushort CadLowAlert = 9;
-            public static ushort PowerHighAlert = 10;
-            public static ushort PowerLowAlert = 11;
-            public static ushort TimeDurationAlert = 12;
-            public static ushort DistanceDurationAlert = 13;
-            public static ushort CalorieDurationAlert = 14;
-            public static ushort FitnessEquipmentState = 15;
-            public static ushort SportPoint = 16;
-            public static ushort GearChangeData = 17;
-            public static ushort RiderPosition = 18;
-            public static ushort CommTimeout = 19;
-            public static ushort DiveAlert = 20;
-            public static ushort AutoActivityDetectDuration = 21;
-            public static ushort RadarThreatAlert = 22;
-            public static ushort Subfields = 23;
-            public static ushort Active = Fit.SubfieldIndexActiveSubfield;
-            public static ushort MainField = Fit.SubfieldIndexMainField;
-        }
-        static class StartTimestampSubfield
-        {
-            public static ushort AutoActivityDetectStartTimestamp = 0;
-            public static ushort Subfields = 1;
-            public static ushort Active = Fit.SubfieldIndexActiveSubfield;
-            public static ushort MainField = Fit.SubfieldIndexMainField;
-        }
-        #endregion
-
-        /// <summary>
-        /// Field Numbers for <see cref="EventMesg"/>
-        /// </summary>
-        public sealed class FieldDefNum
-        {
-            public const byte Timestamp = 253;
-            public const byte Event = 0;
-            public const byte EventType = 1;
-            public const byte Data16 = 2;
-            public const byte Data = 3;
-            public const byte EventGroup = 4;
-            public const byte Score = 7;
-            public const byte OpponentScore = 8;
-            public const byte FrontGearNum = 9;
-            public const byte FrontGear = 10;
-            public const byte RearGearNum = 11;
-            public const byte RearGear = 12;
-            public const byte DeviceIndex = 13;
-            public const byte ActivityType = 14;
-            public const byte StartTimestamp = 15;
-            public const byte RadarThreatLevelMax = 21;
-            public const byte RadarThreatCount = 22;
-            public const byte RadarThreatAvgApproachSpeed = 23;
-            public const byte RadarThreatMaxApproachSpeed = 24;
-            public const byte Invalid = Fit.FieldNumInvalid;
-        }
-
-        #region Constructors
-        public EventMesg() : base(Profile.GetMesg(MesgNum.Event))
-        {
-        }
-
-        public EventMesg(Mesg mesg) : base(mesg)
-        {
-        }
-        #endregion // Constructors
-
-        #region Methods
-        ///<summary>
-        /// Retrieves the Timestamp field
-        /// Units: s</summary>
-        /// <returns>Returns DateTime representing the Timestamp field</returns>
-        public DateTime GetTimestamp()
-        {
-            Object val = GetFieldValue(253, 0, Fit.SubfieldIndexMainField);
-            if(val == null)
-            {
-                return null;
-            }
-
-            return TimestampToDateTime(Convert.ToUInt32(val));
-            
-        }
-
-        /// <summary>
-        /// Set Timestamp field
-        /// Units: s</summary>
-        /// <param name="timestamp_">Nullable field value to be set</param>
-        public void SetTimestamp(DateTime timestamp_)
-        {
-            SetFieldValue(253, 0, timestamp_.GetTimeStamp(), Fit.SubfieldIndexMainField);
-        }
-        
-        ///<summary>
-        /// Retrieves the Event field</summary>
-        /// <returns>Returns nullable Event enum representing the Event field</returns>
-        public Event? GetEvent()
-        {
-            object obj = GetFieldValue(0, 0, Fit.SubfieldIndexMainField);
-            Event? value = obj == null ? (Event?)null : (Event)obj;
-            return value;
-        }
-
-        /// <summary>
-        /// Set Event field</summary>
-        /// <param name="event_">Nullable field value to be set</param>
-        public void SetEvent(Event? event_)
-        {
-            SetFieldValue(0, 0, event_, Fit.SubfieldIndexMainField);
-        }
-        
-        ///<summary>
-        /// Retrieves the EventType field</summary>
-        /// <returns>Returns nullable EventType enum representing the EventType field</returns>
-        public EventType? GetEventType()
-        {
-            object obj = GetFieldValue(1, 0, Fit.SubfieldIndexMainField);
-            EventType? value = obj == null ? (EventType?)null : (EventType)obj;
-            return value;
-        }
-
-        /// <summary>
-        /// Set EventType field</summary>
-        /// <param name="eventType_">Nullable field value to be set</param>
-        public void SetEventType(EventType? eventType_)
-        {
-            SetFieldValue(1, 0, eventType_, Fit.SubfieldIndexMainField);
-        }
-        
-        ///<summary>
-        /// Retrieves the Data16 field</summary>
-        /// <returns>Returns nullable ushort representing the Data16 field</returns>
-        public ushort? GetData16()
-        {
-            Object val = GetFieldValue(2, 0, Fit.SubfieldIndexMainField);
-            if(val == null)
-            {
-                return null;
-            }
-
-            return (Convert.ToUInt16(val));
-            
-        }
-
-        /// <summary>
-        /// Set Data16 field</summary>
-        /// <param name="data16_">Nullable field value to be set</param>
-        public void SetData16(ushort? data16_)
-        {
-            SetFieldValue(2, 0, data16_, Fit.SubfieldIndexMainField);
-        }
-        
-        ///<summary>
-        /// Retrieves the Data field</summary>
-        /// <returns>Returns nullable uint representing the Data field</returns>
-        public uint? GetData()
-        {
-            Object val = GetFieldValue(3, 0, Fit.SubfieldIndexMainField);
-            if(val == null)
-            {
-                return null;
-            }
-
-            return (Convert.ToUInt32(val));
-            
-        }
-
-        /// <summary>
-        /// Set Data field</summary>
-        /// <param name="data_">Nullable field value to be set</param>
-        public void SetData(uint? data_)
-        {
-            SetFieldValue(3, 0, data_, Fit.SubfieldIndexMainField);
-        }
-        
-
-        /// <summary>
-        /// Retrieves the TimerTrigger subfield</summary>
-        /// <returns>Nullable TimerTrigger enum representing the TimerTrigger subfield</returns>
-        public TimerTrigger? GetTimerTrigger()
-        {
-            return (TimerTrigger?)GetFieldValue(3, 0, DataSubfield.TimerTrigger);
-        }
-
-        /// <summary>
-        ///
-        /// Set TimerTrigger subfield</summary>
-        /// <param name="timerTrigger">Subfield value to be set</param>
-        public void SetTimerTrigger(byte? timerTrigger)
-        {
-            SetFieldValue(3, 0, timerTrigger, DataSubfield.TimerTrigger);
-        }
-
-        /// <summary>
-        /// Retrieves the CoursePointIndex subfield</summary>
-        /// <returns>Nullable ushort representing the CoursePointIndex subfield</returns>
-        public ushort? GetCoursePointIndex()
-        {
-            Object val = GetFieldValue(3, 0, DataSubfield.CoursePointIndex);
-            if(val == null)
-            {
-                return null;
-            }
-
-            return (Convert.ToUInt16(val));
-            
-        }
-
-        /// <summary>
-        ///
-        /// Set CoursePointIndex subfield</summary>
-        /// <param name="coursePointIndex">Subfield value to be set</param>
-        public void SetCoursePointIndex(ushort? coursePointIndex)
-        {
-            SetFieldValue(3, 0, coursePointIndex, DataSubfield.CoursePointIndex);
-        }
-
-        /// <summary>
-        /// Retrieves the BatteryLevel subfield
-        /// Units: V</summary>
-        /// <returns>Nullable float representing the BatteryLevel subfield</returns>
-        public float? GetBatteryLevel()
-        {
-            Object val = GetFieldValue(3, 0, DataSubfield.BatteryLevel);
-            if(val == null)
-            {
-                return null;
-            }
-
-            return (Convert.ToSingle(val));
-            
-        }
-
-        /// <summary>
-        ///
-        /// Set BatteryLevel subfield
-        /// Units: V</summary>
-        /// <param name="batteryLevel">Subfield value to be set</param>
-        public void SetBatteryLevel(float? batteryLevel)
-        {
-            SetFieldValue(3, 0, batteryLevel, DataSubfield.BatteryLevel);
-        }
-
-        /// <summary>
-        /// Retrieves the VirtualPartnerSpeed subfield
-        /// Units: m/s</summary>
-        /// <returns>Nullable float representing the VirtualPartnerSpeed subfield</returns>
-        public float? GetVirtualPartnerSpeed()
-        {
-            Object val = GetFieldValue(3, 0, DataSubfield.VirtualPartnerSpeed);
-            if(val == null)
-            {
-                return null;
-            }
-
-            return (Convert.ToSingle(val));
-            
-        }
-
-        /// <summary>
-        ///
-        /// Set VirtualPartnerSpeed subfield
-        /// Units: m/s</summary>
-        /// <param name="virtualPartnerSpeed">Subfield value to be set</param>
-        public void SetVirtualPartnerSpeed(float? virtualPartnerSpeed)
-        {
-            SetFieldValue(3, 0, virtualPartnerSpeed, DataSubfield.VirtualPartnerSpeed);
-        }
-
-        /// <summary>
-        /// Retrieves the HrHighAlert subfield
-        /// Units: bpm</summary>
-        /// <returns>Nullable byte representing the HrHighAlert subfield</returns>
-        public byte? GetHrHighAlert()
-        {
-            Object val = GetFieldValue(3, 0, DataSubfield.HrHighAlert);
-            if(val == null)
-            {
-                return null;
-            }
-
-            return (Convert.ToByte(val));
-            
-        }
-
-        /// <summary>
-        ///
-        /// Set HrHighAlert subfield
-        /// Units: bpm</summary>
-        /// <param name="hrHighAlert">Subfield value to be set</param>
-        public void SetHrHighAlert(byte? hrHighAlert)
-        {
-            SetFieldValue(3, 0, hrHighAlert, DataSubfield.HrHighAlert);
-        }
-
-        /// <summary>
-        /// Retrieves the HrLowAlert subfield
-        /// Units: bpm</summary>
-        /// <returns>Nullable byte representing the HrLowAlert subfield</returns>
-        public byte? GetHrLowAlert()
-        {
-            Object val = GetFieldValue(3, 0, DataSubfield.HrLowAlert);
-            if(val == null)
-            {
-                return null;
-            }
-
-            return (Convert.ToByte(val));
-            
-        }
-
-        /// <summary>
-        ///
-        /// Set HrLowAlert subfield
-        /// Units: bpm</summary>
-        /// <param name="hrLowAlert">Subfield value to be set</param>
-        public void SetHrLowAlert(byte? hrLowAlert)
-        {
-            SetFieldValue(3, 0, hrLowAlert, DataSubfield.HrLowAlert);
-        }
-
-        /// <summary>
-        /// Retrieves the SpeedHighAlert subfield
-        /// Units: m/s</summary>
-        /// <returns>Nullable float representing the SpeedHighAlert subfield</returns>
-        public float? GetSpeedHighAlert()
-        {
-            Object val = GetFieldValue(3, 0, DataSubfield.SpeedHighAlert);
-            if(val == null)
-            {
-                return null;
-            }
-
-            return (Convert.ToSingle(val));
-            
-        }
-
-        /// <summary>
-        ///
-        /// Set SpeedHighAlert subfield
-        /// Units: m/s</summary>
-        /// <param name="speedHighAlert">Subfield value to be set</param>
-        public void SetSpeedHighAlert(float? speedHighAlert)
-        {
-            SetFieldValue(3, 0, speedHighAlert, DataSubfield.SpeedHighAlert);
-        }
-
-        /// <summary>
-        /// Retrieves the SpeedLowAlert subfield
-        /// Units: m/s</summary>
-        /// <returns>Nullable float representing the SpeedLowAlert subfield</returns>
-        public float? GetSpeedLowAlert()
-        {
-            Object val = GetFieldValue(3, 0, DataSubfield.SpeedLowAlert);
-            if(val == null)
-            {
-                return null;
-            }
-
-            return (Convert.ToSingle(val));
-            
-        }
-
-        /// <summary>
-        ///
-        /// Set SpeedLowAlert subfield
-        /// Units: m/s</summary>
-        /// <param name="speedLowAlert">Subfield value to be set</param>
-        public void SetSpeedLowAlert(float? speedLowAlert)
-        {
-            SetFieldValue(3, 0, speedLowAlert, DataSubfield.SpeedLowAlert);
-        }
-
-        /// <summary>
-        /// Retrieves the CadHighAlert subfield
-        /// Units: rpm</summary>
-        /// <returns>Nullable ushort representing the CadHighAlert subfield</returns>
-        public ushort? GetCadHighAlert()
-        {
-            Object val = GetFieldValue(3, 0, DataSubfield.CadHighAlert);
-            if(val == null)
-            {
-                return null;
-            }
-
-            return (Convert.ToUInt16(val));
-            
-        }
-
-        /// <summary>
-        ///
-        /// Set CadHighAlert subfield
-        /// Units: rpm</summary>
-        /// <param name="cadHighAlert">Subfield value to be set</param>
-        public void SetCadHighAlert(ushort? cadHighAlert)
-        {
-            SetFieldValue(3, 0, cadHighAlert, DataSubfield.CadHighAlert);
-        }
-
-        /// <summary>
-        /// Retrieves the CadLowAlert subfield
-        /// Units: rpm</summary>
-        /// <returns>Nullable ushort representing the CadLowAlert subfield</returns>
-        public ushort? GetCadLowAlert()
-        {
-            Object val = GetFieldValue(3, 0, DataSubfield.CadLowAlert);
-            if(val == null)
-            {
-                return null;
-            }
-
-            return (Convert.ToUInt16(val));
-            
-        }
-
-        /// <summary>
-        ///
-        /// Set CadLowAlert subfield
-        /// Units: rpm</summary>
-        /// <param name="cadLowAlert">Subfield value to be set</param>
-        public void SetCadLowAlert(ushort? cadLowAlert)
-        {
-            SetFieldValue(3, 0, cadLowAlert, DataSubfield.CadLowAlert);
-        }
-
-        /// <summary>
-        /// Retrieves the PowerHighAlert subfield
-        /// Units: watts</summary>
-        /// <returns>Nullable ushort representing the PowerHighAlert subfield</returns>
-        public ushort? GetPowerHighAlert()
-        {
-            Object val = GetFieldValue(3, 0, DataSubfield.PowerHighAlert);
-            if(val == null)
-            {
-                return null;
-            }
-
-            return (Convert.ToUInt16(val));
-            
-        }
-
-        /// <summary>
-        ///
-        /// Set PowerHighAlert subfield
-        /// Units: watts</summary>
-        /// <param name="powerHighAlert">Subfield value to be set</param>
-        public void SetPowerHighAlert(ushort? powerHighAlert)
-        {
-            SetFieldValue(3, 0, powerHighAlert, DataSubfield.PowerHighAlert);
-        }
-
-        /// <summary>
-        /// Retrieves the PowerLowAlert subfield
-        /// Units: watts</summary>
-        /// <returns>Nullable ushort representing the PowerLowAlert subfield</returns>
-        public ushort? GetPowerLowAlert()
-        {
-            Object val = GetFieldValue(3, 0, DataSubfield.PowerLowAlert);
-            if(val == null)
-            {
-                return null;
-            }
-
-            return (Convert.ToUInt16(val));
-            
-        }
-
-        /// <summary>
-        ///
-        /// Set PowerLowAlert subfield
-        /// Units: watts</summary>
-        /// <param name="powerLowAlert">Subfield value to be set</param>
-        public void SetPowerLowAlert(ushort? powerLowAlert)
-        {
-            SetFieldValue(3, 0, powerLowAlert, DataSubfield.PowerLowAlert);
-        }
-
-        /// <summary>
-        /// Retrieves the TimeDurationAlert subfield
-        /// Units: s</summary>
-        /// <returns>Nullable float representing the TimeDurationAlert subfield</returns>
-        public float? GetTimeDurationAlert()
-        {
-            Object val = GetFieldValue(3, 0, DataSubfield.TimeDurationAlert);
-            if(val == null)
-            {
-                return null;
-            }
-
-            return (Convert.ToSingle(val));
-            
-        }
-
-        /// <summary>
-        ///
-        /// Set TimeDurationAlert subfield
-        /// Units: s</summary>
-        /// <param name="timeDurationAlert">Subfield value to be set</param>
-        public void SetTimeDurationAlert(float? timeDurationAlert)
-        {
-            SetFieldValue(3, 0, timeDurationAlert, DataSubfield.TimeDurationAlert);
-        }
-
-        /// <summary>
-        /// Retrieves the DistanceDurationAlert subfield
-        /// Units: m</summary>
-        /// <returns>Nullable float representing the DistanceDurationAlert subfield</returns>
-        public float? GetDistanceDurationAlert()
-        {
-            Object val = GetFieldValue(3, 0, DataSubfield.DistanceDurationAlert);
-            if(val == null)
-            {
-                return null;
-            }
-
-            return (Convert.ToSingle(val));
-            
-        }
-
-        /// <summary>
-        ///
-        /// Set DistanceDurationAlert subfield
-        /// Units: m</summary>
-        /// <param name="distanceDurationAlert">Subfield value to be set</param>
-        public void SetDistanceDurationAlert(float? distanceDurationAlert)
-        {
-            SetFieldValue(3, 0, distanceDurationAlert, DataSubfield.DistanceDurationAlert);
-        }
-
-        /// <summary>
-        /// Retrieves the CalorieDurationAlert subfield
-        /// Units: calories</summary>
-        /// <returns>Nullable uint representing the CalorieDurationAlert subfield</returns>
-        public uint? GetCalorieDurationAlert()
-        {
-            Object val = GetFieldValue(3, 0, DataSubfield.CalorieDurationAlert);
-            if(val == null)
-            {
-                return null;
-            }
-
-            return (Convert.ToUInt32(val));
-            
-        }
-
-        /// <summary>
-        ///
-        /// Set CalorieDurationAlert subfield
-        /// Units: calories</summary>
-        /// <param name="calorieDurationAlert">Subfield value to be set</param>
-        public void SetCalorieDurationAlert(uint? calorieDurationAlert)
-        {
-            SetFieldValue(3, 0, calorieDurationAlert, DataSubfield.CalorieDurationAlert);
-        }
-
-        /// <summary>
-        /// Retrieves the FitnessEquipmentState subfield</summary>
-        /// <returns>Nullable FitnessEquipmentState enum representing the FitnessEquipmentState subfield</returns>
-        public FitnessEquipmentState? GetFitnessEquipmentState()
-        {
-            return (FitnessEquipmentState?)GetFieldValue(3, 0, DataSubfield.FitnessEquipmentState);
-        }
-
-        /// <summary>
-        ///
-        /// Set FitnessEquipmentState subfield</summary>
-        /// <param name="fitnessEquipmentState">Subfield value to be set</param>
-        public void SetFitnessEquipmentState(byte? fitnessEquipmentState)
-        {
-            SetFieldValue(3, 0, fitnessEquipmentState, DataSubfield.FitnessEquipmentState);
-        }
-
-        /// <summary>
-        /// Retrieves the SportPoint subfield</summary>
-        /// <returns>Nullable uint representing the SportPoint subfield</returns>
-        public uint? GetSportPoint()
-        {
-            Object val = GetFieldValue(3, 0, DataSubfield.SportPoint);
-            if(val == null)
-            {
-                return null;
-            }
-
-            return (Convert.ToUInt32(val));
-            
-        }
-
-        /// <summary>
-        ///
-        /// Set SportPoint subfield</summary>
-        /// <param name="sportPoint">Subfield value to be set</param>
-        public void SetSportPoint(uint? sportPoint)
-        {
-            SetFieldValue(3, 0, sportPoint, DataSubfield.SportPoint);
-        }
-
-        /// <summary>
-        /// Retrieves the GearChangeData subfield</summary>
-        /// <returns>Nullable uint representing the GearChangeData subfield</returns>
-        public uint? GetGearChangeData()
-        {
-            Object val = GetFieldValue(3, 0, DataSubfield.GearChangeData);
-            if(val == null)
-            {
-                return null;
-            }
-
-            return (Convert.ToUInt32(val));
-            
-        }
-
-        /// <summary>
-        ///
-        /// Set GearChangeData subfield</summary>
-        /// <param name="gearChangeData">Subfield value to be set</param>
-        public void SetGearChangeData(uint? gearChangeData)
-        {
-            SetFieldValue(3, 0, gearChangeData, DataSubfield.GearChangeData);
-        }
-
-        /// <summary>
-        /// Retrieves the RiderPosition subfield
-        /// Comment: Indicates the rider position value.</summary>
-        /// <returns>Nullable RiderPositionType enum representing the RiderPosition subfield</returns>
-        public RiderPositionType? GetRiderPosition()
-        {
-            return (RiderPositionType?)GetFieldValue(3, 0, DataSubfield.RiderPosition);
-        }
-
-        /// <summary>
-        ///
-        /// Set RiderPosition subfield
-        /// Comment: Indicates the rider position value.</summary>
-        /// <param name="riderPosition">Subfield value to be set</param>
-        public void SetRiderPosition(byte? riderPosition)
-        {
-            SetFieldValue(3, 0, riderPosition, DataSubfield.RiderPosition);
-        }
-
-        /// <summary>
-        /// Retrieves the CommTimeout subfield</summary>
-        /// <returns>Nullable ushort representing the CommTimeout subfield</returns>
-        public ushort? GetCommTimeout()
-        {
-            Object val = GetFieldValue(3, 0, DataSubfield.CommTimeout);
-            if(val == null)
-            {
-                return null;
-            }
-
-            return (Convert.ToUInt16(val));
-            
-        }
-
-        /// <summary>
-        ///
-        /// Set CommTimeout subfield</summary>
-        /// <param name="commTimeout">Subfield value to be set</param>
-        public void SetCommTimeout(ushort? commTimeout)
-        {
-            SetFieldValue(3, 0, commTimeout, DataSubfield.CommTimeout);
-        }
-
-        /// <summary>
-        /// Retrieves the DiveAlert subfield</summary>
-        /// <returns>Nullable DiveAlert enum representing the DiveAlert subfield</returns>
-        public DiveAlert? GetDiveAlert()
-        {
-            return (DiveAlert?)GetFieldValue(3, 0, DataSubfield.DiveAlert);
-        }
-
-        /// <summary>
-        ///
-        /// Set DiveAlert subfield</summary>
-        /// <param name="diveAlert">Subfield value to be set</param>
-        public void SetDiveAlert(byte? diveAlert)
-        {
-            SetFieldValue(3, 0, diveAlert, DataSubfield.DiveAlert);
-        }
-
-        /// <summary>
-        /// Retrieves the AutoActivityDetectDuration subfield
-        /// Units: min</summary>
-        /// <returns>Nullable ushort representing the AutoActivityDetectDuration subfield</returns>
-        public ushort? GetAutoActivityDetectDuration()
-        {
-            Object val = GetFieldValue(3, 0, DataSubfield.AutoActivityDetectDuration);
-            if(val == null)
-            {
-                return null;
-            }
-
-            return (Convert.ToUInt16(val));
-            
-        }
-
-        /// <summary>
-        ///
-        /// Set AutoActivityDetectDuration subfield
-        /// Units: min</summary>
-        /// <param name="autoActivityDetectDuration">Subfield value to be set</param>
-        public void SetAutoActivityDetectDuration(ushort? autoActivityDetectDuration)
-        {
-            SetFieldValue(3, 0, autoActivityDetectDuration, DataSubfield.AutoActivityDetectDuration);
-        }
-
-        /// <summary>
-        /// Retrieves the RadarThreatAlert subfield
-        /// Comment: The first byte is the radar_threat_level_max, the second byte is the radar_threat_count, third bytes is the average approach speed, and the 4th byte is the max approach speed</summary>
-        /// <returns>Nullable uint representing the RadarThreatAlert subfield</returns>
-        public uint? GetRadarThreatAlert()
-        {
-            Object val = GetFieldValue(3, 0, DataSubfield.RadarThreatAlert);
-            if(val == null)
-            {
-                return null;
-            }
-
-            return (Convert.ToUInt32(val));
-            
-        }
-
-        /// <summary>
-        ///
-        /// Set RadarThreatAlert subfield
-        /// Comment: The first byte is the radar_threat_level_max, the second byte is the radar_threat_count, third bytes is the average approach speed, and the 4th byte is the max approach speed</summary>
-        /// <param name="radarThreatAlert">Subfield value to be set</param>
-        public void SetRadarThreatAlert(uint? radarThreatAlert)
-        {
-            SetFieldValue(3, 0, radarThreatAlert, DataSubfield.RadarThreatAlert);
-        }
-        ///<summary>
-        /// Retrieves the EventGroup field</summary>
-        /// <returns>Returns nullable byte representing the EventGroup field</returns>
-        public byte? GetEventGroup()
-        {
-            Object val = GetFieldValue(4, 0, Fit.SubfieldIndexMainField);
-            if(val == null)
-            {
-                return null;
-            }
-
-            return (Convert.ToByte(val));
-            
-        }
-
-        /// <summary>
-        /// Set EventGroup field</summary>
-        /// <param name="eventGroup_">Nullable field value to be set</param>
-        public void SetEventGroup(byte? eventGroup_)
-        {
-            SetFieldValue(4, 0, eventGroup_, Fit.SubfieldIndexMainField);
-        }
-        
-        ///<summary>
-        /// Retrieves the Score field
-        /// Comment: Do not populate directly. Autogenerated by decoder for sport_point subfield components</summary>
-        /// <returns>Returns nullable ushort representing the Score field</returns>
-        public ushort? GetScore()
-        {
-            Object val = GetFieldValue(7, 0, Fit.SubfieldIndexMainField);
-            if(val == null)
-            {
-                return null;
-            }
-
-            return (Convert.ToUInt16(val));
-            
-        }
-
-        /// <summary>
-        /// Set Score field
-        /// Comment: Do not populate directly. Autogenerated by decoder for sport_point subfield components</summary>
-        /// <param name="score_">Nullable field value to be set</param>
-        public void SetScore(ushort? score_)
-        {
-            SetFieldValue(7, 0, score_, Fit.SubfieldIndexMainField);
-        }
-        
-        ///<summary>
-        /// Retrieves the OpponentScore field
-        /// Comment: Do not populate directly. Autogenerated by decoder for sport_point subfield components</summary>
-        /// <returns>Returns nullable ushort representing the OpponentScore field</returns>
-        public ushort? GetOpponentScore()
-        {
-            Object val = GetFieldValue(8, 0, Fit.SubfieldIndexMainField);
-            if(val == null)
-            {
-                return null;
-            }
-
-            return (Convert.ToUInt16(val));
-            
-        }
-
-        /// <summary>
-        /// Set OpponentScore field
-        /// Comment: Do not populate directly. Autogenerated by decoder for sport_point subfield components</summary>
-        /// <param name="opponentScore_">Nullable field value to be set</param>
-        public void SetOpponentScore(ushort? opponentScore_)
-        {
-            SetFieldValue(8, 0, opponentScore_, Fit.SubfieldIndexMainField);
-        }
-        
-        ///<summary>
-        /// Retrieves the FrontGearNum field
-        /// Comment: Do not populate directly. Autogenerated by decoder for gear_change subfield components. Front gear number. 1 is innermost.</summary>
-        /// <returns>Returns nullable byte representing the FrontGearNum field</returns>
-        public byte? GetFrontGearNum()
-        {
-            Object val = GetFieldValue(9, 0, Fit.SubfieldIndexMainField);
-            if(val == null)
-            {
-                return null;
-            }
-
-            return (Convert.ToByte(val));
-            
-        }
-
-        /// <summary>
-        /// Set FrontGearNum field
-        /// Comment: Do not populate directly. Autogenerated by decoder for gear_change subfield components. Front gear number. 1 is innermost.</summary>
-        /// <param name="frontGearNum_">Nullable field value to be set</param>
-        public void SetFrontGearNum(byte? frontGearNum_)
-        {
-            SetFieldValue(9, 0, frontGearNum_, Fit.SubfieldIndexMainField);
-        }
-        
-        ///<summary>
-        /// Retrieves the FrontGear field
-        /// Comment: Do not populate directly. Autogenerated by decoder for gear_change subfield components. Number of front teeth.</summary>
-        /// <returns>Returns nullable byte representing the FrontGear field</returns>
-        public byte? GetFrontGear()
-        {
-            Object val = GetFieldValue(10, 0, Fit.SubfieldIndexMainField);
-            if(val == null)
-            {
-                return null;
-            }
-
-            return (Convert.ToByte(val));
-            
-        }
-
-        /// <summary>
-        /// Set FrontGear field
-        /// Comment: Do not populate directly. Autogenerated by decoder for gear_change subfield components. Number of front teeth.</summary>
-        /// <param name="frontGear_">Nullable field value to be set</param>
-        public void SetFrontGear(byte? frontGear_)
-        {
-            SetFieldValue(10, 0, frontGear_, Fit.SubfieldIndexMainField);
-        }
-        
-        ///<summary>
-        /// Retrieves the RearGearNum field
-        /// Comment: Do not populate directly. Autogenerated by decoder for gear_change subfield components. Rear gear number. 1 is innermost.</summary>
-        /// <returns>Returns nullable byte representing the RearGearNum field</returns>
-        public byte? GetRearGearNum()
-        {
-            Object val = GetFieldValue(11, 0, Fit.SubfieldIndexMainField);
-            if(val == null)
-            {
-                return null;
-            }
-
-            return (Convert.ToByte(val));
-            
-        }
-
-        /// <summary>
-        /// Set RearGearNum field
-        /// Comment: Do not populate directly. Autogenerated by decoder for gear_change subfield components. Rear gear number. 1 is innermost.</summary>
-        /// <param name="rearGearNum_">Nullable field value to be set</param>
-        public void SetRearGearNum(byte? rearGearNum_)
-        {
-            SetFieldValue(11, 0, rearGearNum_, Fit.SubfieldIndexMainField);
-        }
-        
-        ///<summary>
-        /// Retrieves the RearGear field
-        /// Comment: Do not populate directly. Autogenerated by decoder for gear_change subfield components. Number of rear teeth.</summary>
-        /// <returns>Returns nullable byte representing the RearGear field</returns>
-        public byte? GetRearGear()
-        {
-            Object val = GetFieldValue(12, 0, Fit.SubfieldIndexMainField);
-            if(val == null)
-            {
-                return null;
-            }
-
-            return (Convert.ToByte(val));
-            
-        }
-
-        /// <summary>
-        /// Set RearGear field
-        /// Comment: Do not populate directly. Autogenerated by decoder for gear_change subfield components. Number of rear teeth.</summary>
-        /// <param name="rearGear_">Nullable field value to be set</param>
-        public void SetRearGear(byte? rearGear_)
-        {
-            SetFieldValue(12, 0, rearGear_, Fit.SubfieldIndexMainField);
-        }
-        
-        ///<summary>
-        /// Retrieves the DeviceIndex field</summary>
-        /// <returns>Returns nullable byte representing the DeviceIndex field</returns>
-        public byte? GetDeviceIndex()
-        {
-            Object val = GetFieldValue(13, 0, Fit.SubfieldIndexMainField);
-            if(val == null)
-            {
-                return null;
-            }
-
-            return (Convert.ToByte(val));
-            
-        }
-
-        /// <summary>
-        /// Set DeviceIndex field</summary>
-        /// <param name="deviceIndex_">Nullable field value to be set</param>
-        public void SetDeviceIndex(byte? deviceIndex_)
-        {
-            SetFieldValue(13, 0, deviceIndex_, Fit.SubfieldIndexMainField);
-        }
-        
-        ///<summary>
-        /// Retrieves the ActivityType field
-        /// Comment: Activity Type associated with an auto_activity_detect event</summary>
-        /// <returns>Returns nullable ActivityType enum representing the ActivityType field</returns>
-        public ActivityType? GetActivityType()
-        {
-            object obj = GetFieldValue(14, 0, Fit.SubfieldIndexMainField);
-            ActivityType? value = obj == null ? (ActivityType?)null : (ActivityType)obj;
-            return value;
-        }
-
-        /// <summary>
-        /// Set ActivityType field
-        /// Comment: Activity Type associated with an auto_activity_detect event</summary>
-        /// <param name="activityType_">Nullable field value to be set</param>
-        public void SetActivityType(ActivityType? activityType_)
-        {
-            SetFieldValue(14, 0, activityType_, Fit.SubfieldIndexMainField);
-        }
-        
-        ///<summary>
-        /// Retrieves the StartTimestamp field
-        /// Units: s
-        /// Comment: Timestamp of when the event started</summary>
-        /// <returns>Returns DateTime representing the StartTimestamp field</returns>
-        public DateTime GetStartTimestamp()
-        {
-            Object val = GetFieldValue(15, 0, Fit.SubfieldIndexMainField);
-            if(val == null)
-            {
-                return null;
-            }
-
-            return TimestampToDateTime(Convert.ToUInt32(val));
-            
-        }
-
-        /// <summary>
-        /// Set StartTimestamp field
-        /// Units: s
-        /// Comment: Timestamp of when the event started</summary>
-        /// <param name="startTimestamp_">Nullable field value to be set</param>
-        public void SetStartTimestamp(DateTime startTimestamp_)
-        {
-            SetFieldValue(15, 0, startTimestamp_.GetTimeStamp(), Fit.SubfieldIndexMainField);
-        }
-        
-
-        /// <summary>
-        /// Retrieves the AutoActivityDetectStartTimestamp subfield
-        /// Units: s
-        /// Comment: Auto Activity Detect Start Timestamp.</summary>
-        /// <returns>Nullable uint representing the AutoActivityDetectStartTimestamp subfield</returns>
-        public DateTime GetAutoActivityDetectStartTimestamp()
-        {
-            Object val = GetFieldValue(15, 0, StartTimestampSubfield.AutoActivityDetectStartTimestamp);
-            if(val == null)
-            {
-                return null;
-            }
-
-            return TimestampToDateTime(Convert.ToUInt32(val));
-            
-        }
-
-        /// <summary>
-        ///
-        /// Set AutoActivityDetectStartTimestamp subfield
-        /// Units: s
-        /// Comment: Auto Activity Detect Start Timestamp.</summary>
-        /// <param name="autoActivityDetectStartTimestamp">Subfield value to be set</param>
-        public void SetAutoActivityDetectStartTimestamp(DateTime autoActivityDetectStartTimestamp)
-        {
-            SetFieldValue(15, 0, autoActivityDetectStartTimestamp.GetTimeStamp(), StartTimestampSubfield.AutoActivityDetectStartTimestamp);
-        }
-        ///<summary>
-        /// Retrieves the RadarThreatLevelMax field
-        /// Comment: Do not populate directly. Autogenerated by decoder for threat_alert subfield components.</summary>
-        /// <returns>Returns nullable RadarThreatLevelType enum representing the RadarThreatLevelMax field</returns>
-        public RadarThreatLevelType? GetRadarThreatLevelMax()
-        {
-            object obj = GetFieldValue(21, 0, Fit.SubfieldIndexMainField);
-            RadarThreatLevelType? value = obj == null ? (RadarThreatLevelType?)null : (RadarThreatLevelType)obj;
-            return value;
-        }
-
-        /// <summary>
-        /// Set RadarThreatLevelMax field
-        /// Comment: Do not populate directly. Autogenerated by decoder for threat_alert subfield components.</summary>
-        /// <param name="radarThreatLevelMax_">Nullable field value to be set</param>
-        public void SetRadarThreatLevelMax(RadarThreatLevelType? radarThreatLevelMax_)
-        {
-            SetFieldValue(21, 0, radarThreatLevelMax_, Fit.SubfieldIndexMainField);
-        }
-        
-        ///<summary>
-        /// Retrieves the RadarThreatCount field
-        /// Comment: Do not populate directly. Autogenerated by decoder for threat_alert subfield components.</summary>
-        /// <returns>Returns nullable byte representing the RadarThreatCount field</returns>
-        public byte? GetRadarThreatCount()
-        {
-            Object val = GetFieldValue(22, 0, Fit.SubfieldIndexMainField);
-            if(val == null)
-            {
-                return null;
-            }
-
-            return (Convert.ToByte(val));
-            
-        }
-
-        /// <summary>
-        /// Set RadarThreatCount field
-        /// Comment: Do not populate directly. Autogenerated by decoder for threat_alert subfield components.</summary>
-        /// <param name="radarThreatCount_">Nullable field value to be set</param>
-        public void SetRadarThreatCount(byte? radarThreatCount_)
-        {
-            SetFieldValue(22, 0, radarThreatCount_, Fit.SubfieldIndexMainField);
-        }
-        
-        ///<summary>
-        /// Retrieves the RadarThreatAvgApproachSpeed field
-        /// Units: m/s
-        /// Comment: Do not populate directly. Autogenerated by decoder for radar_threat_alert subfield components</summary>
-        /// <returns>Returns nullable float representing the RadarThreatAvgApproachSpeed field</returns>
-        public float? GetRadarThreatAvgApproachSpeed()
-        {
-            Object val = GetFieldValue(23, 0, Fit.SubfieldIndexMainField);
-            if(val == null)
-            {
-                return null;
-            }
-
-            return (Convert.ToSingle(val));
-            
-        }
-
-        /// <summary>
-        /// Set RadarThreatAvgApproachSpeed field
-        /// Units: m/s
-        /// Comment: Do not populate directly. Autogenerated by decoder for radar_threat_alert subfield components</summary>
-        /// <param name="radarThreatAvgApproachSpeed_">Nullable field value to be set</param>
-        public void SetRadarThreatAvgApproachSpeed(float? radarThreatAvgApproachSpeed_)
-        {
-            SetFieldValue(23, 0, radarThreatAvgApproachSpeed_, Fit.SubfieldIndexMainField);
-        }
-        
-        ///<summary>
-        /// Retrieves the RadarThreatMaxApproachSpeed field
-        /// Units: m/s
-        /// Comment: Do not populate directly. Autogenerated by decoder for radar_threat_alert subfield components</summary>
-        /// <returns>Returns nullable float representing the RadarThreatMaxApproachSpeed field</returns>
-        public float? GetRadarThreatMaxApproachSpeed()
-        {
-            Object val = GetFieldValue(24, 0, Fit.SubfieldIndexMainField);
-            if(val == null)
-            {
-                return null;
-            }
-
-            return (Convert.ToSingle(val));
-            
-        }
-
-        /// <summary>
-        /// Set RadarThreatMaxApproachSpeed field
-        /// Units: m/s
-        /// Comment: Do not populate directly. Autogenerated by decoder for radar_threat_alert subfield components</summary>
-        /// <param name="radarThreatMaxApproachSpeed_">Nullable field value to be set</param>
-        public void SetRadarThreatMaxApproachSpeed(float? radarThreatMaxApproachSpeed_)
-        {
-            SetFieldValue(24, 0, radarThreatMaxApproachSpeed_, Fit.SubfieldIndexMainField);
-        }
-        
-        #endregion // Methods
-    } // Class
+	/// <summary>
+	/// Implements the Event profile message.
+	/// </summary>
+	public class EventMesg : Mesg
+	{
+		#region Fields
+		static class DataSubfield
+		{
+			public static ushort TimerTrigger = 0;
+			public static ushort CoursePointIndex = 1;
+			public static ushort BatteryLevel = 2;
+			public static ushort VirtualPartnerSpeed = 3;
+			public static ushort HrHighAlert = 4;
+			public static ushort HrLowAlert = 5;
+			public static ushort SpeedHighAlert = 6;
+			public static ushort SpeedLowAlert = 7;
+			public static ushort CadHighAlert = 8;
+			public static ushort CadLowAlert = 9;
+			public static ushort PowerHighAlert = 10;
+			public static ushort PowerLowAlert = 11;
+			public static ushort TimeDurationAlert = 12;
+			public static ushort DistanceDurationAlert = 13;
+			public static ushort CalorieDurationAlert = 14;
+			public static ushort FitnessEquipmentState = 15;
+			public static ushort SportPoint = 16;
+			public static ushort GearChangeData = 17;
+			public static ushort RiderPosition = 18;
+			public static ushort CommTimeout = 19;
+			public static ushort DiveAlert = 20;
+			public static ushort AutoActivityDetectDuration = 21;
+			public static ushort RadarThreatAlert = 22;
+			public static ushort Subfields = 23;
+			public static ushort Active = Fit.SubfieldIndexActiveSubfield;
+			public static ushort MainField = Fit.SubfieldIndexMainField;
+		}
+		static class StartTimestampSubfield
+		{
+			public static ushort AutoActivityDetectStartTimestamp = 0;
+			public static ushort Subfields = 1;
+			public static ushort Active = Fit.SubfieldIndexActiveSubfield;
+			public static ushort MainField = Fit.SubfieldIndexMainField;
+		}
+		#endregion
+
+		/// <summary>
+		/// Field Numbers for <see cref="EventMesg"/>
+		/// </summary>
+		public sealed class FieldDefNum
+		{
+			public const byte Timestamp = 253;
+			public const byte Event = 0;
+			public const byte EventType = 1;
+			public const byte Data16 = 2;
+			public const byte Data = 3;
+			public const byte EventGroup = 4;
+			public const byte Score = 7;
+			public const byte OpponentScore = 8;
+			public const byte FrontGearNum = 9;
+			public const byte FrontGear = 10;
+			public const byte RearGearNum = 11;
+			public const byte RearGear = 12;
+			public const byte DeviceIndex = 13;
+			public const byte ActivityType = 14;
+			public const byte StartTimestamp = 15;
+			public const byte RadarThreatLevelMax = 21;
+			public const byte RadarThreatCount = 22;
+			public const byte RadarThreatAvgApproachSpeed = 23;
+			public const byte RadarThreatMaxApproachSpeed = 24;
+			public const byte Invalid = Fit.FieldNumInvalid;
+		}
+
+		#region Constructors
+		public EventMesg() : base(Profile.GetMesg(MesgNum.Event))
+		{
+		}
+
+		public EventMesg(Mesg mesg) : base(mesg)
+		{
+		}
+		#endregion // Constructors
+
+		#region Methods
+		///<summary>
+		/// Retrieves the Timestamp field
+		/// Units: s</summary>
+		/// <returns>Returns DateTime representing the Timestamp field</returns>
+		public DateTime Timestamp
+		{
+			get
+			{
+				Object val = GetFieldValue(253, 0, Fit.SubfieldIndexMainField);
+				if (val == null)
+				{
+					return null;
+				}
+
+				return TimestampToDateTime(Convert.ToUInt32(val));
+
+			}
+			set
+			{
+				SetFieldValue(253, 0, value.GetTimeStamp(), Fit.SubfieldIndexMainField);
+			}
+		}
+
+		///<summary>
+		/// Retrieves the Event field</summary>
+		/// <returns>Returns nullable Event enum representing the Event field</returns>
+		public Event? Event
+		{
+			get
+			{
+				object obj = GetFieldValue(0, 0, Fit.SubfieldIndexMainField);
+				Event? value = obj == null ? (Event?)null : (Event)obj;
+				return value;
+			}
+			set
+			{
+				SetFieldValue(0, 0, value, Fit.SubfieldIndexMainField);
+			}
+		}
+
+		///<summary>
+		/// Retrieves the EventType field</summary>
+		/// <returns>Returns nullable EventType enum representing the EventType field</returns>
+		public EventType? EventType
+		{
+			get
+			{
+				object obj = GetFieldValue(1, 0, Fit.SubfieldIndexMainField);
+				EventType? value = obj == null ? (EventType?)null : (EventType)obj;
+				return value;
+			}
+			set
+			{
+				SetFieldValue(1, 0, value, Fit.SubfieldIndexMainField);
+			}
+		}
+
+		///<summary>
+		/// Retrieves the Data16 field</summary>
+		/// <returns>Returns nullable ushort representing the Data16 field</returns>
+		public ushort? Data16
+		{
+			get
+			{
+				Object val = GetFieldValue(2, 0, Fit.SubfieldIndexMainField);
+				if (val == null)
+				{
+					return null;
+				}
+
+				return (Convert.ToUInt16(val));
+
+			}
+			set
+			{
+				SetFieldValue(2, 0, value, Fit.SubfieldIndexMainField);
+			}
+		}
+
+		///<summary>
+		/// Retrieves the Data field</summary>
+		/// <returns>Returns nullable uint representing the Data field</returns>
+		public uint? Data
+		{
+			get
+			{
+				Object val = GetFieldValue(3, 0, Fit.SubfieldIndexMainField);
+				if (val == null)
+				{
+					return null;
+				}
+
+				return (Convert.ToUInt32(val));
+
+			}
+			set
+			{
+				SetFieldValue(3, 0, value, Fit.SubfieldIndexMainField);
+			}
+		}
+
+
+		/// <summary>
+		/// Retrieves the TimerTrigger subfield</summary>
+		/// <returns>Nullable TimerTrigger enum representing the TimerTrigger subfield</returns>
+		public TimerTrigger? GetTimerTrigger()
+		{
+			return (TimerTrigger?)GetFieldValue(3, 0, DataSubfield.TimerTrigger);
+		}
+
+		/// <summary>
+		///
+		/// Set TimerTrigger subfield</summary>
+		/// <param name="timerTrigger">Subfield value to be set</param>
+		public void SetTimerTrigger(byte? timerTrigger)
+		{
+			SetFieldValue(3, 0, timerTrigger, DataSubfield.TimerTrigger);
+		}
+
+		/// <summary>
+		/// Retrieves the CoursePointIndex subfield</summary>
+		/// <returns>Nullable ushort representing the CoursePointIndex subfield</returns>
+		public ushort? CoursePointIndex
+		{
+			get
+			{
+				Object val = GetFieldValue(3, 0, DataSubfield.CoursePointIndex);
+				if (val == null)
+				{
+					return null;
+				}
+
+				return (Convert.ToUInt16(val));
+
+			}
+			set
+			{
+				SetFieldValue(3, 0, value, DataSubfield.CoursePointIndex);
+			}
+		}
+
+		/// <summary>
+		/// Retrieves the BatteryLevel subfield
+		/// Units: V</summary>
+		/// <returns>Nullable float representing the BatteryLevel subfield</returns>
+		public float? BatteryLevel
+		{
+			get
+			{
+				Object val = GetFieldValue(3, 0, DataSubfield.BatteryLevel);
+				if (val == null)
+				{
+					return null;
+				}
+
+				return (Convert.ToSingle(val));
+
+			}
+			set
+			{
+				SetFieldValue(3, 0, value, DataSubfield.BatteryLevel);
+			}
+		}
+
+		/// <summary>
+		/// Retrieves the VirtualPartnerSpeed subfield
+		/// Units: m/s</summary>
+		/// <returns>Nullable float representing the VirtualPartnerSpeed subfield</returns>
+		public float? VirtualPartnerSpeed
+		{
+			get
+			{
+				Object val = GetFieldValue(3, 0, DataSubfield.VirtualPartnerSpeed);
+				if (val == null)
+				{
+					return null;
+				}
+
+				return (Convert.ToSingle(val));
+
+			}
+			set
+			{
+				SetFieldValue(3, 0, value, DataSubfield.VirtualPartnerSpeed);
+			}
+		}
+
+		/// <summary>
+		/// Retrieves the HrHighAlert subfield
+		/// Units: bpm</summary>
+		/// <returns>Nullable byte representing the HrHighAlert subfield</returns>
+		public byte? HrHighAlert
+		{
+			get
+			{
+				Object val = GetFieldValue(3, 0, DataSubfield.HrHighAlert);
+				if (val == null)
+				{
+					return null;
+				}
+
+				return (Convert.ToByte(val));
+
+			}
+			set
+			{
+				SetFieldValue(3, 0, value, DataSubfield.HrHighAlert);
+			}
+		}
+
+		/// <summary>
+		/// Retrieves the HrLowAlert subfield
+		/// Units: bpm</summary>
+		/// <returns>Nullable byte representing the HrLowAlert subfield</returns>
+		public byte? HrLowAlert
+		{
+			get
+			{
+				Object val = GetFieldValue(3, 0, DataSubfield.HrLowAlert);
+				if (val == null)
+				{
+					return null;
+				}
+
+				return (Convert.ToByte(val));
+
+			}
+			set
+			{
+				SetFieldValue(3, 0, value, DataSubfield.HrLowAlert);
+			}
+		}
+
+		/// <summary>
+		/// Retrieves the SpeedHighAlert subfield
+		/// Units: m/s</summary>
+		/// <returns>Nullable float representing the SpeedHighAlert subfield</returns>
+		public float? SpeedHighAlert
+		{
+			get
+			{
+				Object val = GetFieldValue(3, 0, DataSubfield.SpeedHighAlert);
+				if (val == null)
+				{
+					return null;
+				}
+
+				return (Convert.ToSingle(val));
+
+			}
+			set
+			{
+				SetFieldValue(3, 0, value, DataSubfield.SpeedHighAlert);
+			}
+		}
+
+		/// <summary>
+		/// Retrieves the SpeedLowAlert subfield
+		/// Units: m/s</summary>
+		/// <returns>Nullable float representing the SpeedLowAlert subfield</returns>
+		public float? SpeedLowAlert
+		{
+			get
+			{
+				Object val = GetFieldValue(3, 0, DataSubfield.SpeedLowAlert);
+				if (val == null)
+				{
+					return null;
+				}
+
+				return (Convert.ToSingle(val));
+
+			}
+			set
+			{
+				SetFieldValue(3, 0, value, DataSubfield.SpeedLowAlert);
+			}
+		}
+
+		/// <summary>
+		/// Retrieves the CadHighAlert subfield
+		/// Units: rpm</summary>
+		/// <returns>Nullable ushort representing the CadHighAlert subfield</returns>
+		public ushort? CadHighAlert
+		{
+			get
+			{
+				Object val = GetFieldValue(3, 0, DataSubfield.CadHighAlert);
+				if (val == null)
+				{
+					return null;
+				}
+
+				return (Convert.ToUInt16(val));
+
+			}
+			set
+			{
+				SetFieldValue(3, 0, value, DataSubfield.CadHighAlert);
+			}
+		}
+
+		/// <summary>
+		/// Retrieves the CadLowAlert subfield
+		/// Units: rpm</summary>
+		/// <returns>Nullable ushort representing the CadLowAlert subfield</returns>
+		public ushort? CadLowAlert
+		{
+			get
+			{
+				Object val = GetFieldValue(3, 0, DataSubfield.CadLowAlert);
+				if (val == null)
+				{
+					return null;
+				}
+
+				return (Convert.ToUInt16(val));
+
+			}
+			set
+			{
+				SetFieldValue(3, 0, value, DataSubfield.CadLowAlert);
+			}
+		}
+
+		/// <summary>
+		/// Retrieves the PowerHighAlert subfield
+		/// Units: watts</summary>
+		/// <returns>Nullable ushort representing the PowerHighAlert subfield</returns>
+		public ushort? PowerHighAlert
+		{
+			get
+			{
+				Object val = GetFieldValue(3, 0, DataSubfield.PowerHighAlert);
+				if (val == null)
+				{
+					return null;
+				}
+
+				return (Convert.ToUInt16(val));
+
+			}
+			set
+			{
+				SetFieldValue(3, 0, value, DataSubfield.PowerHighAlert);
+			}
+		}
+
+		/// <summary>
+		/// Retrieves the PowerLowAlert subfield
+		/// Units: watts</summary>
+		/// <returns>Nullable ushort representing the PowerLowAlert subfield</returns>
+		public ushort? PowerLowAlert
+		{
+			get
+			{
+				Object val = GetFieldValue(3, 0, DataSubfield.PowerLowAlert);
+				if (val == null)
+				{
+					return null;
+				}
+
+				return (Convert.ToUInt16(val));
+
+			}
+			set
+			{
+				SetFieldValue(3, 0, value, DataSubfield.PowerLowAlert);
+			}
+		}
+
+		/// <summary>
+		/// Retrieves the TimeDurationAlert subfield
+		/// Units: s</summary>
+		/// <returns>Nullable float representing the TimeDurationAlert subfield</returns>
+		public float? TimeDurationAlert
+		{
+			get
+			{
+				Object val = GetFieldValue(3, 0, DataSubfield.TimeDurationAlert);
+				if (val == null)
+				{
+					return null;
+				}
+
+				return (Convert.ToSingle(val));
+
+			}
+			set
+			{
+				SetFieldValue(3, 0, value, DataSubfield.TimeDurationAlert);
+			}
+		}
+
+		/// <summary>
+		/// Retrieves the DistanceDurationAlert subfield
+		/// Units: m</summary>
+		/// <returns>Nullable float representing the DistanceDurationAlert subfield</returns>
+		public float? DistanceDurationAlert
+		{
+			get
+			{
+				Object val = GetFieldValue(3, 0, DataSubfield.DistanceDurationAlert);
+				if (val == null)
+				{
+					return null;
+				}
+
+				return (Convert.ToSingle(val));
+
+			}
+			set
+			{
+				SetFieldValue(3, 0, value, DataSubfield.DistanceDurationAlert);
+			}
+		}
+
+		/// <summary>
+		/// Retrieves the CalorieDurationAlert subfield
+		/// Units: calories</summary>
+		/// <returns>Nullable uint representing the CalorieDurationAlert subfield</returns>
+		public uint? CalorieDurationAlert
+		{
+			get
+			{
+				Object val = GetFieldValue(3, 0, DataSubfield.CalorieDurationAlert);
+				if (val == null)
+				{
+					return null;
+				}
+
+				return (Convert.ToUInt32(val));
+
+			}
+			set
+			{
+				SetFieldValue(3, 0, value, DataSubfield.CalorieDurationAlert);
+			}
+		}
+
+		/// <summary>
+		/// Retrieves the FitnessEquipmentState subfield</summary>
+		/// <returns>Nullable FitnessEquipmentState enum representing the FitnessEquipmentState subfield</returns>
+		public FitnessEquipmentState? GetFitnessEquipmentState()
+		{
+			return (FitnessEquipmentState?)GetFieldValue(3, 0, DataSubfield.FitnessEquipmentState);
+		}
+
+		/// <summary>
+		///
+		/// Set FitnessEquipmentState subfield</summary>
+		/// <param name="fitnessEquipmentState">Subfield value to be set</param>
+		public void SetFitnessEquipmentState(byte? fitnessEquipmentState)
+		{
+			SetFieldValue(3, 0, fitnessEquipmentState, DataSubfield.FitnessEquipmentState);
+		}
+
+		/// <summary>
+		/// Retrieves the SportPoint subfield</summary>
+		/// <returns>Nullable uint representing the SportPoint subfield</returns>
+		public uint? SportPoint
+		{
+			get
+			{
+				Object val = GetFieldValue(3, 0, DataSubfield.SportPoint);
+				if (val == null)
+				{
+					return null;
+				}
+
+				return (Convert.ToUInt32(val));
+
+			}
+			set
+			{
+				SetFieldValue(3, 0, value, DataSubfield.SportPoint);
+			}
+		}
+
+		/// <summary>
+		/// Retrieves the GearChangeData subfield</summary>
+		/// <returns>Nullable uint representing the GearChangeData subfield</returns>
+		public uint? GearChangeData
+		{
+			get
+			{
+				Object val = GetFieldValue(3, 0, DataSubfield.GearChangeData);
+				if (val == null)
+				{
+					return null;
+				}
+
+				return (Convert.ToUInt32(val));
+
+			}
+			set
+			{
+				SetFieldValue(3, 0, value, DataSubfield.GearChangeData);
+			}
+		}
+
+		/// <summary>
+		/// Retrieves the RiderPosition subfield
+		/// Comment: Indicates the rider position value.</summary>
+		/// <returns>Nullable RiderPositionType enum representing the RiderPosition subfield</returns>
+		public RiderPositionType? GetRiderPosition()
+		{
+			return (RiderPositionType?)GetFieldValue(3, 0, DataSubfield.RiderPosition);
+		}
+
+		/// <summary>
+		///
+		/// Set RiderPosition subfield
+		/// Comment: Indicates the rider position value.</summary>
+		/// <param name="riderPosition">Subfield value to be set</param>
+		public void SetRiderPosition(byte? riderPosition)
+		{
+			SetFieldValue(3, 0, riderPosition, DataSubfield.RiderPosition);
+		}
+
+		/// <summary>
+		/// Retrieves the CommTimeout subfield</summary>
+		/// <returns>Nullable ushort representing the CommTimeout subfield</returns>
+		public ushort? CommTimeout
+		{
+			get
+			{
+				Object val = GetFieldValue(3, 0, DataSubfield.CommTimeout);
+				if (val == null)
+				{
+					return null;
+				}
+
+				return (Convert.ToUInt16(val));
+
+			}
+			set
+			{
+				SetFieldValue(3, 0, value, DataSubfield.CommTimeout);
+			}
+		}
+
+		/// <summary>
+		/// Retrieves the DiveAlert subfield</summary>
+		/// <returns>Nullable DiveAlert enum representing the DiveAlert subfield</returns>
+		public DiveAlert? GetDiveAlert()
+		{
+			return (DiveAlert?)GetFieldValue(3, 0, DataSubfield.DiveAlert);
+		}
+
+		/// <summary>
+		///
+		/// Set DiveAlert subfield</summary>
+		/// <param name="diveAlert">Subfield value to be set</param>
+		public void SetDiveAlert(byte? diveAlert)
+		{
+			SetFieldValue(3, 0, diveAlert, DataSubfield.DiveAlert);
+		}
+
+		/// <summary>
+		/// Retrieves the AutoActivityDetectDuration subfield
+		/// Units: min</summary>
+		/// <returns>Nullable ushort representing the AutoActivityDetectDuration subfield</returns>
+		public ushort? AutoActivityDetectDuration
+		{
+			get
+			{
+				Object val = GetFieldValue(3, 0, DataSubfield.AutoActivityDetectDuration);
+				if (val == null)
+				{
+					return null;
+				}
+
+				return (Convert.ToUInt16(val));
+
+			}
+			set
+			{
+				SetFieldValue(3, 0, value, DataSubfield.AutoActivityDetectDuration);
+			}
+		}
+
+		/// <summary>
+		/// Retrieves the RadarThreatAlert subfield
+		/// Comment: The first byte is the radar_threat_level_max, the second byte is the radar_threat_count, third bytes is the average approach speed, and the 4th byte is the max approach speed</summary>
+		/// <returns>Nullable uint representing the RadarThreatAlert subfield</returns>
+		public uint? RadarThreatAlert
+		{
+			get
+			{
+				Object val = GetFieldValue(3, 0, DataSubfield.RadarThreatAlert);
+				if (val == null)
+				{
+					return null;
+				}
+
+				return (Convert.ToUInt32(val));
+
+			}
+			set
+			{
+				SetFieldValue(3, 0, value, DataSubfield.RadarThreatAlert);
+			}
+		}
+		///<summary>
+		/// Retrieves the EventGroup field</summary>
+		/// <returns>Returns nullable byte representing the EventGroup field</returns>
+		public byte? EventGroup
+		{
+			get
+			{
+				Object val = GetFieldValue(4, 0, Fit.SubfieldIndexMainField);
+				if (val == null)
+				{
+					return null;
+				}
+
+				return (Convert.ToByte(val));
+
+			}
+			set
+			{
+				SetFieldValue(4, 0, value, Fit.SubfieldIndexMainField);
+			}
+		}
+
+		///<summary>
+		/// Retrieves the Score field
+		/// Comment: Do not populate directly. Autogenerated by decoder for sport_point subfield components</summary>
+		/// <returns>Returns nullable ushort representing the Score field</returns>
+		public ushort? Score
+		{
+			get
+			{
+				Object val = GetFieldValue(7, 0, Fit.SubfieldIndexMainField);
+				if (val == null)
+				{
+					return null;
+				}
+
+				return (Convert.ToUInt16(val));
+
+			}
+			set
+			{
+				SetFieldValue(7, 0, value, Fit.SubfieldIndexMainField);
+			}
+		}
+
+		///<summary>
+		/// Retrieves the OpponentScore field
+		/// Comment: Do not populate directly. Autogenerated by decoder for sport_point subfield components</summary>
+		/// <returns>Returns nullable ushort representing the OpponentScore field</returns>
+		public ushort? OpponentScore
+		{
+			get
+			{
+				Object val = GetFieldValue(8, 0, Fit.SubfieldIndexMainField);
+				if (val == null)
+				{
+					return null;
+				}
+
+				return (Convert.ToUInt16(val));
+
+			}
+			set
+			{
+				SetFieldValue(8, 0, value, Fit.SubfieldIndexMainField);
+			}
+		}
+
+		///<summary>
+		/// Retrieves the FrontGearNum field
+		/// Comment: Do not populate directly. Autogenerated by decoder for gear_change subfield components. Front gear number. 1 is innermost.</summary>
+		/// <returns>Returns nullable byte representing the FrontGearNum field</returns>
+		public byte? FrontGearNum
+		{
+			get
+			{
+				Object val = GetFieldValue(9, 0, Fit.SubfieldIndexMainField);
+				if (val == null)
+				{
+					return null;
+				}
+
+				return (Convert.ToByte(val));
+
+			}
+			set
+			{
+				SetFieldValue(9, 0, value, Fit.SubfieldIndexMainField);
+			}
+		}
+
+		///<summary>
+		/// Retrieves the FrontGear field
+		/// Comment: Do not populate directly. Autogenerated by decoder for gear_change subfield components. Number of front teeth.</summary>
+		/// <returns>Returns nullable byte representing the FrontGear field</returns>
+		public byte? FrontGear
+		{
+			get
+			{
+				Object val = GetFieldValue(10, 0, Fit.SubfieldIndexMainField);
+				if (val == null)
+				{
+					return null;
+				}
+
+				return (Convert.ToByte(val));
+
+			}
+			set
+			{
+				SetFieldValue(10, 0, value, Fit.SubfieldIndexMainField);
+			}
+		}
+
+		///<summary>
+		/// Retrieves the RearGearNum field
+		/// Comment: Do not populate directly. Autogenerated by decoder for gear_change subfield components. Rear gear number. 1 is innermost.</summary>
+		/// <returns>Returns nullable byte representing the RearGearNum field</returns>
+		public byte? RearGearNum
+		{
+			get
+			{
+				Object val = GetFieldValue(11, 0, Fit.SubfieldIndexMainField);
+				if (val == null)
+				{
+					return null;
+				}
+
+				return (Convert.ToByte(val));
+
+			}
+			set
+			{
+				SetFieldValue(11, 0, value, Fit.SubfieldIndexMainField);
+			}
+		}
+
+		///<summary>
+		/// Retrieves the RearGear field
+		/// Comment: Do not populate directly. Autogenerated by decoder for gear_change subfield components. Number of rear teeth.</summary>
+		/// <returns>Returns nullable byte representing the RearGear field</returns>
+		public byte? RearGear
+		{
+			get
+			{
+				Object val = GetFieldValue(12, 0, Fit.SubfieldIndexMainField);
+				if (val == null)
+				{
+					return null;
+				}
+
+				return (Convert.ToByte(val));
+
+			}
+			set
+			{
+				SetFieldValue(12, 0, value, Fit.SubfieldIndexMainField);
+			}
+		}
+
+		///<summary>
+		/// Retrieves the DeviceIndex field</summary>
+		/// <returns>Returns nullable byte representing the DeviceIndex field</returns>
+		public byte? DeviceIndex
+		{
+			get
+			{
+				Object val = GetFieldValue(13, 0, Fit.SubfieldIndexMainField);
+				if (val == null)
+				{
+					return null;
+				}
+
+				return (Convert.ToByte(val));
+
+			}
+			set
+			{
+				SetFieldValue(13, 0, value, Fit.SubfieldIndexMainField);
+			}
+		}
+
+		///<summary>
+		/// Retrieves the ActivityType field
+		/// Comment: Activity Type associated with an auto_activity_detect event</summary>
+		/// <returns>Returns nullable ActivityType enum representing the ActivityType field</returns>
+		public ActivityType? ActivityType
+		{
+			get
+			{
+				object obj = GetFieldValue(14, 0, Fit.SubfieldIndexMainField);
+				ActivityType? value = obj == null ? (ActivityType?)null : (ActivityType)obj;
+				return value;
+			}
+			set
+			{
+				SetFieldValue(14, 0, value, Fit.SubfieldIndexMainField);
+			}
+		}
+
+		///<summary>
+		/// Retrieves the StartTimestamp field
+		/// Units: s
+		/// Comment: Timestamp of when the event started</summary>
+		/// <returns>Returns DateTime representing the StartTimestamp field</returns>
+		public DateTime StartTimestamp
+		{
+			get
+			{
+				Object val = GetFieldValue(15, 0, Fit.SubfieldIndexMainField);
+				if (val == null)
+				{
+					return null;
+				}
+
+				return TimestampToDateTime(Convert.ToUInt32(val));
+
+			}
+			set
+			{
+				SetFieldValue(15, 0, value.GetTimeStamp(), Fit.SubfieldIndexMainField);
+			}
+		}
+
+
+		/// <summary>
+		/// Retrieves the AutoActivityDetectStartTimestamp subfield
+		/// Units: s
+		/// Comment: Auto Activity Detect Start Timestamp.</summary>
+		/// <returns>Nullable uint representing the AutoActivityDetectStartTimestamp subfield</returns>
+		public DateTime AutoActivityDetectStartTimestamp
+		{
+			get
+			{
+				Object val = GetFieldValue(15, 0, StartTimestampSubfield.AutoActivityDetectStartTimestamp);
+				if (val == null)
+				{
+					return null;
+				}
+
+				return TimestampToDateTime(Convert.ToUInt32(val));
+
+			}
+			set
+			{
+				SetFieldValue(15, 0, value.GetTimeStamp(), StartTimestampSubfield.AutoActivityDetectStartTimestamp);
+			}
+		}
+		///<summary>
+		/// Retrieves the RadarThreatLevelMax field
+		/// Comment: Do not populate directly. Autogenerated by decoder for threat_alert subfield components.</summary>
+		/// <returns>Returns nullable RadarThreatLevelType enum representing the RadarThreatLevelMax field</returns>
+		public RadarThreatLevelType? RadarThreatLevelMax
+		{
+			get
+			{
+				object obj = GetFieldValue(21, 0, Fit.SubfieldIndexMainField);
+				RadarThreatLevelType? value = obj == null ? (RadarThreatLevelType?)null : (RadarThreatLevelType)obj;
+				return value;
+			}
+			set
+			{
+				SetFieldValue(21, 0, value, Fit.SubfieldIndexMainField);
+			}
+		}
+
+		///<summary>
+		/// Retrieves the RadarThreatCount field
+		/// Comment: Do not populate directly. Autogenerated by decoder for threat_alert subfield components.</summary>
+		/// <returns>Returns nullable byte representing the RadarThreatCount field</returns>
+		public byte? RadarThreatCount
+		{
+			get
+			{
+				Object val = GetFieldValue(22, 0, Fit.SubfieldIndexMainField);
+				if (val == null)
+				{
+					return null;
+				}
+
+				return (Convert.ToByte(val));
+
+			}
+			set
+			{
+				SetFieldValue(22, 0, value, Fit.SubfieldIndexMainField);
+			}
+		}
+
+		///<summary>
+		/// Retrieves the RadarThreatAvgApproachSpeed field
+		/// Units: m/s
+		/// Comment: Do not populate directly. Autogenerated by decoder for radar_threat_alert subfield components</summary>
+		/// <returns>Returns nullable float representing the RadarThreatAvgApproachSpeed field</returns>
+		public float? RadarThreatAvgApproachSpeed
+		{
+			get
+			{
+				Object val = GetFieldValue(23, 0, Fit.SubfieldIndexMainField);
+				if (val == null)
+				{
+					return null;
+				}
+
+				return (Convert.ToSingle(val));
+
+			}
+			set
+			{
+				SetFieldValue(23, 0, value, Fit.SubfieldIndexMainField);
+			}
+		}
+
+		///<summary>
+		/// Retrieves the RadarThreatMaxApproachSpeed field
+		/// Units: m/s
+		/// Comment: Do not populate directly. Autogenerated by decoder for radar_threat_alert subfield components</summary>
+		/// <returns>Returns nullable float representing the RadarThreatMaxApproachSpeed field</returns>
+		public float? RadarThreatMaxApproachSpeed
+		{
+			get
+			{
+				Object val = GetFieldValue(24, 0, Fit.SubfieldIndexMainField);
+				if (val == null)
+				{
+					return null;
+				}
+
+				return (Convert.ToSingle(val));
+
+			}
+			set
+			{
+				SetFieldValue(24, 0, value, Fit.SubfieldIndexMainField);
+			}
+		}
+
+		#endregion // Methods
+	} // Class
 } // namespace

--- a/Dynastream/Fit/Profile/Mesgs/ExdDataConceptConfigurationMesg.cs
+++ b/Dynastream/Fit/Profile/Mesgs/ExdDataConceptConfigurationMesg.cs
@@ -21,277 +21,266 @@ using System.Linq;
 
 namespace Dynastream.Fit
 {
-    /// <summary>
-    /// Implements the ExdDataConceptConfiguration profile message.
-    /// </summary>
-    public class ExdDataConceptConfigurationMesg : Mesg
-    {
-        #region Fields
-        #endregion
+	/// <summary>
+	/// Implements the ExdDataConceptConfiguration profile message.
+	/// </summary>
+	public class ExdDataConceptConfigurationMesg : Mesg
+	{
+		#region Fields
+		#endregion
 
-        /// <summary>
-        /// Field Numbers for <see cref="ExdDataConceptConfigurationMesg"/>
-        /// </summary>
-        public sealed class FieldDefNum
-        {
-            public const byte ScreenIndex = 0;
-            public const byte ConceptField = 1;
-            public const byte FieldId = 2;
-            public const byte ConceptIndex = 3;
-            public const byte DataPage = 4;
-            public const byte ConceptKey = 5;
-            public const byte Scaling = 6;
-            public const byte DataUnits = 8;
-            public const byte Qualifier = 9;
-            public const byte Descriptor = 10;
-            public const byte IsSigned = 11;
-            public const byte Invalid = Fit.FieldNumInvalid;
-        }
+		/// <summary>
+		/// Field Numbers for <see cref="ExdDataConceptConfigurationMesg"/>
+		/// </summary>
+		public sealed class FieldDefNum
+		{
+			public const byte ScreenIndex = 0;
+			public const byte ConceptField = 1;
+			public const byte FieldId = 2;
+			public const byte ConceptIndex = 3;
+			public const byte DataPage = 4;
+			public const byte ConceptKey = 5;
+			public const byte Scaling = 6;
+			public const byte DataUnits = 8;
+			public const byte Qualifier = 9;
+			public const byte Descriptor = 10;
+			public const byte IsSigned = 11;
+			public const byte Invalid = Fit.FieldNumInvalid;
+		}
 
-        #region Constructors
-        public ExdDataConceptConfigurationMesg() : base(Profile.GetMesg(MesgNum.ExdDataConceptConfiguration))
-        {
-        }
+		#region Constructors
+		public ExdDataConceptConfigurationMesg() : base(Profile.GetMesg(MesgNum.ExdDataConceptConfiguration))
+		{
+		}
 
-        public ExdDataConceptConfigurationMesg(Mesg mesg) : base(mesg)
-        {
-        }
-        #endregion // Constructors
+		public ExdDataConceptConfigurationMesg(Mesg mesg) : base(mesg)
+		{
+		}
+		#endregion // Constructors
 
-        #region Methods
-        ///<summary>
-        /// Retrieves the ScreenIndex field</summary>
-        /// <returns>Returns nullable byte representing the ScreenIndex field</returns>
-        public byte? GetScreenIndex()
-        {
-            Object val = GetFieldValue(0, 0, Fit.SubfieldIndexMainField);
-            if(val == null)
-            {
-                return null;
-            }
+		#region Methods
+		///<summary>
+		/// Retrieves the ScreenIndex field</summary>
+		/// <returns>Returns nullable byte representing the ScreenIndex field</returns>
+		public byte? ScreenIndex
+		{
+			get
+			{
+				Object val = GetFieldValue(0, 0, Fit.SubfieldIndexMainField);
+				if (val == null)
+				{
+					return null;
+				}
 
-            return (Convert.ToByte(val));
-            
-        }
+				return (Convert.ToByte(val));
 
-        /// <summary>
-        /// Set ScreenIndex field</summary>
-        /// <param name="screenIndex_">Nullable field value to be set</param>
-        public void SetScreenIndex(byte? screenIndex_)
-        {
-            SetFieldValue(0, 0, screenIndex_, Fit.SubfieldIndexMainField);
-        }
-        
-        ///<summary>
-        /// Retrieves the ConceptField field</summary>
-        /// <returns>Returns nullable byte representing the ConceptField field</returns>
-        public byte? GetConceptField()
-        {
-            Object val = GetFieldValue(1, 0, Fit.SubfieldIndexMainField);
-            if(val == null)
-            {
-                return null;
-            }
+			}
+			set
+			{
+				SetFieldValue(0, 0, value, Fit.SubfieldIndexMainField);
+			}
+		}
 
-            return (Convert.ToByte(val));
-            
-        }
+		///<summary>
+		/// Retrieves the ConceptField field</summary>
+		/// <returns>Returns nullable byte representing the ConceptField field</returns>
+		public byte? ConceptField
+		{
+			get
+			{
+				Object val = GetFieldValue(1, 0, Fit.SubfieldIndexMainField);
+				if (val == null)
+				{
+					return null;
+				}
 
-        /// <summary>
-        /// Set ConceptField field</summary>
-        /// <param name="conceptField_">Nullable field value to be set</param>
-        public void SetConceptField(byte? conceptField_)
-        {
-            SetFieldValue(1, 0, conceptField_, Fit.SubfieldIndexMainField);
-        }
-        
-        ///<summary>
-        /// Retrieves the FieldId field</summary>
-        /// <returns>Returns nullable byte representing the FieldId field</returns>
-        public byte? GetFieldId()
-        {
-            Object val = GetFieldValue(2, 0, Fit.SubfieldIndexMainField);
-            if(val == null)
-            {
-                return null;
-            }
+				return (Convert.ToByte(val));
 
-            return (Convert.ToByte(val));
-            
-        }
+			}
+			set
+			{
+				SetFieldValue(1, 0, value, Fit.SubfieldIndexMainField);
+			}
+		}
 
-        /// <summary>
-        /// Set FieldId field</summary>
-        /// <param name="fieldId_">Nullable field value to be set</param>
-        public void SetFieldId(byte? fieldId_)
-        {
-            SetFieldValue(2, 0, fieldId_, Fit.SubfieldIndexMainField);
-        }
-        
-        ///<summary>
-        /// Retrieves the ConceptIndex field</summary>
-        /// <returns>Returns nullable byte representing the ConceptIndex field</returns>
-        public byte? GetConceptIndex()
-        {
-            Object val = GetFieldValue(3, 0, Fit.SubfieldIndexMainField);
-            if(val == null)
-            {
-                return null;
-            }
+		///<summary>
+		/// Retrieves the FieldId field</summary>
+		/// <returns>Returns nullable byte representing the FieldId field</returns>
+		public byte? FieldId
+		{
+			get
+			{
+				Object val = GetFieldValue(2, 0, Fit.SubfieldIndexMainField);
+				if (val == null)
+				{
+					return null;
+				}
 
-            return (Convert.ToByte(val));
-            
-        }
+				return (Convert.ToByte(val));
 
-        /// <summary>
-        /// Set ConceptIndex field</summary>
-        /// <param name="conceptIndex_">Nullable field value to be set</param>
-        public void SetConceptIndex(byte? conceptIndex_)
-        {
-            SetFieldValue(3, 0, conceptIndex_, Fit.SubfieldIndexMainField);
-        }
-        
-        ///<summary>
-        /// Retrieves the DataPage field</summary>
-        /// <returns>Returns nullable byte representing the DataPage field</returns>
-        public byte? GetDataPage()
-        {
-            Object val = GetFieldValue(4, 0, Fit.SubfieldIndexMainField);
-            if(val == null)
-            {
-                return null;
-            }
+			}
+			set
+			{
+				SetFieldValue(2, 0, value, Fit.SubfieldIndexMainField);
+			}
+		}
 
-            return (Convert.ToByte(val));
-            
-        }
+		///<summary>
+		/// Retrieves the ConceptIndex field</summary>
+		/// <returns>Returns nullable byte representing the ConceptIndex field</returns>
+		public byte? ConceptIndex
+		{
+			get
+			{
+				Object val = GetFieldValue(3, 0, Fit.SubfieldIndexMainField);
+				if (val == null)
+				{
+					return null;
+				}
 
-        /// <summary>
-        /// Set DataPage field</summary>
-        /// <param name="dataPage_">Nullable field value to be set</param>
-        public void SetDataPage(byte? dataPage_)
-        {
-            SetFieldValue(4, 0, dataPage_, Fit.SubfieldIndexMainField);
-        }
-        
-        ///<summary>
-        /// Retrieves the ConceptKey field</summary>
-        /// <returns>Returns nullable byte representing the ConceptKey field</returns>
-        public byte? GetConceptKey()
-        {
-            Object val = GetFieldValue(5, 0, Fit.SubfieldIndexMainField);
-            if(val == null)
-            {
-                return null;
-            }
+				return (Convert.ToByte(val));
 
-            return (Convert.ToByte(val));
-            
-        }
+			}
+			set
+			{
+				SetFieldValue(3, 0, value, Fit.SubfieldIndexMainField);
+			}
+		}
 
-        /// <summary>
-        /// Set ConceptKey field</summary>
-        /// <param name="conceptKey_">Nullable field value to be set</param>
-        public void SetConceptKey(byte? conceptKey_)
-        {
-            SetFieldValue(5, 0, conceptKey_, Fit.SubfieldIndexMainField);
-        }
-        
-        ///<summary>
-        /// Retrieves the Scaling field</summary>
-        /// <returns>Returns nullable byte representing the Scaling field</returns>
-        public byte? GetScaling()
-        {
-            Object val = GetFieldValue(6, 0, Fit.SubfieldIndexMainField);
-            if(val == null)
-            {
-                return null;
-            }
+		///<summary>
+		/// Retrieves the DataPage field</summary>
+		/// <returns>Returns nullable byte representing the DataPage field</returns>
+		public byte? DataPage
+		{
+			get
+			{
+				Object val = GetFieldValue(4, 0, Fit.SubfieldIndexMainField);
+				if (val == null)
+				{
+					return null;
+				}
 
-            return (Convert.ToByte(val));
-            
-        }
+				return (Convert.ToByte(val));
 
-        /// <summary>
-        /// Set Scaling field</summary>
-        /// <param name="scaling_">Nullable field value to be set</param>
-        public void SetScaling(byte? scaling_)
-        {
-            SetFieldValue(6, 0, scaling_, Fit.SubfieldIndexMainField);
-        }
-        
-        ///<summary>
-        /// Retrieves the DataUnits field</summary>
-        /// <returns>Returns nullable ExdDataUnits enum representing the DataUnits field</returns>
-        public ExdDataUnits? GetDataUnits()
-        {
-            object obj = GetFieldValue(8, 0, Fit.SubfieldIndexMainField);
-            ExdDataUnits? value = obj == null ? (ExdDataUnits?)null : (ExdDataUnits)obj;
-            return value;
-        }
+			}
+			set
+			{
+				SetFieldValue(4, 0, value, Fit.SubfieldIndexMainField);
+			}
+		}
 
-        /// <summary>
-        /// Set DataUnits field</summary>
-        /// <param name="dataUnits_">Nullable field value to be set</param>
-        public void SetDataUnits(ExdDataUnits? dataUnits_)
-        {
-            SetFieldValue(8, 0, dataUnits_, Fit.SubfieldIndexMainField);
-        }
-        
-        ///<summary>
-        /// Retrieves the Qualifier field</summary>
-        /// <returns>Returns nullable ExdQualifiers enum representing the Qualifier field</returns>
-        public ExdQualifiers? GetQualifier()
-        {
-            object obj = GetFieldValue(9, 0, Fit.SubfieldIndexMainField);
-            ExdQualifiers? value = obj == null ? (ExdQualifiers?)null : (ExdQualifiers)obj;
-            return value;
-        }
+		///<summary>
+		/// Retrieves the ConceptKey field</summary>
+		/// <returns>Returns nullable byte representing the ConceptKey field</returns>
+		public byte? ConceptKey
+		{
+			get
+			{
+				Object val = GetFieldValue(5, 0, Fit.SubfieldIndexMainField);
+				if (val == null)
+				{
+					return null;
+				}
 
-        /// <summary>
-        /// Set Qualifier field</summary>
-        /// <param name="qualifier_">Nullable field value to be set</param>
-        public void SetQualifier(ExdQualifiers? qualifier_)
-        {
-            SetFieldValue(9, 0, qualifier_, Fit.SubfieldIndexMainField);
-        }
-        
-        ///<summary>
-        /// Retrieves the Descriptor field</summary>
-        /// <returns>Returns nullable ExdDescriptors enum representing the Descriptor field</returns>
-        public ExdDescriptors? GetDescriptor()
-        {
-            object obj = GetFieldValue(10, 0, Fit.SubfieldIndexMainField);
-            ExdDescriptors? value = obj == null ? (ExdDescriptors?)null : (ExdDescriptors)obj;
-            return value;
-        }
+				return (Convert.ToByte(val));
 
-        /// <summary>
-        /// Set Descriptor field</summary>
-        /// <param name="descriptor_">Nullable field value to be set</param>
-        public void SetDescriptor(ExdDescriptors? descriptor_)
-        {
-            SetFieldValue(10, 0, descriptor_, Fit.SubfieldIndexMainField);
-        }
-        
-        ///<summary>
-        /// Retrieves the IsSigned field</summary>
-        /// <returns>Returns nullable Bool enum representing the IsSigned field</returns>
-        public Bool? GetIsSigned()
-        {
-            object obj = GetFieldValue(11, 0, Fit.SubfieldIndexMainField);
-            Bool? value = obj == null ? (Bool?)null : (Bool)obj;
-            return value;
-        }
+			}
+			set
+			{
+				SetFieldValue(5, 0, value, Fit.SubfieldIndexMainField);
+			}
+		}
 
-        /// <summary>
-        /// Set IsSigned field</summary>
-        /// <param name="isSigned_">Nullable field value to be set</param>
-        public void SetIsSigned(Bool? isSigned_)
-        {
-            SetFieldValue(11, 0, isSigned_, Fit.SubfieldIndexMainField);
-        }
-        
-        #endregion // Methods
-    } // Class
+		///<summary>
+		/// Retrieves the Scaling field</summary>
+		/// <returns>Returns nullable byte representing the Scaling field</returns>
+		public byte? Scaling
+		{
+			get
+			{
+				Object val = GetFieldValue(6, 0, Fit.SubfieldIndexMainField);
+				if (val == null)
+				{
+					return null;
+				}
+
+				return (Convert.ToByte(val));
+
+			}
+			set
+			{
+				SetFieldValue(6, 0, value, Fit.SubfieldIndexMainField);
+			}
+		}
+
+		///<summary>
+		/// Retrieves the DataUnits field</summary>
+		/// <returns>Returns nullable ExdDataUnits enum representing the DataUnits field</returns>
+		public ExdDataUnits? DataUnits
+		{
+			get
+			{
+				object obj = GetFieldValue(8, 0, Fit.SubfieldIndexMainField);
+				ExdDataUnits? value = obj == null ? (ExdDataUnits?)null : (ExdDataUnits)obj;
+				return value;
+			}
+			set
+			{
+				SetFieldValue(8, 0, value, Fit.SubfieldIndexMainField);
+			}
+		}
+
+		///<summary>
+		/// Retrieves the Qualifier field</summary>
+		/// <returns>Returns nullable ExdQualifiers enum representing the Qualifier field</returns>
+		public ExdQualifiers? Qualifier
+		{
+			get
+			{
+				object obj = GetFieldValue(9, 0, Fit.SubfieldIndexMainField);
+				ExdQualifiers? value = obj == null ? (ExdQualifiers?)null : (ExdQualifiers)obj;
+				return value;
+			}
+			set
+			{
+				SetFieldValue(9, 0, value, Fit.SubfieldIndexMainField);
+			}
+		}
+
+		///<summary>
+		/// Retrieves the Descriptor field</summary>
+		/// <returns>Returns nullable ExdDescriptors enum representing the Descriptor field</returns>
+		public ExdDescriptors? Descriptor
+		{
+			get
+			{
+				object obj = GetFieldValue(10, 0, Fit.SubfieldIndexMainField);
+				ExdDescriptors? value = obj == null ? (ExdDescriptors?)null : (ExdDescriptors)obj;
+				return value;
+			}
+			set
+			{
+				SetFieldValue(10, 0, value, Fit.SubfieldIndexMainField);
+			}
+		}
+
+		///<summary>
+		/// Retrieves the IsSigned field</summary>
+		/// <returns>Returns nullable Bool enum representing the IsSigned field</returns>
+		public Bool? IsSigned
+		{
+			get
+			{
+				object obj = GetFieldValue(11, 0, Fit.SubfieldIndexMainField);
+				Bool? value = obj == null ? (Bool?)null : (Bool)obj;
+				return value;
+			}
+			set
+			{
+				SetFieldValue(11, 0, value, Fit.SubfieldIndexMainField);
+			}
+		}
+
+		#endregion // Methods
+	} // Class
 } // namespace

--- a/Dynastream/Fit/Profile/Mesgs/ExdDataFieldConfigurationMesg.cs
+++ b/Dynastream/Fit/Profile/Mesgs/ExdDataFieldConfigurationMesg.cs
@@ -21,201 +21,196 @@ using System.Linq;
 
 namespace Dynastream.Fit
 {
-    /// <summary>
-    /// Implements the ExdDataFieldConfiguration profile message.
-    /// </summary>
-    public class ExdDataFieldConfigurationMesg : Mesg
-    {
-        #region Fields
-        #endregion
+	/// <summary>
+	/// Implements the ExdDataFieldConfiguration profile message.
+	/// </summary>
+	public class ExdDataFieldConfigurationMesg : Mesg
+	{
+		#region Fields
+		#endregion
 
-        /// <summary>
-        /// Field Numbers for <see cref="ExdDataFieldConfigurationMesg"/>
-        /// </summary>
-        public sealed class FieldDefNum
-        {
-            public const byte ScreenIndex = 0;
-            public const byte ConceptField = 1;
-            public const byte FieldId = 2;
-            public const byte ConceptCount = 3;
-            public const byte DisplayType = 4;
-            public const byte Title = 5;
-            public const byte Invalid = Fit.FieldNumInvalid;
-        }
+		/// <summary>
+		/// Field Numbers for <see cref="ExdDataFieldConfigurationMesg"/>
+		/// </summary>
+		public sealed class FieldDefNum
+		{
+			public const byte ScreenIndex = 0;
+			public const byte ConceptField = 1;
+			public const byte FieldId = 2;
+			public const byte ConceptCount = 3;
+			public const byte DisplayType = 4;
+			public const byte Title = 5;
+			public const byte Invalid = Fit.FieldNumInvalid;
+		}
 
-        #region Constructors
-        public ExdDataFieldConfigurationMesg() : base(Profile.GetMesg(MesgNum.ExdDataFieldConfiguration))
-        {
-        }
+		#region Constructors
+		public ExdDataFieldConfigurationMesg() : base(Profile.GetMesg(MesgNum.ExdDataFieldConfiguration))
+		{
+		}
 
-        public ExdDataFieldConfigurationMesg(Mesg mesg) : base(mesg)
-        {
-        }
-        #endregion // Constructors
+		public ExdDataFieldConfigurationMesg(Mesg mesg) : base(mesg)
+		{
+		}
+		#endregion // Constructors
 
-        #region Methods
-        ///<summary>
-        /// Retrieves the ScreenIndex field</summary>
-        /// <returns>Returns nullable byte representing the ScreenIndex field</returns>
-        public byte? GetScreenIndex()
-        {
-            Object val = GetFieldValue(0, 0, Fit.SubfieldIndexMainField);
-            if(val == null)
-            {
-                return null;
-            }
+		#region Methods
+		///<summary>
+		/// Retrieves the ScreenIndex field</summary>
+		/// <returns>Returns nullable byte representing the ScreenIndex field</returns>
+		public byte? ScreenIndex
+		{
+			get
+			{
+				Object val = GetFieldValue(0, 0, Fit.SubfieldIndexMainField);
+				if (val == null)
+				{
+					return null;
+				}
 
-            return (Convert.ToByte(val));
-            
-        }
+				return (Convert.ToByte(val));
 
-        /// <summary>
-        /// Set ScreenIndex field</summary>
-        /// <param name="screenIndex_">Nullable field value to be set</param>
-        public void SetScreenIndex(byte? screenIndex_)
-        {
-            SetFieldValue(0, 0, screenIndex_, Fit.SubfieldIndexMainField);
-        }
-        
-        ///<summary>
-        /// Retrieves the ConceptField field</summary>
-        /// <returns>Returns nullable byte representing the ConceptField field</returns>
-        public byte? GetConceptField()
-        {
-            Object val = GetFieldValue(1, 0, Fit.SubfieldIndexMainField);
-            if(val == null)
-            {
-                return null;
-            }
+			}
+			set
+			{
+				SetFieldValue(0, 0, value, Fit.SubfieldIndexMainField);
+			}
+		}
 
-            return (Convert.ToByte(val));
-            
-        }
+		///<summary>
+		/// Retrieves the ConceptField field</summary>
+		/// <returns>Returns nullable byte representing the ConceptField field</returns>
+		public byte? ConceptField
+		{
+			get
+			{
+				Object val = GetFieldValue(1, 0, Fit.SubfieldIndexMainField);
+				if (val == null)
+				{
+					return null;
+				}
 
-        /// <summary>
-        /// Set ConceptField field</summary>
-        /// <param name="conceptField_">Nullable field value to be set</param>
-        public void SetConceptField(byte? conceptField_)
-        {
-            SetFieldValue(1, 0, conceptField_, Fit.SubfieldIndexMainField);
-        }
-        
-        ///<summary>
-        /// Retrieves the FieldId field</summary>
-        /// <returns>Returns nullable byte representing the FieldId field</returns>
-        public byte? GetFieldId()
-        {
-            Object val = GetFieldValue(2, 0, Fit.SubfieldIndexMainField);
-            if(val == null)
-            {
-                return null;
-            }
+				return (Convert.ToByte(val));
 
-            return (Convert.ToByte(val));
-            
-        }
+			}
+			set
+			{
+				SetFieldValue(1, 0, value, Fit.SubfieldIndexMainField);
+			}
+		}
 
-        /// <summary>
-        /// Set FieldId field</summary>
-        /// <param name="fieldId_">Nullable field value to be set</param>
-        public void SetFieldId(byte? fieldId_)
-        {
-            SetFieldValue(2, 0, fieldId_, Fit.SubfieldIndexMainField);
-        }
-        
-        ///<summary>
-        /// Retrieves the ConceptCount field</summary>
-        /// <returns>Returns nullable byte representing the ConceptCount field</returns>
-        public byte? GetConceptCount()
-        {
-            Object val = GetFieldValue(3, 0, Fit.SubfieldIndexMainField);
-            if(val == null)
-            {
-                return null;
-            }
+		///<summary>
+		/// Retrieves the FieldId field</summary>
+		/// <returns>Returns nullable byte representing the FieldId field</returns>
+		public byte? FieldId
+		{
+			get
+			{
+				Object val = GetFieldValue(2, 0, Fit.SubfieldIndexMainField);
+				if (val == null)
+				{
+					return null;
+				}
 
-            return (Convert.ToByte(val));
-            
-        }
+				return (Convert.ToByte(val));
 
-        /// <summary>
-        /// Set ConceptCount field</summary>
-        /// <param name="conceptCount_">Nullable field value to be set</param>
-        public void SetConceptCount(byte? conceptCount_)
-        {
-            SetFieldValue(3, 0, conceptCount_, Fit.SubfieldIndexMainField);
-        }
-        
-        ///<summary>
-        /// Retrieves the DisplayType field</summary>
-        /// <returns>Returns nullable ExdDisplayType enum representing the DisplayType field</returns>
-        public ExdDisplayType? GetDisplayType()
-        {
-            object obj = GetFieldValue(4, 0, Fit.SubfieldIndexMainField);
-            ExdDisplayType? value = obj == null ? (ExdDisplayType?)null : (ExdDisplayType)obj;
-            return value;
-        }
+			}
+			set
+			{
+				SetFieldValue(2, 0, value, Fit.SubfieldIndexMainField);
+			}
+		}
 
-        /// <summary>
-        /// Set DisplayType field</summary>
-        /// <param name="displayType_">Nullable field value to be set</param>
-        public void SetDisplayType(ExdDisplayType? displayType_)
-        {
-            SetFieldValue(4, 0, displayType_, Fit.SubfieldIndexMainField);
-        }
-        
-        
-        /// <summary>
-        ///
-        /// </summary>
-        /// <returns>returns number of elements in field Title</returns>
-        public int GetNumTitle()
-        {
-            return GetNumFieldValues(5, Fit.SubfieldIndexMainField);
-        }
+		///<summary>
+		/// Retrieves the ConceptCount field</summary>
+		/// <returns>Returns nullable byte representing the ConceptCount field</returns>
+		public byte? ConceptCount
+		{
+			get
+			{
+				Object val = GetFieldValue(3, 0, Fit.SubfieldIndexMainField);
+				if (val == null)
+				{
+					return null;
+				}
 
-        ///<summary>
-        /// Retrieves the Title field</summary>
-        /// <param name="index">0 based index of Title element to retrieve</param>
-        /// <returns>Returns byte[] representing the Title field</returns>
-        public byte[] GetTitle(int index)
-        {
-            byte[] data = (byte[])GetFieldValue(5, index, Fit.SubfieldIndexMainField);
-            return data.Take(data.Length - 1).ToArray();
-        }
+				return (Convert.ToByte(val));
 
-        ///<summary>
-        /// Retrieves the Title field</summary>
-        /// <param name="index">0 based index of Title element to retrieve</param>
-        /// <returns>Returns String representing the Title field</returns>
-        public String GetTitleAsString(int index)
-        {
-            byte[] data = (byte[])GetFieldValue(5, index, Fit.SubfieldIndexMainField);
-            return data != null ? Encoding.UTF8.GetString(data, 0, data.Length - 1) : null;
-        }
+			}
+			set
+			{
+				SetFieldValue(3, 0, value, Fit.SubfieldIndexMainField);
+			}
+		}
 
-        ///<summary>
-        /// Set Title field</summary>
-        /// <param name="index">0 based index of Title element to retrieve</param>
-        /// <param name="title_"> field value to be set</param>
-        public void SetTitle(int index, String title_)
-        {
-            byte[] data = Encoding.UTF8.GetBytes(title_);
-            byte[] zdata = new byte[data.Length + 1];
-            data.CopyTo(zdata, 0);
-            SetFieldValue(5, index, zdata, Fit.SubfieldIndexMainField);
-        }
+		///<summary>
+		/// Retrieves the DisplayType field</summary>
+		/// <returns>Returns nullable ExdDisplayType enum representing the DisplayType field</returns>
+		public ExdDisplayType? DisplayType
+		{
+			get
+			{
+				object obj = GetFieldValue(4, 0, Fit.SubfieldIndexMainField);
+				ExdDisplayType? value = obj == null ? (ExdDisplayType?)null : (ExdDisplayType)obj;
+				return value;
+			}
+			set
+			{
+				SetFieldValue(4, 0, value, Fit.SubfieldIndexMainField);
+			}
+		}
 
-        
-        /// <summary>
-        /// Set Title field</summary>
-        /// <param name="index">0 based index of title</param>
-        /// <param name="title_">field value to be set</param>
-        public void SetTitle(int index, byte[] title_)
-        {
-            SetFieldValue(5, index, title_, Fit.SubfieldIndexMainField);
-        }
-        
-        #endregion // Methods
-    } // Class
+
+		/// <summary>
+		///
+		/// </summary>
+		/// <returns>returns number of elements in field Title</returns>
+		public int GetNumTitle()
+		{
+			return GetNumFieldValues(5, Fit.SubfieldIndexMainField);
+		}
+
+		///<summary>
+		/// Retrieves the Title field</summary>
+		/// <param name="index">0 based index of Title element to retrieve</param>
+		/// <returns>Returns byte[] representing the Title field</returns>
+		public byte[] GetTitle(int index)
+		{
+			byte[] data = (byte[])GetFieldValue(5, index, Fit.SubfieldIndexMainField);
+			return data.Take(data.Length - 1).ToArray();
+		}
+
+		///<summary>
+		/// Retrieves the Title field</summary>
+		/// <param name="index">0 based index of Title element to retrieve</param>
+		/// <returns>Returns String representing the Title field</returns>
+		public String GetTitleAsString(int index)
+		{
+			byte[] data = (byte[])GetFieldValue(5, index, Fit.SubfieldIndexMainField);
+			return data != null ? Encoding.UTF8.GetString(data, 0, data.Length - 1) : null;
+		}
+
+		///<summary>
+		/// Set Title field</summary>
+		/// <param name="index">0 based index of Title element to retrieve</param>
+		/// <param name="title_"> field value to be set</param>
+		public void SetTitle(int index, String title_)
+		{
+			byte[] data = Encoding.UTF8.GetBytes(title_);
+			byte[] zdata = new byte[data.Length + 1];
+			data.CopyTo(zdata, 0);
+			SetFieldValue(5, index, zdata, Fit.SubfieldIndexMainField);
+		}
+
+
+		/// <summary>
+		/// Set Title field</summary>
+		/// <param name="index">0 based index of title</param>
+		/// <param name="title_">field value to be set</param>
+		public void SetTitle(int index, byte[] title_)
+		{
+			SetFieldValue(5, index, title_, Fit.SubfieldIndexMainField);
+		}
+
+		#endregion // Methods
+	} // Class
 } // namespace

--- a/Dynastream/Fit/Profile/Mesgs/ExdScreenConfigurationMesg.cs
+++ b/Dynastream/Fit/Profile/Mesgs/ExdScreenConfigurationMesg.cs
@@ -21,121 +21,116 @@ using System.Linq;
 
 namespace Dynastream.Fit
 {
-    /// <summary>
-    /// Implements the ExdScreenConfiguration profile message.
-    /// </summary>
-    public class ExdScreenConfigurationMesg : Mesg
-    {
-        #region Fields
-        #endregion
+	/// <summary>
+	/// Implements the ExdScreenConfiguration profile message.
+	/// </summary>
+	public class ExdScreenConfigurationMesg : Mesg
+	{
+		#region Fields
+		#endregion
 
-        /// <summary>
-        /// Field Numbers for <see cref="ExdScreenConfigurationMesg"/>
-        /// </summary>
-        public sealed class FieldDefNum
-        {
-            public const byte ScreenIndex = 0;
-            public const byte FieldCount = 1;
-            public const byte Layout = 2;
-            public const byte ScreenEnabled = 3;
-            public const byte Invalid = Fit.FieldNumInvalid;
-        }
+		/// <summary>
+		/// Field Numbers for <see cref="ExdScreenConfigurationMesg"/>
+		/// </summary>
+		public sealed class FieldDefNum
+		{
+			public const byte ScreenIndex = 0;
+			public const byte FieldCount = 1;
+			public const byte Layout = 2;
+			public const byte ScreenEnabled = 3;
+			public const byte Invalid = Fit.FieldNumInvalid;
+		}
 
-        #region Constructors
-        public ExdScreenConfigurationMesg() : base(Profile.GetMesg(MesgNum.ExdScreenConfiguration))
-        {
-        }
+		#region Constructors
+		public ExdScreenConfigurationMesg() : base(Profile.GetMesg(MesgNum.ExdScreenConfiguration))
+		{
+		}
 
-        public ExdScreenConfigurationMesg(Mesg mesg) : base(mesg)
-        {
-        }
-        #endregion // Constructors
+		public ExdScreenConfigurationMesg(Mesg mesg) : base(mesg)
+		{
+		}
+		#endregion // Constructors
 
-        #region Methods
-        ///<summary>
-        /// Retrieves the ScreenIndex field</summary>
-        /// <returns>Returns nullable byte representing the ScreenIndex field</returns>
-        public byte? GetScreenIndex()
-        {
-            Object val = GetFieldValue(0, 0, Fit.SubfieldIndexMainField);
-            if(val == null)
-            {
-                return null;
-            }
+		#region Methods
+		///<summary>
+		/// Retrieves the ScreenIndex field</summary>
+		/// <returns>Returns nullable byte representing the ScreenIndex field</returns>
+		public byte? ScreenIndex
+		{
+			get
+			{
+				Object val = GetFieldValue(0, 0, Fit.SubfieldIndexMainField);
+				if (val == null)
+				{
+					return null;
+				}
 
-            return (Convert.ToByte(val));
-            
-        }
+				return (Convert.ToByte(val));
 
-        /// <summary>
-        /// Set ScreenIndex field</summary>
-        /// <param name="screenIndex_">Nullable field value to be set</param>
-        public void SetScreenIndex(byte? screenIndex_)
-        {
-            SetFieldValue(0, 0, screenIndex_, Fit.SubfieldIndexMainField);
-        }
-        
-        ///<summary>
-        /// Retrieves the FieldCount field
-        /// Comment: number of fields in screen</summary>
-        /// <returns>Returns nullable byte representing the FieldCount field</returns>
-        public byte? GetFieldCount()
-        {
-            Object val = GetFieldValue(1, 0, Fit.SubfieldIndexMainField);
-            if(val == null)
-            {
-                return null;
-            }
+			}
+			set
+			{
+				SetFieldValue(0, 0, value, Fit.SubfieldIndexMainField);
+			}
+		}
 
-            return (Convert.ToByte(val));
-            
-        }
+		///<summary>
+		/// Retrieves the FieldCount field
+		/// Comment: number of fields in screen</summary>
+		/// <returns>Returns nullable byte representing the FieldCount field</returns>
+		public byte? FieldCount
+		{
+			get
+			{
+				Object val = GetFieldValue(1, 0, Fit.SubfieldIndexMainField);
+				if (val == null)
+				{
+					return null;
+				}
 
-        /// <summary>
-        /// Set FieldCount field
-        /// Comment: number of fields in screen</summary>
-        /// <param name="fieldCount_">Nullable field value to be set</param>
-        public void SetFieldCount(byte? fieldCount_)
-        {
-            SetFieldValue(1, 0, fieldCount_, Fit.SubfieldIndexMainField);
-        }
-        
-        ///<summary>
-        /// Retrieves the Layout field</summary>
-        /// <returns>Returns nullable ExdLayout enum representing the Layout field</returns>
-        public ExdLayout? GetLayout()
-        {
-            object obj = GetFieldValue(2, 0, Fit.SubfieldIndexMainField);
-            ExdLayout? value = obj == null ? (ExdLayout?)null : (ExdLayout)obj;
-            return value;
-        }
+				return (Convert.ToByte(val));
 
-        /// <summary>
-        /// Set Layout field</summary>
-        /// <param name="layout_">Nullable field value to be set</param>
-        public void SetLayout(ExdLayout? layout_)
-        {
-            SetFieldValue(2, 0, layout_, Fit.SubfieldIndexMainField);
-        }
-        
-        ///<summary>
-        /// Retrieves the ScreenEnabled field</summary>
-        /// <returns>Returns nullable Bool enum representing the ScreenEnabled field</returns>
-        public Bool? GetScreenEnabled()
-        {
-            object obj = GetFieldValue(3, 0, Fit.SubfieldIndexMainField);
-            Bool? value = obj == null ? (Bool?)null : (Bool)obj;
-            return value;
-        }
+			}
+			set
+			{
+				SetFieldValue(1, 0, value, Fit.SubfieldIndexMainField);
+			}
+		}
 
-        /// <summary>
-        /// Set ScreenEnabled field</summary>
-        /// <param name="screenEnabled_">Nullable field value to be set</param>
-        public void SetScreenEnabled(Bool? screenEnabled_)
-        {
-            SetFieldValue(3, 0, screenEnabled_, Fit.SubfieldIndexMainField);
-        }
-        
-        #endregion // Methods
-    } // Class
+		///<summary>
+		/// Retrieves the Layout field</summary>
+		/// <returns>Returns nullable ExdLayout enum representing the Layout field</returns>
+		public ExdLayout? Layout
+		{
+			get
+			{
+				object obj = GetFieldValue(2, 0, Fit.SubfieldIndexMainField);
+				ExdLayout? value = obj == null ? (ExdLayout?)null : (ExdLayout)obj;
+				return value;
+			}
+			set
+			{
+				SetFieldValue(2, 0, value, Fit.SubfieldIndexMainField);
+			}
+		}
+
+		///<summary>
+		/// Retrieves the ScreenEnabled field</summary>
+		/// <returns>Returns nullable Bool enum representing the ScreenEnabled field</returns>
+		public Bool? ScreenEnabled
+		{
+			get
+			{
+				object obj = GetFieldValue(3, 0, Fit.SubfieldIndexMainField);
+				Bool? value = obj == null ? (Bool?)null : (Bool)obj;
+				return value;
+			}
+			set
+			{
+				SetFieldValue(3, 0, value, Fit.SubfieldIndexMainField);
+			}
+		}
+
+		#endregion // Methods
+	} // Class
 } // namespace

--- a/Dynastream/Fit/Profile/Mesgs/ExerciseTitleMesg.cs
+++ b/Dynastream/Fit/Profile/Mesgs/ExerciseTitleMesg.cs
@@ -21,158 +21,155 @@ using System.Linq;
 
 namespace Dynastream.Fit
 {
-    /// <summary>
-    /// Implements the ExerciseTitle profile message.
-    /// </summary>
-    public class ExerciseTitleMesg : Mesg
-    {
-        #region Fields
-        #endregion
+	/// <summary>
+	/// Implements the ExerciseTitle profile message.
+	/// </summary>
+	public class ExerciseTitleMesg : Mesg
+	{
+		#region Fields
+		#endregion
 
-        /// <summary>
-        /// Field Numbers for <see cref="ExerciseTitleMesg"/>
-        /// </summary>
-        public sealed class FieldDefNum
-        {
-            public const byte MessageIndex = 254;
-            public const byte ExerciseCategory = 0;
-            public const byte ExerciseName = 1;
-            public const byte WktStepName = 2;
-            public const byte Invalid = Fit.FieldNumInvalid;
-        }
+		/// <summary>
+		/// Field Numbers for <see cref="ExerciseTitleMesg"/>
+		/// </summary>
+		public sealed class FieldDefNum
+		{
+			public const byte MessageIndex = 254;
+			public const byte ExerciseCategory = 0;
+			public const byte ExerciseName = 1;
+			public const byte WktStepName = 2;
+			public const byte Invalid = Fit.FieldNumInvalid;
+		}
 
-        #region Constructors
-        public ExerciseTitleMesg() : base(Profile.GetMesg(MesgNum.ExerciseTitle))
-        {
-        }
+		#region Constructors
+		public ExerciseTitleMesg() : base(Profile.GetMesg(MesgNum.ExerciseTitle))
+		{
+		}
 
-        public ExerciseTitleMesg(Mesg mesg) : base(mesg)
-        {
-        }
-        #endregion // Constructors
+		public ExerciseTitleMesg(Mesg mesg) : base(mesg)
+		{
+		}
+		#endregion // Constructors
 
-        #region Methods
-        ///<summary>
-        /// Retrieves the MessageIndex field</summary>
-        /// <returns>Returns nullable ushort representing the MessageIndex field</returns>
-        public ushort? GetMessageIndex()
-        {
-            Object val = GetFieldValue(254, 0, Fit.SubfieldIndexMainField);
-            if(val == null)
-            {
-                return null;
-            }
+		#region Methods
+		///<summary>
+		/// Retrieves the MessageIndex field</summary>
+		/// <returns>Returns nullable ushort representing the MessageIndex field</returns>
+		public ushort? MessageIndex
+		{
+			get
+			{
+				Object val = GetFieldValue(254, 0, Fit.SubfieldIndexMainField);
+				if (val == null)
+				{
+					return null;
+				}
 
-            return (Convert.ToUInt16(val));
-            
-        }
+				return (Convert.ToUInt16(val));
 
-        /// <summary>
-        /// Set MessageIndex field</summary>
-        /// <param name="messageIndex_">Nullable field value to be set</param>
-        public void SetMessageIndex(ushort? messageIndex_)
-        {
-            SetFieldValue(254, 0, messageIndex_, Fit.SubfieldIndexMainField);
-        }
-        
-        ///<summary>
-        /// Retrieves the ExerciseCategory field</summary>
-        /// <returns>Returns nullable ushort representing the ExerciseCategory field</returns>
-        public ushort? GetExerciseCategory()
-        {
-            Object val = GetFieldValue(0, 0, Fit.SubfieldIndexMainField);
-            if(val == null)
-            {
-                return null;
-            }
+			}
+			set
+			{
+				SetFieldValue(254, 0, value, Fit.SubfieldIndexMainField);
+			}
+		}
 
-            return (Convert.ToUInt16(val));
-            
-        }
+		///<summary>
+		/// Retrieves the ExerciseCategory field</summary>
+		/// <returns>Returns nullable ushort representing the ExerciseCategory field</returns>
+		public ushort? ExerciseCategory
+		{
+			get
+			{
+				Object val = GetFieldValue(0, 0, Fit.SubfieldIndexMainField);
+				if (val == null)
+				{
+					return null;
+				}
 
-        /// <summary>
-        /// Set ExerciseCategory field</summary>
-        /// <param name="exerciseCategory_">Nullable field value to be set</param>
-        public void SetExerciseCategory(ushort? exerciseCategory_)
-        {
-            SetFieldValue(0, 0, exerciseCategory_, Fit.SubfieldIndexMainField);
-        }
-        
-        ///<summary>
-        /// Retrieves the ExerciseName field</summary>
-        /// <returns>Returns nullable ushort representing the ExerciseName field</returns>
-        public ushort? GetExerciseName()
-        {
-            Object val = GetFieldValue(1, 0, Fit.SubfieldIndexMainField);
-            if(val == null)
-            {
-                return null;
-            }
+				return (Convert.ToUInt16(val));
 
-            return (Convert.ToUInt16(val));
-            
-        }
+			}
+			set
+			{
+				SetFieldValue(0, 0, value, Fit.SubfieldIndexMainField);
+			}
+		}
 
-        /// <summary>
-        /// Set ExerciseName field</summary>
-        /// <param name="exerciseName_">Nullable field value to be set</param>
-        public void SetExerciseName(ushort? exerciseName_)
-        {
-            SetFieldValue(1, 0, exerciseName_, Fit.SubfieldIndexMainField);
-        }
-        
-        
-        /// <summary>
-        ///
-        /// </summary>
-        /// <returns>returns number of elements in field WktStepName</returns>
-        public int GetNumWktStepName()
-        {
-            return GetNumFieldValues(2, Fit.SubfieldIndexMainField);
-        }
+		///<summary>
+		/// Retrieves the ExerciseName field</summary>
+		/// <returns>Returns nullable ushort representing the ExerciseName field</returns>
+		public ushort? ExerciseName
+		{
+			get
+			{
+				Object val = GetFieldValue(1, 0, Fit.SubfieldIndexMainField);
+				if (val == null)
+				{
+					return null;
+				}
 
-        ///<summary>
-        /// Retrieves the WktStepName field</summary>
-        /// <param name="index">0 based index of WktStepName element to retrieve</param>
-        /// <returns>Returns byte[] representing the WktStepName field</returns>
-        public byte[] GetWktStepName(int index)
-        {
-            byte[] data = (byte[])GetFieldValue(2, index, Fit.SubfieldIndexMainField);
-            return data.Take(data.Length - 1).ToArray();
-        }
+				return (Convert.ToUInt16(val));
 
-        ///<summary>
-        /// Retrieves the WktStepName field</summary>
-        /// <param name="index">0 based index of WktStepName element to retrieve</param>
-        /// <returns>Returns String representing the WktStepName field</returns>
-        public String GetWktStepNameAsString(int index)
-        {
-            byte[] data = (byte[])GetFieldValue(2, index, Fit.SubfieldIndexMainField);
-            return data != null ? Encoding.UTF8.GetString(data, 0, data.Length - 1) : null;
-        }
+			}
+			set
+			{
+				SetFieldValue(1, 0, value, Fit.SubfieldIndexMainField);
+			}
+		}
 
-        ///<summary>
-        /// Set WktStepName field</summary>
-        /// <param name="index">0 based index of WktStepName element to retrieve</param>
-        /// <param name="wktStepName_"> field value to be set</param>
-        public void SetWktStepName(int index, String wktStepName_)
-        {
-            byte[] data = Encoding.UTF8.GetBytes(wktStepName_);
-            byte[] zdata = new byte[data.Length + 1];
-            data.CopyTo(zdata, 0);
-            SetFieldValue(2, index, zdata, Fit.SubfieldIndexMainField);
-        }
 
-        
-        /// <summary>
-        /// Set WktStepName field</summary>
-        /// <param name="index">0 based index of wkt_step_name</param>
-        /// <param name="wktStepName_">field value to be set</param>
-        public void SetWktStepName(int index, byte[] wktStepName_)
-        {
-            SetFieldValue(2, index, wktStepName_, Fit.SubfieldIndexMainField);
-        }
-        
-        #endregion // Methods
-    } // Class
+		/// <summary>
+		///
+		/// </summary>
+		/// <returns>returns number of elements in field WktStepName</returns>
+		public int GetNumWktStepName()
+		{
+			return GetNumFieldValues(2, Fit.SubfieldIndexMainField);
+		}
+
+		///<summary>
+		/// Retrieves the WktStepName field</summary>
+		/// <param name="index">0 based index of WktStepName element to retrieve</param>
+		/// <returns>Returns byte[] representing the WktStepName field</returns>
+		public byte[] GetWktStepName(int index)
+		{
+			byte[] data = (byte[])GetFieldValue(2, index, Fit.SubfieldIndexMainField);
+			return data.Take(data.Length - 1).ToArray();
+		}
+
+		///<summary>
+		/// Retrieves the WktStepName field</summary>
+		/// <param name="index">0 based index of WktStepName element to retrieve</param>
+		/// <returns>Returns String representing the WktStepName field</returns>
+		public String GetWktStepNameAsString(int index)
+		{
+			byte[] data = (byte[])GetFieldValue(2, index, Fit.SubfieldIndexMainField);
+			return data != null ? Encoding.UTF8.GetString(data, 0, data.Length - 1) : null;
+		}
+
+		///<summary>
+		/// Set WktStepName field</summary>
+		/// <param name="index">0 based index of WktStepName element to retrieve</param>
+		/// <param name="wktStepName_"> field value to be set</param>
+		public void SetWktStepName(int index, String wktStepName_)
+		{
+			byte[] data = Encoding.UTF8.GetBytes(wktStepName_);
+			byte[] zdata = new byte[data.Length + 1];
+			data.CopyTo(zdata, 0);
+			SetFieldValue(2, index, zdata, Fit.SubfieldIndexMainField);
+		}
+
+
+		/// <summary>
+		/// Set WktStepName field</summary>
+		/// <param name="index">0 based index of wkt_step_name</param>
+		/// <param name="wktStepName_">field value to be set</param>
+		public void SetWktStepName(int index, byte[] wktStepName_)
+		{
+			SetFieldValue(2, index, wktStepName_, Fit.SubfieldIndexMainField);
+		}
+
+		#endregion // Methods
+	} // Class
 } // namespace

--- a/Dynastream/Fit/Profile/Mesgs/FieldCapabilitiesMesg.cs
+++ b/Dynastream/Fit/Profile/Mesgs/FieldCapabilitiesMesg.cs
@@ -21,148 +21,143 @@ using System.Linq;
 
 namespace Dynastream.Fit
 {
-    /// <summary>
-    /// Implements the FieldCapabilities profile message.
-    /// </summary>
-    public class FieldCapabilitiesMesg : Mesg
-    {
-        #region Fields
-        #endregion
+	/// <summary>
+	/// Implements the FieldCapabilities profile message.
+	/// </summary>
+	public class FieldCapabilitiesMesg : Mesg
+	{
+		#region Fields
+		#endregion
 
-        /// <summary>
-        /// Field Numbers for <see cref="FieldCapabilitiesMesg"/>
-        /// </summary>
-        public sealed class FieldDefNum
-        {
-            public const byte MessageIndex = 254;
-            public const byte File = 0;
-            public const byte MesgNum = 1;
-            public const byte FieldNum = 2;
-            public const byte Count = 3;
-            public const byte Invalid = Fit.FieldNumInvalid;
-        }
+		/// <summary>
+		/// Field Numbers for <see cref="FieldCapabilitiesMesg"/>
+		/// </summary>
+		public sealed class FieldDefNum
+		{
+			public const byte MessageIndex = 254;
+			public const byte File = 0;
+			public const byte MesgNum = 1;
+			public const byte FieldNum = 2;
+			public const byte Count = 3;
+			public const byte Invalid = Fit.FieldNumInvalid;
+		}
 
-        #region Constructors
-        public FieldCapabilitiesMesg() : base(Profile.GetMesg(MesgNum.FieldCapabilities))
-        {
-        }
+		#region Constructors
+		public FieldCapabilitiesMesg() : base(Profile.GetMesg(Dynastream.Fit.MesgNum.FieldCapabilities))
+		{
+		}
 
-        public FieldCapabilitiesMesg(Mesg mesg) : base(mesg)
-        {
-        }
-        #endregion // Constructors
+		public FieldCapabilitiesMesg(Mesg mesg) : base(mesg)
+		{
+		}
+		#endregion // Constructors
 
-        #region Methods
-        ///<summary>
-        /// Retrieves the MessageIndex field</summary>
-        /// <returns>Returns nullable ushort representing the MessageIndex field</returns>
-        public ushort? GetMessageIndex()
-        {
-            Object val = GetFieldValue(254, 0, Fit.SubfieldIndexMainField);
-            if(val == null)
-            {
-                return null;
-            }
+		#region Methods
+		///<summary>
+		/// Retrieves the MessageIndex field</summary>
+		/// <returns>Returns nullable ushort representing the MessageIndex field</returns>
+		public ushort? MessageIndex
+		{
+			get
+			{
+				Object val = GetFieldValue(254, 0, Fit.SubfieldIndexMainField);
+				if (val == null)
+				{
+					return null;
+				}
 
-            return (Convert.ToUInt16(val));
-            
-        }
+				return (Convert.ToUInt16(val));
 
-        /// <summary>
-        /// Set MessageIndex field</summary>
-        /// <param name="messageIndex_">Nullable field value to be set</param>
-        public void SetMessageIndex(ushort? messageIndex_)
-        {
-            SetFieldValue(254, 0, messageIndex_, Fit.SubfieldIndexMainField);
-        }
-        
-        ///<summary>
-        /// Retrieves the File field</summary>
-        /// <returns>Returns nullable File enum representing the File field</returns>
-        public File? GetFile()
-        {
-            object obj = GetFieldValue(0, 0, Fit.SubfieldIndexMainField);
-            File? value = obj == null ? (File?)null : (File)obj;
-            return value;
-        }
+			}
+			set
+			{
+				SetFieldValue(254, 0, value, Fit.SubfieldIndexMainField);
+			}
+		}
 
-        /// <summary>
-        /// Set File field</summary>
-        /// <param name="file_">Nullable field value to be set</param>
-        public void SetFile(File? file_)
-        {
-            SetFieldValue(0, 0, file_, Fit.SubfieldIndexMainField);
-        }
-        
-        ///<summary>
-        /// Retrieves the MesgNum field</summary>
-        /// <returns>Returns nullable ushort representing the MesgNum field</returns>
-        public ushort? GetMesgNum()
-        {
-            Object val = GetFieldValue(1, 0, Fit.SubfieldIndexMainField);
-            if(val == null)
-            {
-                return null;
-            }
+		///<summary>
+		/// Retrieves the File field</summary>
+		/// <returns>Returns nullable File enum representing the File field</returns>
+		public File? File
+		{
+			get
+			{
+				object obj = GetFieldValue(0, 0, Fit.SubfieldIndexMainField);
+				File? value = obj == null ? (File?)null : (File)obj;
+				return value;
+			}
+			set
+			{
+				SetFieldValue(0, 0, value, Fit.SubfieldIndexMainField);
+			}
+		}
 
-            return (Convert.ToUInt16(val));
-            
-        }
+		///<summary>
+		/// Retrieves the MesgNum field</summary>
+		/// <returns>Returns nullable ushort representing the MesgNum field</returns>
+		public ushort? MesgNum
+		{
+			get
+			{
+				Object val = GetFieldValue(1, 0, Fit.SubfieldIndexMainField);
+				if (val == null)
+				{
+					return null;
+				}
 
-        /// <summary>
-        /// Set MesgNum field</summary>
-        /// <param name="mesgNum_">Nullable field value to be set</param>
-        public void SetMesgNum(ushort? mesgNum_)
-        {
-            SetFieldValue(1, 0, mesgNum_, Fit.SubfieldIndexMainField);
-        }
-        
-        ///<summary>
-        /// Retrieves the FieldNum field</summary>
-        /// <returns>Returns nullable byte representing the FieldNum field</returns>
-        public byte? GetFieldNum()
-        {
-            Object val = GetFieldValue(2, 0, Fit.SubfieldIndexMainField);
-            if(val == null)
-            {
-                return null;
-            }
+				return (Convert.ToUInt16(val));
 
-            return (Convert.ToByte(val));
-            
-        }
+			}
+			set
+			{
+				SetFieldValue(1, 0, value, Fit.SubfieldIndexMainField);
+			}
+		}
 
-        /// <summary>
-        /// Set FieldNum field</summary>
-        /// <param name="fieldNum_">Nullable field value to be set</param>
-        public void SetFieldNum(byte? fieldNum_)
-        {
-            SetFieldValue(2, 0, fieldNum_, Fit.SubfieldIndexMainField);
-        }
-        
-        ///<summary>
-        /// Retrieves the Count field</summary>
-        /// <returns>Returns nullable ushort representing the Count field</returns>
-        public ushort? GetCount()
-        {
-            Object val = GetFieldValue(3, 0, Fit.SubfieldIndexMainField);
-            if(val == null)
-            {
-                return null;
-            }
+		///<summary>
+		/// Retrieves the FieldNum field</summary>
+		/// <returns>Returns nullable byte representing the FieldNum field</returns>
+		public byte? FieldNum
+		{
+			get
+			{
+				Object val = GetFieldValue(2, 0, Fit.SubfieldIndexMainField);
+				if (val == null)
+				{
+					return null;
+				}
 
-            return (Convert.ToUInt16(val));
-            
-        }
+				return (Convert.ToByte(val));
 
-        /// <summary>
-        /// Set Count field</summary>
-        /// <param name="count_">Nullable field value to be set</param>
-        public void SetCount(ushort? count_)
-        {
-            SetFieldValue(3, 0, count_, Fit.SubfieldIndexMainField);
-        }
-        
-        #endregion // Methods
-    } // Class
+			}
+			set
+			{
+				SetFieldValue(2, 0, value, Fit.SubfieldIndexMainField);
+			}
+		}
+
+		///<summary>
+		/// Retrieves the Count field</summary>
+		/// <returns>Returns nullable ushort representing the Count field</returns>
+		public ushort? Count
+		{
+			get
+			{
+				Object val = GetFieldValue(3, 0, Fit.SubfieldIndexMainField);
+				if (val == null)
+				{
+					return null;
+				}
+
+				return (Convert.ToUInt16(val));
+
+			}
+			set
+			{
+				SetFieldValue(3, 0, value, Fit.SubfieldIndexMainField);
+			}
+		}
+
+		#endregion // Methods
+	} // Class
 } // namespace

--- a/Dynastream/Fit/Profile/Mesgs/FieldDescriptionMesg.cs
+++ b/Dynastream/Fit/Profile/Mesgs/FieldDescriptionMesg.cs
@@ -21,472 +21,457 @@ using System.Linq;
 
 namespace Dynastream.Fit
 {
-    /// <summary>
-    /// Implements the FieldDescription profile message.
-    /// </summary>
-    public class FieldDescriptionMesg : Mesg
-    {
-        #region Fields
-        #endregion
+	/// <summary>
+	/// Implements the FieldDescription profile message.
+	/// </summary>
+	public class FieldDescriptionMesg : Mesg
+	{
+		#region Fields
+		#endregion
 
-        /// <summary>
-        /// Field Numbers for <see cref="FieldDescriptionMesg"/>
-        /// </summary>
-        public sealed class FieldDefNum
-        {
-            public const byte DeveloperDataIndex = 0;
-            public const byte FieldDefinitionNumber = 1;
-            public const byte FitBaseTypeId = 2;
-            public const byte FieldName = 3;
-            public const byte Array = 4;
-            public const byte Components = 5;
-            public const byte Scale = 6;
-            public const byte Offset = 7;
-            public const byte Units = 8;
-            public const byte Bits = 9;
-            public const byte Accumulate = 10;
-            public const byte FitBaseUnitId = 13;
-            public const byte NativeMesgNum = 14;
-            public const byte NativeFieldNum = 15;
-            public const byte Invalid = Fit.FieldNumInvalid;
-        }
+		/// <summary>
+		/// Field Numbers for <see cref="FieldDescriptionMesg"/>
+		/// </summary>
+		public sealed class FieldDefNum
+		{
+			public const byte DeveloperDataIndex = 0;
+			public const byte FieldDefinitionNumber = 1;
+			public const byte FitBaseTypeId = 2;
+			public const byte FieldName = 3;
+			public const byte Array = 4;
+			public const byte Components = 5;
+			public const byte Scale = 6;
+			public const byte Offset = 7;
+			public const byte Units = 8;
+			public const byte Bits = 9;
+			public const byte Accumulate = 10;
+			public const byte FitBaseUnitId = 13;
+			public const byte NativeMesgNum = 14;
+			public const byte NativeFieldNum = 15;
+			public const byte Invalid = Fit.FieldNumInvalid;
+		}
 
-        #region Constructors
-        public FieldDescriptionMesg() : base(Profile.GetMesg(MesgNum.FieldDescription))
-        {
-        }
+		#region Constructors
+		public FieldDescriptionMesg() : base(Profile.GetMesg(MesgNum.FieldDescription))
+		{
+		}
 
-        public FieldDescriptionMesg(Mesg mesg) : base(mesg)
-        {
-        }
-        #endregion // Constructors
+		public FieldDescriptionMesg(Mesg mesg) : base(mesg)
+		{
+		}
+		#endregion // Constructors
 
-        #region Methods
-        ///<summary>
-        /// Retrieves the DeveloperDataIndex field</summary>
-        /// <returns>Returns nullable byte representing the DeveloperDataIndex field</returns>
-        public byte? GetDeveloperDataIndex()
-        {
-            Object val = GetFieldValue(0, 0, Fit.SubfieldIndexMainField);
-            if(val == null)
-            {
-                return null;
-            }
+		#region Methods
+		///<summary>
+		/// Retrieves the DeveloperDataIndex field</summary>
+		/// <returns>Returns nullable byte representing the DeveloperDataIndex field</returns>
+		public byte? DeveloperDataIndex
+		{
+			get
+			{
+				Object val = GetFieldValue(0, 0, Fit.SubfieldIndexMainField);
+				if (val == null)
+				{
+					return null;
+				}
 
-            return (Convert.ToByte(val));
-            
-        }
+				return (Convert.ToByte(val));
 
-        /// <summary>
-        /// Set DeveloperDataIndex field</summary>
-        /// <param name="developerDataIndex_">Nullable field value to be set</param>
-        public void SetDeveloperDataIndex(byte? developerDataIndex_)
-        {
-            SetFieldValue(0, 0, developerDataIndex_, Fit.SubfieldIndexMainField);
-        }
-        
-        ///<summary>
-        /// Retrieves the FieldDefinitionNumber field</summary>
-        /// <returns>Returns nullable byte representing the FieldDefinitionNumber field</returns>
-        public byte? GetFieldDefinitionNumber()
-        {
-            Object val = GetFieldValue(1, 0, Fit.SubfieldIndexMainField);
-            if(val == null)
-            {
-                return null;
-            }
+			}
+			set
+			{
+				SetFieldValue(0, 0, value, Fit.SubfieldIndexMainField);
+			}
+		}
 
-            return (Convert.ToByte(val));
-            
-        }
+		///<summary>
+		/// Retrieves the FieldDefinitionNumber field</summary>
+		/// <returns>Returns nullable byte representing the FieldDefinitionNumber field</returns>
+		public byte? FieldDefinitionNumber
+		{
+			get
+			{
+				Object val = GetFieldValue(1, 0, Fit.SubfieldIndexMainField);
+				if (val == null)
+				{
+					return null;
+				}
 
-        /// <summary>
-        /// Set FieldDefinitionNumber field</summary>
-        /// <param name="fieldDefinitionNumber_">Nullable field value to be set</param>
-        public void SetFieldDefinitionNumber(byte? fieldDefinitionNumber_)
-        {
-            SetFieldValue(1, 0, fieldDefinitionNumber_, Fit.SubfieldIndexMainField);
-        }
-        
-        ///<summary>
-        /// Retrieves the FitBaseTypeId field</summary>
-        /// <returns>Returns nullable byte representing the FitBaseTypeId field</returns>
-        public byte? GetFitBaseTypeId()
-        {
-            Object val = GetFieldValue(2, 0, Fit.SubfieldIndexMainField);
-            if(val == null)
-            {
-                return null;
-            }
+				return (Convert.ToByte(val));
 
-            return (Convert.ToByte(val));
-            
-        }
+			}
+			set
+			{
+				SetFieldValue(1, 0, value, Fit.SubfieldIndexMainField);
+			}
+		}
 
-        /// <summary>
-        /// Set FitBaseTypeId field</summary>
-        /// <param name="fitBaseTypeId_">Nullable field value to be set</param>
-        public void SetFitBaseTypeId(byte? fitBaseTypeId_)
-        {
-            SetFieldValue(2, 0, fitBaseTypeId_, Fit.SubfieldIndexMainField);
-        }
-        
-        
-        /// <summary>
-        ///
-        /// </summary>
-        /// <returns>returns number of elements in field FieldName</returns>
-        public int GetNumFieldName()
-        {
-            return GetNumFieldValues(3, Fit.SubfieldIndexMainField);
-        }
+		///<summary>
+		/// Retrieves the FitBaseTypeId field</summary>
+		/// <returns>Returns nullable byte representing the FitBaseTypeId field</returns>
+		public byte? FitBaseTypeId
+		{
+			get
+			{
+				Object val = GetFieldValue(2, 0, Fit.SubfieldIndexMainField);
+				if (val == null)
+				{
+					return null;
+				}
 
-        ///<summary>
-        /// Retrieves the FieldName field</summary>
-        /// <param name="index">0 based index of FieldName element to retrieve</param>
-        /// <returns>Returns byte[] representing the FieldName field</returns>
-        public byte[] GetFieldName(int index)
-        {
-            byte[] data = (byte[])GetFieldValue(3, index, Fit.SubfieldIndexMainField);
-            return data.Take(data.Length - 1).ToArray();
-        }
+				return (Convert.ToByte(val));
 
-        ///<summary>
-        /// Retrieves the FieldName field</summary>
-        /// <param name="index">0 based index of FieldName element to retrieve</param>
-        /// <returns>Returns String representing the FieldName field</returns>
-        public String GetFieldNameAsString(int index)
-        {
-            byte[] data = (byte[])GetFieldValue(3, index, Fit.SubfieldIndexMainField);
-            return data != null ? Encoding.UTF8.GetString(data, 0, data.Length - 1) : null;
-        }
+			}
+			set
+			{
+				SetFieldValue(2, 0, value, Fit.SubfieldIndexMainField);
+			}
+		}
 
-        ///<summary>
-        /// Set FieldName field</summary>
-        /// <param name="index">0 based index of FieldName element to retrieve</param>
-        /// <param name="fieldName_"> field value to be set</param>
-        public void SetFieldName(int index, String fieldName_)
-        {
-            byte[] data = Encoding.UTF8.GetBytes(fieldName_);
-            byte[] zdata = new byte[data.Length + 1];
-            data.CopyTo(zdata, 0);
-            SetFieldValue(3, index, zdata, Fit.SubfieldIndexMainField);
-        }
 
-        
-        /// <summary>
-        /// Set FieldName field</summary>
-        /// <param name="index">0 based index of field_name</param>
-        /// <param name="fieldName_">field value to be set</param>
-        public void SetFieldName(int index, byte[] fieldName_)
-        {
-            SetFieldValue(3, index, fieldName_, Fit.SubfieldIndexMainField);
-        }
-        
-        ///<summary>
-        /// Retrieves the Array field</summary>
-        /// <returns>Returns nullable byte representing the Array field</returns>
-        public byte? GetArray()
-        {
-            Object val = GetFieldValue(4, 0, Fit.SubfieldIndexMainField);
-            if(val == null)
-            {
-                return null;
-            }
+		/// <summary>
+		///
+		/// </summary>
+		/// <returns>returns number of elements in field FieldName</returns>
+		public int GetNumFieldName()
+		{
+			return GetNumFieldValues(3, Fit.SubfieldIndexMainField);
+		}
 
-            return (Convert.ToByte(val));
-            
-        }
+		///<summary>
+		/// Retrieves the FieldName field</summary>
+		/// <param name="index">0 based index of FieldName element to retrieve</param>
+		/// <returns>Returns byte[] representing the FieldName field</returns>
+		public byte[] GetFieldName(int index)
+		{
+			byte[] data = (byte[])GetFieldValue(3, index, Fit.SubfieldIndexMainField);
+			return data.Take(data.Length - 1).ToArray();
+		}
 
-        /// <summary>
-        /// Set Array field</summary>
-        /// <param name="array_">Nullable field value to be set</param>
-        public void SetArray(byte? array_)
-        {
-            SetFieldValue(4, 0, array_, Fit.SubfieldIndexMainField);
-        }
-        
-        ///<summary>
-        /// Retrieves the Components field</summary>
-        /// <returns>Returns byte[] representing the Components field</returns>
-        public byte[] GetComponents()
-        {
-            byte[] data = (byte[])GetFieldValue(5, 0, Fit.SubfieldIndexMainField);
-            return data.Take(data.Length - 1).ToArray();
-        }
+		///<summary>
+		/// Retrieves the FieldName field</summary>
+		/// <param name="index">0 based index of FieldName element to retrieve</param>
+		/// <returns>Returns String representing the FieldName field</returns>
+		public String GetFieldNameAsString(int index)
+		{
+			byte[] data = (byte[])GetFieldValue(3, index, Fit.SubfieldIndexMainField);
+			return data != null ? Encoding.UTF8.GetString(data, 0, data.Length - 1) : null;
+		}
 
-        ///<summary>
-        /// Retrieves the Components field</summary>
-        /// <returns>Returns String representing the Components field</returns>
-        public String GetComponentsAsString()
-        {
-            byte[] data = (byte[])GetFieldValue(5, 0, Fit.SubfieldIndexMainField);
-            return data != null ? Encoding.UTF8.GetString(data, 0, data.Length - 1) : null;
-        }
+		///<summary>
+		/// Set FieldName field</summary>
+		/// <param name="index">0 based index of FieldName element to retrieve</param>
+		/// <param name="fieldName_"> field value to be set</param>
+		public void SetFieldName(int index, String fieldName_)
+		{
+			byte[] data = Encoding.UTF8.GetBytes(fieldName_);
+			byte[] zdata = new byte[data.Length + 1];
+			data.CopyTo(zdata, 0);
+			SetFieldValue(3, index, zdata, Fit.SubfieldIndexMainField);
+		}
 
-        ///<summary>
-        /// Set Components field</summary>
-        /// <param name="components_"> field value to be set</param>
-        public void SetComponents(String components_)
-        {
-            byte[] data = Encoding.UTF8.GetBytes(components_);
-            byte[] zdata = new byte[data.Length + 1];
-            data.CopyTo(zdata, 0);
-            SetFieldValue(5, 0, zdata, Fit.SubfieldIndexMainField);
-        }
 
-        
-        /// <summary>
-        /// Set Components field</summary>
-        /// <param name="components_">field value to be set</param>
-        public void SetComponents(byte[] components_)
-        {
-            SetFieldValue(5, 0, components_, Fit.SubfieldIndexMainField);
-        }
-        
-        ///<summary>
-        /// Retrieves the Scale field</summary>
-        /// <returns>Returns nullable byte representing the Scale field</returns>
-        public byte? GetScale()
-        {
-            Object val = GetFieldValue(6, 0, Fit.SubfieldIndexMainField);
-            if(val == null)
-            {
-                return null;
-            }
+		/// <summary>
+		/// Set FieldName field</summary>
+		/// <param name="index">0 based index of field_name</param>
+		/// <param name="fieldName_">field value to be set</param>
+		public void SetFieldName(int index, byte[] fieldName_)
+		{
+			SetFieldValue(3, index, fieldName_, Fit.SubfieldIndexMainField);
+		}
 
-            return (Convert.ToByte(val));
-            
-        }
+		///<summary>
+		/// Retrieves the Array field</summary>
+		/// <returns>Returns nullable byte representing the Array field</returns>
+		public byte? Array
+		{
+			get
+			{
+				Object val = GetFieldValue(4, 0, Fit.SubfieldIndexMainField);
+				if (val == null)
+				{
+					return null;
+				}
 
-        /// <summary>
-        /// Set Scale field</summary>
-        /// <param name="scale_">Nullable field value to be set</param>
-        public void SetScale(byte? scale_)
-        {
-            SetFieldValue(6, 0, scale_, Fit.SubfieldIndexMainField);
-        }
-        
-        ///<summary>
-        /// Retrieves the Offset field</summary>
-        /// <returns>Returns nullable sbyte representing the Offset field</returns>
-        public sbyte? GetOffset()
-        {
-            Object val = GetFieldValue(7, 0, Fit.SubfieldIndexMainField);
-            if(val == null)
-            {
-                return null;
-            }
+				return (Convert.ToByte(val));
 
-            return (Convert.ToSByte(val));
-            
-        }
+			}
+			set
+			{
+				SetFieldValue(4, 0, value, Fit.SubfieldIndexMainField);
+			}
+		}
 
-        /// <summary>
-        /// Set Offset field</summary>
-        /// <param name="offset_">Nullable field value to be set</param>
-        public void SetOffset(sbyte? offset_)
-        {
-            SetFieldValue(7, 0, offset_, Fit.SubfieldIndexMainField);
-        }
-        
-        
-        /// <summary>
-        ///
-        /// </summary>
-        /// <returns>returns number of elements in field Units</returns>
-        public int GetNumUnits()
-        {
-            return GetNumFieldValues(8, Fit.SubfieldIndexMainField);
-        }
+		///<summary>
+		/// Retrieves the Components field</summary>
+		/// <returns>Returns byte[] representing the Components field</returns>
+		public byte[] Components
+		{
+			get
+			{
+				byte[] data = (byte[])GetFieldValue(5, 0, Fit.SubfieldIndexMainField);
+				return data.Take(data.Length - 1).ToArray();
+			}
+			set
+			{
+				SetFieldValue(5, 0, value, Fit.SubfieldIndexMainField);
+			}
+		}
 
-        ///<summary>
-        /// Retrieves the Units field</summary>
-        /// <param name="index">0 based index of Units element to retrieve</param>
-        /// <returns>Returns byte[] representing the Units field</returns>
-        public byte[] GetUnits(int index)
-        {
-            byte[] data = (byte[])GetFieldValue(8, index, Fit.SubfieldIndexMainField);
-            return data.Take(data.Length - 1).ToArray();
-        }
+		///<summary>
+		/// Retrieves the Components field</summary>
+		/// <returns>Returns String representing the Components field</returns>
+		public String GetComponentsAsString()
+		{
+			byte[] data = (byte[])GetFieldValue(5, 0, Fit.SubfieldIndexMainField);
+			return data != null ? Encoding.UTF8.GetString(data, 0, data.Length - 1) : null;
+		}
 
-        ///<summary>
-        /// Retrieves the Units field</summary>
-        /// <param name="index">0 based index of Units element to retrieve</param>
-        /// <returns>Returns String representing the Units field</returns>
-        public String GetUnitsAsString(int index)
-        {
-            byte[] data = (byte[])GetFieldValue(8, index, Fit.SubfieldIndexMainField);
-            return data != null ? Encoding.UTF8.GetString(data, 0, data.Length - 1) : null;
-        }
+		///<summary>
+		/// Set Components field</summary>
+		/// <param name="components_"> field value to be set</param>
+		public void SetComponents(String components_)
+		{
+			byte[] data = Encoding.UTF8.GetBytes(components_);
+			byte[] zdata = new byte[data.Length + 1];
+			data.CopyTo(zdata, 0);
+			SetFieldValue(5, 0, zdata, Fit.SubfieldIndexMainField);
+		}
 
-        ///<summary>
-        /// Set Units field</summary>
-        /// <param name="index">0 based index of Units element to retrieve</param>
-        /// <param name="units_"> field value to be set</param>
-        public void SetUnits(int index, String units_)
-        {
-            byte[] data = Encoding.UTF8.GetBytes(units_);
-            byte[] zdata = new byte[data.Length + 1];
-            data.CopyTo(zdata, 0);
-            SetFieldValue(8, index, zdata, Fit.SubfieldIndexMainField);
-        }
+		///<summary>
+		/// Retrieves the Scale field</summary>
+		/// <returns>Returns nullable byte representing the Scale field</returns>
+		public byte? Scale
+		{
+			get
+			{
+				Object val = GetFieldValue(6, 0, Fit.SubfieldIndexMainField);
+				if (val == null)
+				{
+					return null;
+				}
 
-        
-        /// <summary>
-        /// Set Units field</summary>
-        /// <param name="index">0 based index of units</param>
-        /// <param name="units_">field value to be set</param>
-        public void SetUnits(int index, byte[] units_)
-        {
-            SetFieldValue(8, index, units_, Fit.SubfieldIndexMainField);
-        }
-        
-        ///<summary>
-        /// Retrieves the Bits field</summary>
-        /// <returns>Returns byte[] representing the Bits field</returns>
-        public byte[] GetBits()
-        {
-            byte[] data = (byte[])GetFieldValue(9, 0, Fit.SubfieldIndexMainField);
-            return data.Take(data.Length - 1).ToArray();
-        }
+				return (Convert.ToByte(val));
 
-        ///<summary>
-        /// Retrieves the Bits field</summary>
-        /// <returns>Returns String representing the Bits field</returns>
-        public String GetBitsAsString()
-        {
-            byte[] data = (byte[])GetFieldValue(9, 0, Fit.SubfieldIndexMainField);
-            return data != null ? Encoding.UTF8.GetString(data, 0, data.Length - 1) : null;
-        }
+			}
+			set
+			{
+				SetFieldValue(6, 0, value, Fit.SubfieldIndexMainField);
+			}
+		}
 
-        ///<summary>
-        /// Set Bits field</summary>
-        /// <param name="bits_"> field value to be set</param>
-        public void SetBits(String bits_)
-        {
-            byte[] data = Encoding.UTF8.GetBytes(bits_);
-            byte[] zdata = new byte[data.Length + 1];
-            data.CopyTo(zdata, 0);
-            SetFieldValue(9, 0, zdata, Fit.SubfieldIndexMainField);
-        }
+		///<summary>
+		/// Retrieves the Offset field</summary>
+		/// <returns>Returns nullable sbyte representing the Offset field</returns>
+		public sbyte? Offset
+		{
+			get
+			{
+				Object val = GetFieldValue(7, 0, Fit.SubfieldIndexMainField);
+				if (val == null)
+				{
+					return null;
+				}
 
-        
-        /// <summary>
-        /// Set Bits field</summary>
-        /// <param name="bits_">field value to be set</param>
-        public void SetBits(byte[] bits_)
-        {
-            SetFieldValue(9, 0, bits_, Fit.SubfieldIndexMainField);
-        }
-        
-        ///<summary>
-        /// Retrieves the Accumulate field</summary>
-        /// <returns>Returns byte[] representing the Accumulate field</returns>
-        public byte[] GetAccumulate()
-        {
-            byte[] data = (byte[])GetFieldValue(10, 0, Fit.SubfieldIndexMainField);
-            return data.Take(data.Length - 1).ToArray();
-        }
+				return (Convert.ToSByte(val));
 
-        ///<summary>
-        /// Retrieves the Accumulate field</summary>
-        /// <returns>Returns String representing the Accumulate field</returns>
-        public String GetAccumulateAsString()
-        {
-            byte[] data = (byte[])GetFieldValue(10, 0, Fit.SubfieldIndexMainField);
-            return data != null ? Encoding.UTF8.GetString(data, 0, data.Length - 1) : null;
-        }
+			}
+			set
+			{
+				SetFieldValue(7, 0, value, Fit.SubfieldIndexMainField);
+			}
+		}
 
-        ///<summary>
-        /// Set Accumulate field</summary>
-        /// <param name="accumulate_"> field value to be set</param>
-        public void SetAccumulate(String accumulate_)
-        {
-            byte[] data = Encoding.UTF8.GetBytes(accumulate_);
-            byte[] zdata = new byte[data.Length + 1];
-            data.CopyTo(zdata, 0);
-            SetFieldValue(10, 0, zdata, Fit.SubfieldIndexMainField);
-        }
 
-        
-        /// <summary>
-        /// Set Accumulate field</summary>
-        /// <param name="accumulate_">field value to be set</param>
-        public void SetAccumulate(byte[] accumulate_)
-        {
-            SetFieldValue(10, 0, accumulate_, Fit.SubfieldIndexMainField);
-        }
-        
-        ///<summary>
-        /// Retrieves the FitBaseUnitId field</summary>
-        /// <returns>Returns nullable ushort representing the FitBaseUnitId field</returns>
-        public ushort? GetFitBaseUnitId()
-        {
-            Object val = GetFieldValue(13, 0, Fit.SubfieldIndexMainField);
-            if(val == null)
-            {
-                return null;
-            }
+		/// <summary>
+		///
+		/// </summary>
+		/// <returns>returns number of elements in field Units</returns>
+		public int GetNumUnits()
+		{
+			return GetNumFieldValues(8, Fit.SubfieldIndexMainField);
+		}
 
-            return (Convert.ToUInt16(val));
-            
-        }
+		///<summary>
+		/// Retrieves the Units field</summary>
+		/// <param name="index">0 based index of Units element to retrieve</param>
+		/// <returns>Returns byte[] representing the Units field</returns>
+		public byte[] GetUnits(int index)
+		{
+			byte[] data = (byte[])GetFieldValue(8, index, Fit.SubfieldIndexMainField);
+			return data.Take(data.Length - 1).ToArray();
+		}
 
-        /// <summary>
-        /// Set FitBaseUnitId field</summary>
-        /// <param name="fitBaseUnitId_">Nullable field value to be set</param>
-        public void SetFitBaseUnitId(ushort? fitBaseUnitId_)
-        {
-            SetFieldValue(13, 0, fitBaseUnitId_, Fit.SubfieldIndexMainField);
-        }
-        
-        ///<summary>
-        /// Retrieves the NativeMesgNum field</summary>
-        /// <returns>Returns nullable ushort representing the NativeMesgNum field</returns>
-        public ushort? GetNativeMesgNum()
-        {
-            Object val = GetFieldValue(14, 0, Fit.SubfieldIndexMainField);
-            if(val == null)
-            {
-                return null;
-            }
+		///<summary>
+		/// Retrieves the Units field</summary>
+		/// <param name="index">0 based index of Units element to retrieve</param>
+		/// <returns>Returns String representing the Units field</returns>
+		public String GetUnitsAsString(int index)
+		{
+			byte[] data = (byte[])GetFieldValue(8, index, Fit.SubfieldIndexMainField);
+			return data != null ? Encoding.UTF8.GetString(data, 0, data.Length - 1) : null;
+		}
 
-            return (Convert.ToUInt16(val));
-            
-        }
+		///<summary>
+		/// Set Units field</summary>
+		/// <param name="index">0 based index of Units element to retrieve</param>
+		/// <param name="units_"> field value to be set</param>
+		public void SetUnits(int index, String units_)
+		{
+			byte[] data = Encoding.UTF8.GetBytes(units_);
+			byte[] zdata = new byte[data.Length + 1];
+			data.CopyTo(zdata, 0);
+			SetFieldValue(8, index, zdata, Fit.SubfieldIndexMainField);
+		}
 
-        /// <summary>
-        /// Set NativeMesgNum field</summary>
-        /// <param name="nativeMesgNum_">Nullable field value to be set</param>
-        public void SetNativeMesgNum(ushort? nativeMesgNum_)
-        {
-            SetFieldValue(14, 0, nativeMesgNum_, Fit.SubfieldIndexMainField);
-        }
-        
-        ///<summary>
-        /// Retrieves the NativeFieldNum field</summary>
-        /// <returns>Returns nullable byte representing the NativeFieldNum field</returns>
-        public byte? GetNativeFieldNum()
-        {
-            Object val = GetFieldValue(15, 0, Fit.SubfieldIndexMainField);
-            if(val == null)
-            {
-                return null;
-            }
 
-            return (Convert.ToByte(val));
-            
-        }
+		/// <summary>
+		/// Set Units field</summary>
+		/// <param name="index">0 based index of units</param>
+		/// <param name="units_">field value to be set</param>
+		public void SetUnits(int index, byte[] units_)
+		{
+			SetFieldValue(8, index, units_, Fit.SubfieldIndexMainField);
+		}
 
-        /// <summary>
-        /// Set NativeFieldNum field</summary>
-        /// <param name="nativeFieldNum_">Nullable field value to be set</param>
-        public void SetNativeFieldNum(byte? nativeFieldNum_)
-        {
-            SetFieldValue(15, 0, nativeFieldNum_, Fit.SubfieldIndexMainField);
-        }
-        
-        #endregion // Methods
-    } // Class
+		///<summary>
+		/// Retrieves the Bits field</summary>
+		/// <returns>Returns byte[] representing the Bits field</returns>
+		public byte[] Bits
+		{
+			get
+			{
+				byte[] data = (byte[])GetFieldValue(9, 0, Fit.SubfieldIndexMainField);
+				return data.Take(data.Length - 1).ToArray();
+			}
+			set
+			{
+				SetFieldValue(9, 0, value, Fit.SubfieldIndexMainField);
+			}
+		}
+
+		///<summary>
+		/// Retrieves the Bits field</summary>
+		/// <returns>Returns String representing the Bits field</returns>
+		public String GetBitsAsString()
+		{
+			byte[] data = (byte[])GetFieldValue(9, 0, Fit.SubfieldIndexMainField);
+			return data != null ? Encoding.UTF8.GetString(data, 0, data.Length - 1) : null;
+		}
+
+		///<summary>
+		/// Set Bits field</summary>
+		/// <param name="bits_"> field value to be set</param>
+		public void SetBits(String bits_)
+		{
+			byte[] data = Encoding.UTF8.GetBytes(bits_);
+			byte[] zdata = new byte[data.Length + 1];
+			data.CopyTo(zdata, 0);
+			SetFieldValue(9, 0, zdata, Fit.SubfieldIndexMainField);
+		}
+
+		///<summary>
+		/// Retrieves the Accumulate field</summary>
+		/// <returns>Returns byte[] representing the Accumulate field</returns>
+		public byte[] Accumulate
+		{
+			get
+			{
+				byte[] data = (byte[])GetFieldValue(10, 0, Fit.SubfieldIndexMainField);
+				return data.Take(data.Length - 1).ToArray();
+			}
+			set
+			{
+				SetFieldValue(10, 0, value, Fit.SubfieldIndexMainField);
+			}
+		}
+
+		///<summary>
+		/// Retrieves the Accumulate field</summary>
+		/// <returns>Returns String representing the Accumulate field</returns>
+		public String GetAccumulateAsString()
+		{
+			byte[] data = (byte[])GetFieldValue(10, 0, Fit.SubfieldIndexMainField);
+			return data != null ? Encoding.UTF8.GetString(data, 0, data.Length - 1) : null;
+		}
+
+		///<summary>
+		/// Set Accumulate field</summary>
+		/// <param name="accumulate_"> field value to be set</param>
+		public void SetAccumulate(String accumulate_)
+		{
+			byte[] data = Encoding.UTF8.GetBytes(accumulate_);
+			byte[] zdata = new byte[data.Length + 1];
+			data.CopyTo(zdata, 0);
+			SetFieldValue(10, 0, zdata, Fit.SubfieldIndexMainField);
+		}
+
+		///<summary>
+		/// Retrieves the FitBaseUnitId field</summary>
+		/// <returns>Returns nullable ushort representing the FitBaseUnitId field</returns>
+		public ushort? FitBaseUnitId
+		{
+			get
+			{
+				Object val = GetFieldValue(13, 0, Fit.SubfieldIndexMainField);
+				if (val == null)
+				{
+					return null;
+				}
+
+				return (Convert.ToUInt16(val));
+
+			}
+			set
+			{
+				SetFieldValue(13, 0, value, Fit.SubfieldIndexMainField);
+			}
+		}
+
+		///<summary>
+		/// Retrieves the NativeMesgNum field</summary>
+		/// <returns>Returns nullable ushort representing the NativeMesgNum field</returns>
+		public ushort? NativeMesgNum
+		{
+			get
+			{
+				Object val = GetFieldValue(14, 0, Fit.SubfieldIndexMainField);
+				if (val == null)
+				{
+					return null;
+				}
+
+				return (Convert.ToUInt16(val));
+
+			}
+			set
+			{
+				SetFieldValue(14, 0, value, Fit.SubfieldIndexMainField);
+			}
+		}
+
+		///<summary>
+		/// Retrieves the NativeFieldNum field</summary>
+		/// <returns>Returns nullable byte representing the NativeFieldNum field</returns>
+		public byte? NativeFieldNum
+		{
+			get
+			{
+				Object val = GetFieldValue(15, 0, Fit.SubfieldIndexMainField);
+				if (val == null)
+				{
+					return null;
+				}
+
+				return (Convert.ToByte(val));
+
+			}
+			set
+			{
+				SetFieldValue(15, 0, value, Fit.SubfieldIndexMainField);
+			}
+		}
+
+		#endregion // Methods
+	} // Class
 } // namespace

--- a/Dynastream/Fit/Profile/Mesgs/FileCapabilitiesMesg.cs
+++ b/Dynastream/Fit/Profile/Mesgs/FileCapabilitiesMesg.cs
@@ -21,189 +21,181 @@ using System.Linq;
 
 namespace Dynastream.Fit
 {
-    /// <summary>
-    /// Implements the FileCapabilities profile message.
-    /// </summary>
-    public class FileCapabilitiesMesg : Mesg
-    {
-        #region Fields
-        #endregion
+	/// <summary>
+	/// Implements the FileCapabilities profile message.
+	/// </summary>
+	public class FileCapabilitiesMesg : Mesg
+	{
+		#region Fields
+		#endregion
 
-        /// <summary>
-        /// Field Numbers for <see cref="FileCapabilitiesMesg"/>
-        /// </summary>
-        public sealed class FieldDefNum
-        {
-            public const byte MessageIndex = 254;
-            public const byte Type = 0;
-            public const byte Flags = 1;
-            public const byte Directory = 2;
-            public const byte MaxCount = 3;
-            public const byte MaxSize = 4;
-            public const byte Invalid = Fit.FieldNumInvalid;
-        }
+		/// <summary>
+		/// Field Numbers for <see cref="FileCapabilitiesMesg"/>
+		/// </summary>
+		public sealed class FieldDefNum
+		{
+			public const byte MessageIndex = 254;
+			public const byte Type = 0;
+			public const byte Flags = 1;
+			public const byte Directory = 2;
+			public const byte MaxCount = 3;
+			public const byte MaxSize = 4;
+			public const byte Invalid = Fit.FieldNumInvalid;
+		}
 
-        #region Constructors
-        public FileCapabilitiesMesg() : base(Profile.GetMesg(MesgNum.FileCapabilities))
-        {
-        }
+		#region Constructors
+		public FileCapabilitiesMesg() : base(Profile.GetMesg(MesgNum.FileCapabilities))
+		{
+		}
 
-        public FileCapabilitiesMesg(Mesg mesg) : base(mesg)
-        {
-        }
-        #endregion // Constructors
+		public FileCapabilitiesMesg(Mesg mesg) : base(mesg)
+		{
+		}
+		#endregion // Constructors
 
-        #region Methods
-        ///<summary>
-        /// Retrieves the MessageIndex field</summary>
-        /// <returns>Returns nullable ushort representing the MessageIndex field</returns>
-        public ushort? GetMessageIndex()
-        {
-            Object val = GetFieldValue(254, 0, Fit.SubfieldIndexMainField);
-            if(val == null)
-            {
-                return null;
-            }
+		#region Methods
+		///<summary>
+		/// Retrieves the MessageIndex field</summary>
+		/// <returns>Returns nullable ushort representing the MessageIndex field</returns>
+		public ushort? MessageIndex
+		{
+			get
+			{
+				Object val = GetFieldValue(254, 0, Fit.SubfieldIndexMainField);
+				if (val == null)
+				{
+					return null;
+				}
 
-            return (Convert.ToUInt16(val));
-            
-        }
+				return (Convert.ToUInt16(val));
 
-        /// <summary>
-        /// Set MessageIndex field</summary>
-        /// <param name="messageIndex_">Nullable field value to be set</param>
-        public void SetMessageIndex(ushort? messageIndex_)
-        {
-            SetFieldValue(254, 0, messageIndex_, Fit.SubfieldIndexMainField);
-        }
-        
-        ///<summary>
-        /// Retrieves the Type field</summary>
-        /// <returns>Returns nullable File enum representing the Type field</returns>
-        new public File? GetType()
-        {
-            object obj = GetFieldValue(0, 0, Fit.SubfieldIndexMainField);
-            File? value = obj == null ? (File?)null : (File)obj;
-            return value;
-        }
+			}
+			set
+			{
+				SetFieldValue(254, 0, value, Fit.SubfieldIndexMainField);
+			}
+		}
 
-        /// <summary>
-        /// Set Type field</summary>
-        /// <param name="type_">Nullable field value to be set</param>
-        public void SetType(File? type_)
-        {
-            SetFieldValue(0, 0, type_, Fit.SubfieldIndexMainField);
-        }
-        
-        ///<summary>
-        /// Retrieves the Flags field</summary>
-        /// <returns>Returns nullable byte representing the Flags field</returns>
-        public byte? GetFlags()
-        {
-            Object val = GetFieldValue(1, 0, Fit.SubfieldIndexMainField);
-            if(val == null)
-            {
-                return null;
-            }
+		///<summary>
+		/// Retrieves the Type field</summary>
+		/// <returns>Returns nullable File enum representing the Type field</returns>
+		public File? Type
+		{
+			get
+			{
+				object obj = GetFieldValue(0, 0, Fit.SubfieldIndexMainField);
+				File? value = obj == null ? (File?)null : (File)obj;
+				return value;
+			}
+			set
+			{
+				SetFieldValue(0, 0, value, Fit.SubfieldIndexMainField);
+			}
+		}
 
-            return (Convert.ToByte(val));
-            
-        }
+		///<summary>
+		/// Retrieves the Flags field</summary>
+		/// <returns>Returns nullable byte representing the Flags field</returns>
+		public byte? Flags
+		{
+			get
+			{
+				Object val = GetFieldValue(1, 0, Fit.SubfieldIndexMainField);
+				if (val == null)
+				{
+					return null;
+				}
 
-        /// <summary>
-        /// Set Flags field</summary>
-        /// <param name="flags_">Nullable field value to be set</param>
-        public void SetFlags(byte? flags_)
-        {
-            SetFieldValue(1, 0, flags_, Fit.SubfieldIndexMainField);
-        }
-        
-        ///<summary>
-        /// Retrieves the Directory field</summary>
-        /// <returns>Returns byte[] representing the Directory field</returns>
-        public byte[] GetDirectory()
-        {
-            byte[] data = (byte[])GetFieldValue(2, 0, Fit.SubfieldIndexMainField);
-            return data.Take(data.Length - 1).ToArray();
-        }
+				return (Convert.ToByte(val));
 
-        ///<summary>
-        /// Retrieves the Directory field</summary>
-        /// <returns>Returns String representing the Directory field</returns>
-        public String GetDirectoryAsString()
-        {
-            byte[] data = (byte[])GetFieldValue(2, 0, Fit.SubfieldIndexMainField);
-            return data != null ? Encoding.UTF8.GetString(data, 0, data.Length - 1) : null;
-        }
+			}
+			set
+			{
+				SetFieldValue(1, 0, value, Fit.SubfieldIndexMainField);
+			}
+		}
 
-        ///<summary>
-        /// Set Directory field</summary>
-        /// <param name="directory_"> field value to be set</param>
-        public void SetDirectory(String directory_)
-        {
-            byte[] data = Encoding.UTF8.GetBytes(directory_);
-            byte[] zdata = new byte[data.Length + 1];
-            data.CopyTo(zdata, 0);
-            SetFieldValue(2, 0, zdata, Fit.SubfieldIndexMainField);
-        }
+		///<summary>
+		/// Retrieves the Directory field</summary>
+		/// <returns>Returns byte[] representing the Directory field</returns>
+		public byte[] Directory
+		{
+			get
+			{
+				byte[] data = (byte[])GetFieldValue(2, 0, Fit.SubfieldIndexMainField);
+				return data.Take(data.Length - 1).ToArray();
+			}
+			set
+			{
+				SetFieldValue(2, 0, value, Fit.SubfieldIndexMainField);
+			}
+		}
 
-        
-        /// <summary>
-        /// Set Directory field</summary>
-        /// <param name="directory_">field value to be set</param>
-        public void SetDirectory(byte[] directory_)
-        {
-            SetFieldValue(2, 0, directory_, Fit.SubfieldIndexMainField);
-        }
-        
-        ///<summary>
-        /// Retrieves the MaxCount field</summary>
-        /// <returns>Returns nullable ushort representing the MaxCount field</returns>
-        public ushort? GetMaxCount()
-        {
-            Object val = GetFieldValue(3, 0, Fit.SubfieldIndexMainField);
-            if(val == null)
-            {
-                return null;
-            }
+		///<summary>
+		/// Retrieves the Directory field</summary>
+		/// <returns>Returns String representing the Directory field</returns>
+		public String GetDirectoryAsString()
+		{
+			byte[] data = (byte[])GetFieldValue(2, 0, Fit.SubfieldIndexMainField);
+			return data != null ? Encoding.UTF8.GetString(data, 0, data.Length - 1) : null;
+		}
 
-            return (Convert.ToUInt16(val));
-            
-        }
+		///<summary>
+		/// Set Directory field</summary>
+		/// <param name="directory_"> field value to be set</param>
+		public void SetDirectory(String directory_)
+		{
+			byte[] data = Encoding.UTF8.GetBytes(directory_);
+			byte[] zdata = new byte[data.Length + 1];
+			data.CopyTo(zdata, 0);
+			SetFieldValue(2, 0, zdata, Fit.SubfieldIndexMainField);
+		}
 
-        /// <summary>
-        /// Set MaxCount field</summary>
-        /// <param name="maxCount_">Nullable field value to be set</param>
-        public void SetMaxCount(ushort? maxCount_)
-        {
-            SetFieldValue(3, 0, maxCount_, Fit.SubfieldIndexMainField);
-        }
-        
-        ///<summary>
-        /// Retrieves the MaxSize field
-        /// Units: bytes</summary>
-        /// <returns>Returns nullable uint representing the MaxSize field</returns>
-        public uint? GetMaxSize()
-        {
-            Object val = GetFieldValue(4, 0, Fit.SubfieldIndexMainField);
-            if(val == null)
-            {
-                return null;
-            }
+		///<summary>
+		/// Retrieves the MaxCount field</summary>
+		/// <returns>Returns nullable ushort representing the MaxCount field</returns>
+		public ushort? MaxCount
+		{
+			get
+			{
+				Object val = GetFieldValue(3, 0, Fit.SubfieldIndexMainField);
+				if (val == null)
+				{
+					return null;
+				}
 
-            return (Convert.ToUInt32(val));
-            
-        }
+				return (Convert.ToUInt16(val));
 
-        /// <summary>
-        /// Set MaxSize field
-        /// Units: bytes</summary>
-        /// <param name="maxSize_">Nullable field value to be set</param>
-        public void SetMaxSize(uint? maxSize_)
-        {
-            SetFieldValue(4, 0, maxSize_, Fit.SubfieldIndexMainField);
-        }
-        
-        #endregion // Methods
-    } // Class
+			}
+			set
+			{
+				SetFieldValue(3, 0, value, Fit.SubfieldIndexMainField);
+			}
+		}
+
+		///<summary>
+		/// Retrieves the MaxSize field
+		/// Units: bytes</summary>
+		/// <returns>Returns nullable uint representing the MaxSize field</returns>
+		public uint? MaxSize
+		{
+			get
+			{
+				Object val = GetFieldValue(4, 0, Fit.SubfieldIndexMainField);
+				if (val == null)
+				{
+					return null;
+				}
+
+				return (Convert.ToUInt32(val));
+
+			}
+			set
+			{
+				SetFieldValue(4, 0, value, Fit.SubfieldIndexMainField);
+			}
+		}
+
+		#endregion // Methods
+	} // Class
 } // namespace

--- a/Dynastream/Fit/Profile/Mesgs/FileCreatorMesg.cs
+++ b/Dynastream/Fit/Profile/Mesgs/FileCreatorMesg.cs
@@ -21,81 +21,79 @@ using System.Linq;
 
 namespace Dynastream.Fit
 {
-    /// <summary>
-    /// Implements the FileCreator profile message.
-    /// </summary>
-    public class FileCreatorMesg : Mesg
-    {
-        #region Fields
-        #endregion
+	/// <summary>
+	/// Implements the FileCreator profile message.
+	/// </summary>
+	public class FileCreatorMesg : Mesg
+	{
+		#region Fields
+		#endregion
 
-        /// <summary>
-        /// Field Numbers for <see cref="FileCreatorMesg"/>
-        /// </summary>
-        public sealed class FieldDefNum
-        {
-            public const byte SoftwareVersion = 0;
-            public const byte HardwareVersion = 1;
-            public const byte Invalid = Fit.FieldNumInvalid;
-        }
+		/// <summary>
+		/// Field Numbers for <see cref="FileCreatorMesg"/>
+		/// </summary>
+		public sealed class FieldDefNum
+		{
+			public const byte SoftwareVersion = 0;
+			public const byte HardwareVersion = 1;
+			public const byte Invalid = Fit.FieldNumInvalid;
+		}
 
-        #region Constructors
-        public FileCreatorMesg() : base(Profile.GetMesg(MesgNum.FileCreator))
-        {
-        }
+		#region Constructors
+		public FileCreatorMesg() : base(Profile.GetMesg(MesgNum.FileCreator))
+		{
+		}
 
-        public FileCreatorMesg(Mesg mesg) : base(mesg)
-        {
-        }
-        #endregion // Constructors
+		public FileCreatorMesg(Mesg mesg) : base(mesg)
+		{
+		}
+		#endregion // Constructors
 
-        #region Methods
-        ///<summary>
-        /// Retrieves the SoftwareVersion field</summary>
-        /// <returns>Returns nullable ushort representing the SoftwareVersion field</returns>
-        public ushort? GetSoftwareVersion()
-        {
-            Object val = GetFieldValue(0, 0, Fit.SubfieldIndexMainField);
-            if(val == null)
-            {
-                return null;
-            }
+		#region Methods
+		///<summary>
+		/// Retrieves the SoftwareVersion field</summary>
+		/// <returns>Returns nullable ushort representing the SoftwareVersion field</returns>
+		public ushort? SoftwareVersion
+		{
+			get
+			{
+				Object val = GetFieldValue(0, 0, Fit.SubfieldIndexMainField);
+				if (val == null)
+				{
+					return null;
+				}
 
-            return (Convert.ToUInt16(val));
-            
-        }
+				return (Convert.ToUInt16(val));
 
-        /// <summary>
-        /// Set SoftwareVersion field</summary>
-        /// <param name="softwareVersion_">Nullable field value to be set</param>
-        public void SetSoftwareVersion(ushort? softwareVersion_)
-        {
-            SetFieldValue(0, 0, softwareVersion_, Fit.SubfieldIndexMainField);
-        }
-        
-        ///<summary>
-        /// Retrieves the HardwareVersion field</summary>
-        /// <returns>Returns nullable byte representing the HardwareVersion field</returns>
-        public byte? GetHardwareVersion()
-        {
-            Object val = GetFieldValue(1, 0, Fit.SubfieldIndexMainField);
-            if(val == null)
-            {
-                return null;
-            }
+			}
+			set
+			{
+				SetFieldValue(0, 0, value, Fit.SubfieldIndexMainField);
+			}
+		}
 
-            return (Convert.ToByte(val));
-            
-        }
+		///<summary>
+		/// Retrieves the HardwareVersion field</summary>
+		/// <returns>Returns nullable byte representing the HardwareVersion field</returns>
+		public byte? HardwareVersion
+		{
+			get
+			{
+				Object val = GetFieldValue(1, 0, Fit.SubfieldIndexMainField);
+				if (val == null)
+				{
+					return null;
+				}
 
-        /// <summary>
-        /// Set HardwareVersion field</summary>
-        /// <param name="hardwareVersion_">Nullable field value to be set</param>
-        public void SetHardwareVersion(byte? hardwareVersion_)
-        {
-            SetFieldValue(1, 0, hardwareVersion_, Fit.SubfieldIndexMainField);
-        }
-        
-        #endregion // Methods
-    } // Class
+				return (Convert.ToByte(val));
+
+			}
+			set
+			{
+				SetFieldValue(1, 0, value, Fit.SubfieldIndexMainField);
+			}
+		}
+
+		#endregion // Methods
+	} // Class
 } // namespace

--- a/Dynastream/Fit/Profile/Mesgs/FileIdMesg.cs
+++ b/Dynastream/Fit/Profile/Mesgs/FileIdMesg.cs
@@ -21,275 +21,260 @@ using System.Linq;
 
 namespace Dynastream.Fit
 {
-    /// <summary>
-    /// Implements the FileId profile message.
-    /// </summary>
-    public class FileIdMesg : Mesg
-    {
-        #region Fields
-        static class ProductSubfield
-        {
-            public static ushort FaveroProduct = 0;
-            public static ushort GarminProduct = 1;
-            public static ushort Subfields = 2;
-            public static ushort Active = Fit.SubfieldIndexActiveSubfield;
-            public static ushort MainField = Fit.SubfieldIndexMainField;
-        }
-        #endregion
+	/// <summary>
+	/// Implements the FileId profile message.
+	/// </summary>
+	public class FileIdMesg : Mesg
+	{
+		#region Fields
+		static class ProductSubfield
+		{
+			public static ushort FaveroProduct = 0;
+			public static ushort GarminProduct = 1;
+			public static ushort Subfields = 2;
+			public static ushort Active = Fit.SubfieldIndexActiveSubfield;
+			public static ushort MainField = Fit.SubfieldIndexMainField;
+		}
+		#endregion
 
-        /// <summary>
-        /// Field Numbers for <see cref="FileIdMesg"/>
-        /// </summary>
-        public sealed class FieldDefNum
-        {
-            public const byte Type = 0;
-            public const byte Manufacturer = 1;
-            public const byte Product = 2;
-            public const byte SerialNumber = 3;
-            public const byte TimeCreated = 4;
-            public const byte Number = 5;
-            public const byte ProductName = 8;
-            public const byte Invalid = Fit.FieldNumInvalid;
-        }
+		/// <summary>
+		/// Field Numbers for <see cref="FileIdMesg"/>
+		/// </summary>
+		public sealed class FieldDefNum
+		{
+			public const byte Type = 0;
+			public const byte Manufacturer = 1;
+			public const byte Product = 2;
+			public const byte SerialNumber = 3;
+			public const byte TimeCreated = 4;
+			public const byte Number = 5;
+			public const byte ProductName = 8;
+			public const byte Invalid = Fit.FieldNumInvalid;
+		}
 
-        #region Constructors
-        public FileIdMesg() : base(Profile.GetMesg(MesgNum.FileId))
-        {
-        }
+		#region Constructors
+		public FileIdMesg() : base(Profile.GetMesg(MesgNum.FileId))
+		{
+		}
 
-        public FileIdMesg(Mesg mesg) : base(mesg)
-        {
-        }
-        #endregion // Constructors
+		public FileIdMesg(Mesg mesg) : base(mesg)
+		{
+		}
+		#endregion // Constructors
 
-        #region Methods
-        ///<summary>
-        /// Retrieves the Type field</summary>
-        /// <returns>Returns nullable File enum representing the Type field</returns>
-        new public File? GetType()
-        {
-            object obj = GetFieldValue(0, 0, Fit.SubfieldIndexMainField);
-            File? value = obj == null ? (File?)null : (File)obj;
-            return value;
-        }
+		#region Methods
+		///<summary>
+		/// Retrieves the Type field</summary>
+		/// <returns>Returns nullable File enum representing the Type field</returns>
+		public File? Type
+		{
+			get
+			{
+				object obj = GetFieldValue(0, 0, Fit.SubfieldIndexMainField);
+				File? value = obj == null ? (File?)null : (File)obj;
+				return value;
+			}
+			set
+			{
+				SetFieldValue(0, 0, value, Fit.SubfieldIndexMainField);
+			}
+		}
 
-        /// <summary>
-        /// Set Type field</summary>
-        /// <param name="type_">Nullable field value to be set</param>
-        public void SetType(File? type_)
-        {
-            SetFieldValue(0, 0, type_, Fit.SubfieldIndexMainField);
-        }
-        
-        ///<summary>
-        /// Retrieves the Manufacturer field</summary>
-        /// <returns>Returns nullable ushort representing the Manufacturer field</returns>
-        public ushort? GetManufacturer()
-        {
-            Object val = GetFieldValue(1, 0, Fit.SubfieldIndexMainField);
-            if(val == null)
-            {
-                return null;
-            }
+		///<summary>
+		/// Retrieves the Manufacturer field</summary>
+		/// <returns>Returns nullable ushort representing the Manufacturer field</returns>
+		public ushort? Manufacturer
+		{
+			get
+			{
+				Object val = GetFieldValue(1, 0, Fit.SubfieldIndexMainField);
+				if (val == null)
+				{
+					return null;
+				}
 
-            return (Convert.ToUInt16(val));
-            
-        }
+				return (Convert.ToUInt16(val));
 
-        /// <summary>
-        /// Set Manufacturer field</summary>
-        /// <param name="manufacturer_">Nullable field value to be set</param>
-        public void SetManufacturer(ushort? manufacturer_)
-        {
-            SetFieldValue(1, 0, manufacturer_, Fit.SubfieldIndexMainField);
-        }
-        
-        ///<summary>
-        /// Retrieves the Product field</summary>
-        /// <returns>Returns nullable ushort representing the Product field</returns>
-        public ushort? GetProduct()
-        {
-            Object val = GetFieldValue(2, 0, Fit.SubfieldIndexMainField);
-            if(val == null)
-            {
-                return null;
-            }
+			}
+			set
+			{
+				SetFieldValue(1, 0, value, Fit.SubfieldIndexMainField);
+			}
+		}
 
-            return (Convert.ToUInt16(val));
-            
-        }
+		///<summary>
+		/// Retrieves the Product field</summary>
+		/// <returns>Returns nullable ushort representing the Product field</returns>
+		public ushort? Product
+		{
+			get
+			{
+				Object val = GetFieldValue(2, 0, Fit.SubfieldIndexMainField);
+				if (val == null)
+				{
+					return null;
+				}
 
-        /// <summary>
-        /// Set Product field</summary>
-        /// <param name="product_">Nullable field value to be set</param>
-        public void SetProduct(ushort? product_)
-        {
-            SetFieldValue(2, 0, product_, Fit.SubfieldIndexMainField);
-        }
-        
+				return (Convert.ToUInt16(val));
 
-        /// <summary>
-        /// Retrieves the FaveroProduct subfield</summary>
-        /// <returns>Nullable ushort representing the FaveroProduct subfield</returns>
-        public ushort? GetFaveroProduct()
-        {
-            Object val = GetFieldValue(2, 0, ProductSubfield.FaveroProduct);
-            if(val == null)
-            {
-                return null;
-            }
+			}
+			set
+			{
+				SetFieldValue(2, 0, value, Fit.SubfieldIndexMainField);
+			}
+		}
 
-            return (Convert.ToUInt16(val));
-            
-        }
 
-        /// <summary>
-        ///
-        /// Set FaveroProduct subfield</summary>
-        /// <param name="faveroProduct">Subfield value to be set</param>
-        public void SetFaveroProduct(ushort? faveroProduct)
-        {
-            SetFieldValue(2, 0, faveroProduct, ProductSubfield.FaveroProduct);
-        }
+		/// <summary>
+		/// Retrieves the FaveroProduct subfield</summary>
+		/// <returns>Nullable ushort representing the FaveroProduct subfield</returns>
+		public ushort? FaveroProduct
+		{
+			get
+			{
+				Object val = GetFieldValue(2, 0, ProductSubfield.FaveroProduct);
+				if (val == null)
+				{
+					return null;
+				}
 
-        /// <summary>
-        /// Retrieves the GarminProduct subfield</summary>
-        /// <returns>Nullable ushort representing the GarminProduct subfield</returns>
-        public ushort? GetGarminProduct()
-        {
-            Object val = GetFieldValue(2, 0, ProductSubfield.GarminProduct);
-            if(val == null)
-            {
-                return null;
-            }
+				return (Convert.ToUInt16(val));
 
-            return (Convert.ToUInt16(val));
-            
-        }
+			}
+			set
+			{
+				SetFieldValue(2, 0, value, ProductSubfield.FaveroProduct);
+			}
+		}
 
-        /// <summary>
-        ///
-        /// Set GarminProduct subfield</summary>
-        /// <param name="garminProduct">Subfield value to be set</param>
-        public void SetGarminProduct(ushort? garminProduct)
-        {
-            SetFieldValue(2, 0, garminProduct, ProductSubfield.GarminProduct);
-        }
-        ///<summary>
-        /// Retrieves the SerialNumber field</summary>
-        /// <returns>Returns nullable uint representing the SerialNumber field</returns>
-        public uint? GetSerialNumber()
-        {
-            Object val = GetFieldValue(3, 0, Fit.SubfieldIndexMainField);
-            if(val == null)
-            {
-                return null;
-            }
+		/// <summary>
+		/// Retrieves the GarminProduct subfield</summary>
+		/// <returns>Nullable ushort representing the GarminProduct subfield</returns>
+		public ushort? GarminProduct
+		{
+			get
+			{
+				Object val = GetFieldValue(2, 0, ProductSubfield.GarminProduct);
+				if (val == null)
+				{
+					return null;
+				}
 
-            return (Convert.ToUInt32(val));
-            
-        }
+				return (Convert.ToUInt16(val));
 
-        /// <summary>
-        /// Set SerialNumber field</summary>
-        /// <param name="serialNumber_">Nullable field value to be set</param>
-        public void SetSerialNumber(uint? serialNumber_)
-        {
-            SetFieldValue(3, 0, serialNumber_, Fit.SubfieldIndexMainField);
-        }
-        
-        ///<summary>
-        /// Retrieves the TimeCreated field
-        /// Comment: Only set for files that are can be created/erased.</summary>
-        /// <returns>Returns DateTime representing the TimeCreated field</returns>
-        public DateTime GetTimeCreated()
-        {
-            Object val = GetFieldValue(4, 0, Fit.SubfieldIndexMainField);
-            if(val == null)
-            {
-                return null;
-            }
+			}
+			set
+			{
+				SetFieldValue(2, 0, value, ProductSubfield.GarminProduct);
+			}
+		}
+		///<summary>
+		/// Retrieves the SerialNumber field</summary>
+		/// <returns>Returns nullable uint representing the SerialNumber field</returns>
+		public uint? SerialNumber
+		{
+			get
+			{
+				Object val = GetFieldValue(3, 0, Fit.SubfieldIndexMainField);
+				if (val == null)
+				{
+					return null;
+				}
 
-            return TimestampToDateTime(Convert.ToUInt32(val));
-            
-        }
+				return (Convert.ToUInt32(val));
 
-        /// <summary>
-        /// Set TimeCreated field
-        /// Comment: Only set for files that are can be created/erased.</summary>
-        /// <param name="timeCreated_">Nullable field value to be set</param>
-        public void SetTimeCreated(DateTime timeCreated_)
-        {
-            SetFieldValue(4, 0, timeCreated_.GetTimeStamp(), Fit.SubfieldIndexMainField);
-        }
-        
-        ///<summary>
-        /// Retrieves the Number field
-        /// Comment: Only set for files that are not created/erased.</summary>
-        /// <returns>Returns nullable ushort representing the Number field</returns>
-        public ushort? GetNumber()
-        {
-            Object val = GetFieldValue(5, 0, Fit.SubfieldIndexMainField);
-            if(val == null)
-            {
-                return null;
-            }
+			}
+			set
+			{
+				SetFieldValue(3, 0, value, Fit.SubfieldIndexMainField);
+			}
+		}
 
-            return (Convert.ToUInt16(val));
-            
-        }
+		///<summary>
+		/// Retrieves the TimeCreated field
+		/// Comment: Only set for files that are can be created/erased.</summary>
+		/// <returns>Returns DateTime representing the TimeCreated field</returns>
+		public DateTime TimeCreated
+		{
+			get
+			{
+				Object val = GetFieldValue(4, 0, Fit.SubfieldIndexMainField);
+				if (val == null)
+				{
+					return null;
+				}
 
-        /// <summary>
-        /// Set Number field
-        /// Comment: Only set for files that are not created/erased.</summary>
-        /// <param name="number_">Nullable field value to be set</param>
-        public void SetNumber(ushort? number_)
-        {
-            SetFieldValue(5, 0, number_, Fit.SubfieldIndexMainField);
-        }
-        
-        ///<summary>
-        /// Retrieves the ProductName field
-        /// Comment: Optional free form string to indicate the devices name or model</summary>
-        /// <returns>Returns byte[] representing the ProductName field</returns>
-        public byte[] GetProductName()
-        {
-            byte[] data = (byte[])GetFieldValue(8, 0, Fit.SubfieldIndexMainField);
-            return data.Take(data.Length - 1).ToArray();
-        }
+				return TimestampToDateTime(Convert.ToUInt32(val));
 
-        ///<summary>
-        /// Retrieves the ProductName field
-        /// Comment: Optional free form string to indicate the devices name or model</summary>
-        /// <returns>Returns String representing the ProductName field</returns>
-        public String GetProductNameAsString()
-        {
-            byte[] data = (byte[])GetFieldValue(8, 0, Fit.SubfieldIndexMainField);
-            return data != null ? Encoding.UTF8.GetString(data, 0, data.Length - 1) : null;
-        }
+			}
+			set
+			{
+				SetFieldValue(4, 0, value.GetTimeStamp(), Fit.SubfieldIndexMainField);
+			}
+		}
 
-        ///<summary>
-        /// Set ProductName field
-        /// Comment: Optional free form string to indicate the devices name or model</summary>
-        /// <param name="productName_"> field value to be set</param>
-        public void SetProductName(String productName_)
-        {
-            byte[] data = Encoding.UTF8.GetBytes(productName_);
-            byte[] zdata = new byte[data.Length + 1];
-            data.CopyTo(zdata, 0);
-            SetFieldValue(8, 0, zdata, Fit.SubfieldIndexMainField);
-        }
+		///<summary>
+		/// Retrieves the Number field
+		/// Comment: Only set for files that are not created/erased.</summary>
+		/// <returns>Returns nullable ushort representing the Number field</returns>
+		public ushort? Number
+		{
+			get
+			{
+				Object val = GetFieldValue(5, 0, Fit.SubfieldIndexMainField);
+				if (val == null)
+				{
+					return null;
+				}
 
-        
-        /// <summary>
-        /// Set ProductName field
-        /// Comment: Optional free form string to indicate the devices name or model</summary>
-        /// <param name="productName_">field value to be set</param>
-        public void SetProductName(byte[] productName_)
-        {
-            SetFieldValue(8, 0, productName_, Fit.SubfieldIndexMainField);
-        }
-        
-        #endregion // Methods
-    } // Class
+				return (Convert.ToUInt16(val));
+
+			}
+			set
+			{
+				SetFieldValue(5, 0, value, Fit.SubfieldIndexMainField);
+			}
+		}
+
+		///<summary>
+		/// Retrieves the ProductName field
+		/// Comment: Optional free form string to indicate the devices name or model</summary>
+		/// <returns>Returns byte[] representing the ProductName field</returns>
+		public byte[] ProductName
+		{
+			get
+			{
+				byte[] data = (byte[])GetFieldValue(8, 0, Fit.SubfieldIndexMainField);
+				return data.Take(data.Length - 1).ToArray();
+			}
+			set
+			{
+				SetFieldValue(8, 0, value, Fit.SubfieldIndexMainField);
+			}
+		}
+
+		///<summary>
+		/// Retrieves the ProductName field
+		/// Comment: Optional free form string to indicate the devices name or model</summary>
+		/// <returns>Returns String representing the ProductName field</returns>
+		public String GetProductNameAsString()
+		{
+			byte[] data = (byte[])GetFieldValue(8, 0, Fit.SubfieldIndexMainField);
+			return data != null ? Encoding.UTF8.GetString(data, 0, data.Length - 1) : null;
+		}
+
+		///<summary>
+		/// Set ProductName field
+		/// Comment: Optional free form string to indicate the devices name or model</summary>
+		/// <param name="productName_"> field value to be set</param>
+		public void SetProductName(String productName_)
+		{
+			byte[] data = Encoding.UTF8.GetBytes(productName_);
+			byte[] zdata = new byte[data.Length + 1];
+			data.CopyTo(zdata, 0);
+			SetFieldValue(8, 0, zdata, Fit.SubfieldIndexMainField);
+		}
+
+		#endregion // Methods
+	} // Class
 } // namespace

--- a/Dynastream/Fit/Profile/Mesgs/GoalMesg.cs
+++ b/Dynastream/Fit/Profile/Mesgs/GoalMesg.cs
@@ -21,310 +21,297 @@ using System.Linq;
 
 namespace Dynastream.Fit
 {
-    /// <summary>
-    /// Implements the Goal profile message.
-    /// </summary>
-    public class GoalMesg : Mesg
-    {
-        #region Fields
-        #endregion
+	/// <summary>
+	/// Implements the Goal profile message.
+	/// </summary>
+	public class GoalMesg : Mesg
+	{
+		#region Fields
+		#endregion
 
-        /// <summary>
-        /// Field Numbers for <see cref="GoalMesg"/>
-        /// </summary>
-        public sealed class FieldDefNum
-        {
-            public const byte MessageIndex = 254;
-            public const byte Sport = 0;
-            public const byte SubSport = 1;
-            public const byte StartDate = 2;
-            public const byte EndDate = 3;
-            public const byte Type = 4;
-            public const byte Value = 5;
-            public const byte Repeat = 6;
-            public const byte TargetValue = 7;
-            public const byte Recurrence = 8;
-            public const byte RecurrenceValue = 9;
-            public const byte Enabled = 10;
-            public const byte Source = 11;
-            public const byte Invalid = Fit.FieldNumInvalid;
-        }
+		/// <summary>
+		/// Field Numbers for <see cref="GoalMesg"/>
+		/// </summary>
+		public sealed class FieldDefNum
+		{
+			public const byte MessageIndex = 254;
+			public const byte Sport = 0;
+			public const byte SubSport = 1;
+			public const byte StartDate = 2;
+			public const byte EndDate = 3;
+			public const byte Type = 4;
+			public const byte Value = 5;
+			public const byte Repeat = 6;
+			public const byte TargetValue = 7;
+			public const byte Recurrence = 8;
+			public const byte RecurrenceValue = 9;
+			public const byte Enabled = 10;
+			public const byte Source = 11;
+			public const byte Invalid = Fit.FieldNumInvalid;
+		}
 
-        #region Constructors
-        public GoalMesg() : base(Profile.GetMesg(MesgNum.Goal))
-        {
-        }
+		#region Constructors
+		public GoalMesg() : base(Profile.GetMesg(MesgNum.Goal))
+		{
+		}
 
-        public GoalMesg(Mesg mesg) : base(mesg)
-        {
-        }
-        #endregion // Constructors
+		public GoalMesg(Mesg mesg) : base(mesg)
+		{
+		}
+		#endregion // Constructors
 
-        #region Methods
-        ///<summary>
-        /// Retrieves the MessageIndex field</summary>
-        /// <returns>Returns nullable ushort representing the MessageIndex field</returns>
-        public ushort? GetMessageIndex()
-        {
-            Object val = GetFieldValue(254, 0, Fit.SubfieldIndexMainField);
-            if(val == null)
-            {
-                return null;
-            }
+		#region Methods
+		///<summary>
+		/// Retrieves the MessageIndex field</summary>
+		/// <returns>Returns nullable ushort representing the MessageIndex field</returns>
+		public ushort? MessageIndex
+		{
+			get
+			{
+				Object val = GetFieldValue(254, 0, Fit.SubfieldIndexMainField);
+				if (val == null)
+				{
+					return null;
+				}
 
-            return (Convert.ToUInt16(val));
-            
-        }
+				return (Convert.ToUInt16(val));
 
-        /// <summary>
-        /// Set MessageIndex field</summary>
-        /// <param name="messageIndex_">Nullable field value to be set</param>
-        public void SetMessageIndex(ushort? messageIndex_)
-        {
-            SetFieldValue(254, 0, messageIndex_, Fit.SubfieldIndexMainField);
-        }
-        
-        ///<summary>
-        /// Retrieves the Sport field</summary>
-        /// <returns>Returns nullable Sport enum representing the Sport field</returns>
-        public Sport? GetSport()
-        {
-            object obj = GetFieldValue(0, 0, Fit.SubfieldIndexMainField);
-            Sport? value = obj == null ? (Sport?)null : (Sport)obj;
-            return value;
-        }
+			}
+			set
+			{
+				SetFieldValue(254, 0, value, Fit.SubfieldIndexMainField);
+			}
+		}
 
-        /// <summary>
-        /// Set Sport field</summary>
-        /// <param name="sport_">Nullable field value to be set</param>
-        public void SetSport(Sport? sport_)
-        {
-            SetFieldValue(0, 0, sport_, Fit.SubfieldIndexMainField);
-        }
-        
-        ///<summary>
-        /// Retrieves the SubSport field</summary>
-        /// <returns>Returns nullable SubSport enum representing the SubSport field</returns>
-        public SubSport? GetSubSport()
-        {
-            object obj = GetFieldValue(1, 0, Fit.SubfieldIndexMainField);
-            SubSport? value = obj == null ? (SubSport?)null : (SubSport)obj;
-            return value;
-        }
+		///<summary>
+		/// Retrieves the Sport field</summary>
+		/// <returns>Returns nullable Sport enum representing the Sport field</returns>
+		public Sport? Sport
+		{
+			get
+			{
+				object obj = GetFieldValue(0, 0, Fit.SubfieldIndexMainField);
+				Sport? value = obj == null ? (Sport?)null : (Sport)obj;
+				return value;
+			}
+			set
+			{
+				SetFieldValue(0, 0, value, Fit.SubfieldIndexMainField);
+			}
+		}
 
-        /// <summary>
-        /// Set SubSport field</summary>
-        /// <param name="subSport_">Nullable field value to be set</param>
-        public void SetSubSport(SubSport? subSport_)
-        {
-            SetFieldValue(1, 0, subSport_, Fit.SubfieldIndexMainField);
-        }
-        
-        ///<summary>
-        /// Retrieves the StartDate field</summary>
-        /// <returns>Returns DateTime representing the StartDate field</returns>
-        public DateTime GetStartDate()
-        {
-            Object val = GetFieldValue(2, 0, Fit.SubfieldIndexMainField);
-            if(val == null)
-            {
-                return null;
-            }
+		///<summary>
+		/// Retrieves the SubSport field</summary>
+		/// <returns>Returns nullable SubSport enum representing the SubSport field</returns>
+		public SubSport? SubSport
+		{
+			get
+			{
+				object obj = GetFieldValue(1, 0, Fit.SubfieldIndexMainField);
+				SubSport? value = obj == null ? (SubSport?)null : (SubSport)obj;
+				return value;
+			}
+			set
+			{
+				SetFieldValue(1, 0, value, Fit.SubfieldIndexMainField);
+			}
+		}
 
-            return TimestampToDateTime(Convert.ToUInt32(val));
-            
-        }
+		///<summary>
+		/// Retrieves the StartDate field</summary>
+		/// <returns>Returns DateTime representing the StartDate field</returns>
+		public DateTime StartDate
+		{
+			get
+			{
+				Object val = GetFieldValue(2, 0, Fit.SubfieldIndexMainField);
+				if (val == null)
+				{
+					return null;
+				}
 
-        /// <summary>
-        /// Set StartDate field</summary>
-        /// <param name="startDate_">Nullable field value to be set</param>
-        public void SetStartDate(DateTime startDate_)
-        {
-            SetFieldValue(2, 0, startDate_.GetTimeStamp(), Fit.SubfieldIndexMainField);
-        }
-        
-        ///<summary>
-        /// Retrieves the EndDate field</summary>
-        /// <returns>Returns DateTime representing the EndDate field</returns>
-        public DateTime GetEndDate()
-        {
-            Object val = GetFieldValue(3, 0, Fit.SubfieldIndexMainField);
-            if(val == null)
-            {
-                return null;
-            }
+				return TimestampToDateTime(Convert.ToUInt32(val));
 
-            return TimestampToDateTime(Convert.ToUInt32(val));
-            
-        }
+			}
+			set
+			{
+				SetFieldValue(2, 0, value.GetTimeStamp(), Fit.SubfieldIndexMainField);
+			}
+		}
 
-        /// <summary>
-        /// Set EndDate field</summary>
-        /// <param name="endDate_">Nullable field value to be set</param>
-        public void SetEndDate(DateTime endDate_)
-        {
-            SetFieldValue(3, 0, endDate_.GetTimeStamp(), Fit.SubfieldIndexMainField);
-        }
-        
-        ///<summary>
-        /// Retrieves the Type field</summary>
-        /// <returns>Returns nullable Goal enum representing the Type field</returns>
-        new public Goal? GetType()
-        {
-            object obj = GetFieldValue(4, 0, Fit.SubfieldIndexMainField);
-            Goal? value = obj == null ? (Goal?)null : (Goal)obj;
-            return value;
-        }
+		///<summary>
+		/// Retrieves the EndDate field</summary>
+		/// <returns>Returns DateTime representing the EndDate field</returns>
+		public DateTime EndDate
+		{
+			get
+			{
+				Object val = GetFieldValue(3, 0, Fit.SubfieldIndexMainField);
+				if (val == null)
+				{
+					return null;
+				}
 
-        /// <summary>
-        /// Set Type field</summary>
-        /// <param name="type_">Nullable field value to be set</param>
-        public void SetType(Goal? type_)
-        {
-            SetFieldValue(4, 0, type_, Fit.SubfieldIndexMainField);
-        }
-        
-        ///<summary>
-        /// Retrieves the Value field</summary>
-        /// <returns>Returns nullable uint representing the Value field</returns>
-        public uint? GetValue()
-        {
-            Object val = GetFieldValue(5, 0, Fit.SubfieldIndexMainField);
-            if(val == null)
-            {
-                return null;
-            }
+				return TimestampToDateTime(Convert.ToUInt32(val));
 
-            return (Convert.ToUInt32(val));
-            
-        }
+			}
+			set
+			{
+				SetFieldValue(3, 0, value.GetTimeStamp(), Fit.SubfieldIndexMainField);
+			}
+		}
 
-        /// <summary>
-        /// Set Value field</summary>
-        /// <param name="value_">Nullable field value to be set</param>
-        public void SetValue(uint? value_)
-        {
-            SetFieldValue(5, 0, value_, Fit.SubfieldIndexMainField);
-        }
-        
-        ///<summary>
-        /// Retrieves the Repeat field</summary>
-        /// <returns>Returns nullable Bool enum representing the Repeat field</returns>
-        public Bool? GetRepeat()
-        {
-            object obj = GetFieldValue(6, 0, Fit.SubfieldIndexMainField);
-            Bool? value = obj == null ? (Bool?)null : (Bool)obj;
-            return value;
-        }
+		///<summary>
+		/// Retrieves the Type field</summary>
+		/// <returns>Returns nullable Goal enum representing the Type field</returns>
+		public Goal? Type
+		{
+			get
+			{
+				object obj = GetFieldValue(4, 0, Fit.SubfieldIndexMainField);
+				Goal? value = obj == null ? (Goal?)null : (Goal)obj;
+				return value;
+			}
+			set
+			{
+				SetFieldValue(4, 0, value, Fit.SubfieldIndexMainField);
+			}
+		}
 
-        /// <summary>
-        /// Set Repeat field</summary>
-        /// <param name="repeat_">Nullable field value to be set</param>
-        public void SetRepeat(Bool? repeat_)
-        {
-            SetFieldValue(6, 0, repeat_, Fit.SubfieldIndexMainField);
-        }
-        
-        ///<summary>
-        /// Retrieves the TargetValue field</summary>
-        /// <returns>Returns nullable uint representing the TargetValue field</returns>
-        public uint? GetTargetValue()
-        {
-            Object val = GetFieldValue(7, 0, Fit.SubfieldIndexMainField);
-            if(val == null)
-            {
-                return null;
-            }
+		///<summary>
+		/// Retrieves the Value field</summary>
+		/// <returns>Returns nullable uint representing the Value field</returns>
+		public uint? Value
+		{
+			get
+			{
+				Object val = GetFieldValue(5, 0, Fit.SubfieldIndexMainField);
+				if (val == null)
+				{
+					return null;
+				}
 
-            return (Convert.ToUInt32(val));
-            
-        }
+				return (Convert.ToUInt32(val));
 
-        /// <summary>
-        /// Set TargetValue field</summary>
-        /// <param name="targetValue_">Nullable field value to be set</param>
-        public void SetTargetValue(uint? targetValue_)
-        {
-            SetFieldValue(7, 0, targetValue_, Fit.SubfieldIndexMainField);
-        }
-        
-        ///<summary>
-        /// Retrieves the Recurrence field</summary>
-        /// <returns>Returns nullable GoalRecurrence enum representing the Recurrence field</returns>
-        public GoalRecurrence? GetRecurrence()
-        {
-            object obj = GetFieldValue(8, 0, Fit.SubfieldIndexMainField);
-            GoalRecurrence? value = obj == null ? (GoalRecurrence?)null : (GoalRecurrence)obj;
-            return value;
-        }
+			}
+			set
+			{
+				SetFieldValue(5, 0, value, Fit.SubfieldIndexMainField);
+			}
+		}
 
-        /// <summary>
-        /// Set Recurrence field</summary>
-        /// <param name="recurrence_">Nullable field value to be set</param>
-        public void SetRecurrence(GoalRecurrence? recurrence_)
-        {
-            SetFieldValue(8, 0, recurrence_, Fit.SubfieldIndexMainField);
-        }
-        
-        ///<summary>
-        /// Retrieves the RecurrenceValue field</summary>
-        /// <returns>Returns nullable ushort representing the RecurrenceValue field</returns>
-        public ushort? GetRecurrenceValue()
-        {
-            Object val = GetFieldValue(9, 0, Fit.SubfieldIndexMainField);
-            if(val == null)
-            {
-                return null;
-            }
+		///<summary>
+		/// Retrieves the Repeat field</summary>
+		/// <returns>Returns nullable Bool enum representing the Repeat field</returns>
+		public Bool? Repeat
+		{
+			get
+			{
+				object obj = GetFieldValue(6, 0, Fit.SubfieldIndexMainField);
+				Bool? value = obj == null ? (Bool?)null : (Bool)obj;
+				return value;
+			}
+			set
+			{
+				SetFieldValue(6, 0, value, Fit.SubfieldIndexMainField);
+			}
+		}
 
-            return (Convert.ToUInt16(val));
-            
-        }
+		///<summary>
+		/// Retrieves the TargetValue field</summary>
+		/// <returns>Returns nullable uint representing the TargetValue field</returns>
+		public uint? TargetValue
+		{
+			get
+			{
+				Object val = GetFieldValue(7, 0, Fit.SubfieldIndexMainField);
+				if (val == null)
+				{
+					return null;
+				}
 
-        /// <summary>
-        /// Set RecurrenceValue field</summary>
-        /// <param name="recurrenceValue_">Nullable field value to be set</param>
-        public void SetRecurrenceValue(ushort? recurrenceValue_)
-        {
-            SetFieldValue(9, 0, recurrenceValue_, Fit.SubfieldIndexMainField);
-        }
-        
-        ///<summary>
-        /// Retrieves the Enabled field</summary>
-        /// <returns>Returns nullable Bool enum representing the Enabled field</returns>
-        public Bool? GetEnabled()
-        {
-            object obj = GetFieldValue(10, 0, Fit.SubfieldIndexMainField);
-            Bool? value = obj == null ? (Bool?)null : (Bool)obj;
-            return value;
-        }
+				return (Convert.ToUInt32(val));
 
-        /// <summary>
-        /// Set Enabled field</summary>
-        /// <param name="enabled_">Nullable field value to be set</param>
-        public void SetEnabled(Bool? enabled_)
-        {
-            SetFieldValue(10, 0, enabled_, Fit.SubfieldIndexMainField);
-        }
-        
-        ///<summary>
-        /// Retrieves the Source field</summary>
-        /// <returns>Returns nullable GoalSource enum representing the Source field</returns>
-        public GoalSource? GetSource()
-        {
-            object obj = GetFieldValue(11, 0, Fit.SubfieldIndexMainField);
-            GoalSource? value = obj == null ? (GoalSource?)null : (GoalSource)obj;
-            return value;
-        }
+			}
+			set
+			{
+				SetFieldValue(7, 0, value, Fit.SubfieldIndexMainField);
+			}
+		}
 
-        /// <summary>
-        /// Set Source field</summary>
-        /// <param name="source_">Nullable field value to be set</param>
-        public void SetSource(GoalSource? source_)
-        {
-            SetFieldValue(11, 0, source_, Fit.SubfieldIndexMainField);
-        }
-        
-        #endregion // Methods
-    } // Class
+		///<summary>
+		/// Retrieves the Recurrence field</summary>
+		/// <returns>Returns nullable GoalRecurrence enum representing the Recurrence field</returns>
+		public GoalRecurrence? Recurrence
+		{
+			get
+			{
+				object obj = GetFieldValue(8, 0, Fit.SubfieldIndexMainField);
+				GoalRecurrence? value = obj == null ? (GoalRecurrence?)null : (GoalRecurrence)obj;
+				return value;
+			}
+			set
+			{
+				SetFieldValue(8, 0, value, Fit.SubfieldIndexMainField);
+			}
+		}
+
+		///<summary>
+		/// Retrieves the RecurrenceValue field</summary>
+		/// <returns>Returns nullable ushort representing the RecurrenceValue field</returns>
+		public ushort? RecurrenceValue
+		{
+			get
+			{
+				Object val = GetFieldValue(9, 0, Fit.SubfieldIndexMainField);
+				if (val == null)
+				{
+					return null;
+				}
+
+				return (Convert.ToUInt16(val));
+
+			}
+			set
+			{
+				SetFieldValue(9, 0, value, Fit.SubfieldIndexMainField);
+			}
+		}
+
+		///<summary>
+		/// Retrieves the Enabled field</summary>
+		/// <returns>Returns nullable Bool enum representing the Enabled field</returns>
+		public Bool? Enabled
+		{
+			get
+			{
+				object obj = GetFieldValue(10, 0, Fit.SubfieldIndexMainField);
+				Bool? value = obj == null ? (Bool?)null : (Bool)obj;
+				return value;
+			}
+			set
+			{
+				SetFieldValue(10, 0, value, Fit.SubfieldIndexMainField);
+			}
+		}
+
+		///<summary>
+		/// Retrieves the Source field</summary>
+		/// <returns>Returns nullable GoalSource enum representing the Source field</returns>
+		public GoalSource? Source
+		{
+			get
+			{
+				object obj = GetFieldValue(11, 0, Fit.SubfieldIndexMainField);
+				GoalSource? value = obj == null ? (GoalSource?)null : (GoalSource)obj;
+				return value;
+			}
+			set
+			{
+				SetFieldValue(11, 0, value, Fit.SubfieldIndexMainField);
+			}
+		}
+
+		#endregion // Methods
+	} // Class
 } // namespace

--- a/Dynastream/Fit/Profile/Mesgs/GpsMetadataMesg.cs
+++ b/Dynastream/Fit/Profile/Mesgs/GpsMetadataMesg.cs
@@ -21,287 +21,268 @@ using System.Linq;
 
 namespace Dynastream.Fit
 {
-    /// <summary>
-    /// Implements the GpsMetadata profile message.
-    /// </summary>
-    public class GpsMetadataMesg : Mesg
-    {
-        #region Fields
-        #endregion
+	/// <summary>
+	/// Implements the GpsMetadata profile message.
+	/// </summary>
+	public class GpsMetadataMesg : Mesg
+	{
+		#region Fields
+		#endregion
 
-        /// <summary>
-        /// Field Numbers for <see cref="GpsMetadataMesg"/>
-        /// </summary>
-        public sealed class FieldDefNum
-        {
-            public const byte Timestamp = 253;
-            public const byte TimestampMs = 0;
-            public const byte PositionLat = 1;
-            public const byte PositionLong = 2;
-            public const byte EnhancedAltitude = 3;
-            public const byte EnhancedSpeed = 4;
-            public const byte Heading = 5;
-            public const byte UtcTimestamp = 6;
-            public const byte Velocity = 7;
-            public const byte Invalid = Fit.FieldNumInvalid;
-        }
+		/// <summary>
+		/// Field Numbers for <see cref="GpsMetadataMesg"/>
+		/// </summary>
+		public sealed class FieldDefNum
+		{
+			public const byte Timestamp = 253;
+			public const byte TimestampMs = 0;
+			public const byte PositionLat = 1;
+			public const byte PositionLong = 2;
+			public const byte EnhancedAltitude = 3;
+			public const byte EnhancedSpeed = 4;
+			public const byte Heading = 5;
+			public const byte UtcTimestamp = 6;
+			public const byte Velocity = 7;
+			public const byte Invalid = Fit.FieldNumInvalid;
+		}
 
-        #region Constructors
-        public GpsMetadataMesg() : base(Profile.GetMesg(MesgNum.GpsMetadata))
-        {
-        }
+		#region Constructors
+		public GpsMetadataMesg() : base(Profile.GetMesg(MesgNum.GpsMetadata))
+		{
+		}
 
-        public GpsMetadataMesg(Mesg mesg) : base(mesg)
-        {
-        }
-        #endregion // Constructors
+		public GpsMetadataMesg(Mesg mesg) : base(mesg)
+		{
+		}
+		#endregion // Constructors
 
-        #region Methods
-        ///<summary>
-        /// Retrieves the Timestamp field
-        /// Units: s
-        /// Comment: Whole second part of the timestamp.</summary>
-        /// <returns>Returns DateTime representing the Timestamp field</returns>
-        public DateTime GetTimestamp()
-        {
-            Object val = GetFieldValue(253, 0, Fit.SubfieldIndexMainField);
-            if(val == null)
-            {
-                return null;
-            }
+		#region Methods
+		///<summary>
+		/// Retrieves the Timestamp field
+		/// Units: s
+		/// Comment: Whole second part of the timestamp.</summary>
+		/// <returns>Returns DateTime representing the Timestamp field</returns>
+		public DateTime Timestamp
+		{
+			get
+			{
+				Object val = GetFieldValue(253, 0, Fit.SubfieldIndexMainField);
+				if (val == null)
+				{
+					return null;
+				}
 
-            return TimestampToDateTime(Convert.ToUInt32(val));
-            
-        }
+				return TimestampToDateTime(Convert.ToUInt32(val));
 
-        /// <summary>
-        /// Set Timestamp field
-        /// Units: s
-        /// Comment: Whole second part of the timestamp.</summary>
-        /// <param name="timestamp_">Nullable field value to be set</param>
-        public void SetTimestamp(DateTime timestamp_)
-        {
-            SetFieldValue(253, 0, timestamp_.GetTimeStamp(), Fit.SubfieldIndexMainField);
-        }
-        
-        ///<summary>
-        /// Retrieves the TimestampMs field
-        /// Units: ms
-        /// Comment: Millisecond part of the timestamp.</summary>
-        /// <returns>Returns nullable ushort representing the TimestampMs field</returns>
-        public ushort? GetTimestampMs()
-        {
-            Object val = GetFieldValue(0, 0, Fit.SubfieldIndexMainField);
-            if(val == null)
-            {
-                return null;
-            }
+			}
+			set
+			{
+				SetFieldValue(253, 0, value.GetTimeStamp(), Fit.SubfieldIndexMainField);
+			}
+		}
 
-            return (Convert.ToUInt16(val));
-            
-        }
+		///<summary>
+		/// Retrieves the TimestampMs field
+		/// Units: ms
+		/// Comment: Millisecond part of the timestamp.</summary>
+		/// <returns>Returns nullable ushort representing the TimestampMs field</returns>
+		public ushort? TimestampMs
+		{
+			get
+			{
+				Object val = GetFieldValue(0, 0, Fit.SubfieldIndexMainField);
+				if (val == null)
+				{
+					return null;
+				}
 
-        /// <summary>
-        /// Set TimestampMs field
-        /// Units: ms
-        /// Comment: Millisecond part of the timestamp.</summary>
-        /// <param name="timestampMs_">Nullable field value to be set</param>
-        public void SetTimestampMs(ushort? timestampMs_)
-        {
-            SetFieldValue(0, 0, timestampMs_, Fit.SubfieldIndexMainField);
-        }
-        
-        ///<summary>
-        /// Retrieves the PositionLat field
-        /// Units: semicircles</summary>
-        /// <returns>Returns nullable int representing the PositionLat field</returns>
-        public int? GetPositionLat()
-        {
-            Object val = GetFieldValue(1, 0, Fit.SubfieldIndexMainField);
-            if(val == null)
-            {
-                return null;
-            }
+				return (Convert.ToUInt16(val));
 
-            return (Convert.ToInt32(val));
-            
-        }
+			}
+			set
+			{
+				SetFieldValue(0, 0, value, Fit.SubfieldIndexMainField);
+			}
+		}
 
-        /// <summary>
-        /// Set PositionLat field
-        /// Units: semicircles</summary>
-        /// <param name="positionLat_">Nullable field value to be set</param>
-        public void SetPositionLat(int? positionLat_)
-        {
-            SetFieldValue(1, 0, positionLat_, Fit.SubfieldIndexMainField);
-        }
-        
-        ///<summary>
-        /// Retrieves the PositionLong field
-        /// Units: semicircles</summary>
-        /// <returns>Returns nullable int representing the PositionLong field</returns>
-        public int? GetPositionLong()
-        {
-            Object val = GetFieldValue(2, 0, Fit.SubfieldIndexMainField);
-            if(val == null)
-            {
-                return null;
-            }
+		///<summary>
+		/// Retrieves the PositionLat field
+		/// Units: semicircles</summary>
+		/// <returns>Returns nullable int representing the PositionLat field</returns>
+		public int? PositionLat
+		{
+			get
+			{
+				Object val = GetFieldValue(1, 0, Fit.SubfieldIndexMainField);
+				if (val == null)
+				{
+					return null;
+				}
 
-            return (Convert.ToInt32(val));
-            
-        }
+				return (Convert.ToInt32(val));
 
-        /// <summary>
-        /// Set PositionLong field
-        /// Units: semicircles</summary>
-        /// <param name="positionLong_">Nullable field value to be set</param>
-        public void SetPositionLong(int? positionLong_)
-        {
-            SetFieldValue(2, 0, positionLong_, Fit.SubfieldIndexMainField);
-        }
-        
-        ///<summary>
-        /// Retrieves the EnhancedAltitude field
-        /// Units: m</summary>
-        /// <returns>Returns nullable float representing the EnhancedAltitude field</returns>
-        public float? GetEnhancedAltitude()
-        {
-            Object val = GetFieldValue(3, 0, Fit.SubfieldIndexMainField);
-            if(val == null)
-            {
-                return null;
-            }
+			}
+			set
+			{
+				SetFieldValue(1, 0, value, Fit.SubfieldIndexMainField);
+			}
+		}
 
-            return (Convert.ToSingle(val));
-            
-        }
+		///<summary>
+		/// Retrieves the PositionLong field
+		/// Units: semicircles</summary>
+		/// <returns>Returns nullable int representing the PositionLong field</returns>
+		public int? PositionLong
+		{
+			get
+			{
+				Object val = GetFieldValue(2, 0, Fit.SubfieldIndexMainField);
+				if (val == null)
+				{
+					return null;
+				}
 
-        /// <summary>
-        /// Set EnhancedAltitude field
-        /// Units: m</summary>
-        /// <param name="enhancedAltitude_">Nullable field value to be set</param>
-        public void SetEnhancedAltitude(float? enhancedAltitude_)
-        {
-            SetFieldValue(3, 0, enhancedAltitude_, Fit.SubfieldIndexMainField);
-        }
-        
-        ///<summary>
-        /// Retrieves the EnhancedSpeed field
-        /// Units: m/s</summary>
-        /// <returns>Returns nullable float representing the EnhancedSpeed field</returns>
-        public float? GetEnhancedSpeed()
-        {
-            Object val = GetFieldValue(4, 0, Fit.SubfieldIndexMainField);
-            if(val == null)
-            {
-                return null;
-            }
+				return (Convert.ToInt32(val));
 
-            return (Convert.ToSingle(val));
-            
-        }
+			}
+			set
+			{
+				SetFieldValue(2, 0, value, Fit.SubfieldIndexMainField);
+			}
+		}
 
-        /// <summary>
-        /// Set EnhancedSpeed field
-        /// Units: m/s</summary>
-        /// <param name="enhancedSpeed_">Nullable field value to be set</param>
-        public void SetEnhancedSpeed(float? enhancedSpeed_)
-        {
-            SetFieldValue(4, 0, enhancedSpeed_, Fit.SubfieldIndexMainField);
-        }
-        
-        ///<summary>
-        /// Retrieves the Heading field
-        /// Units: degrees</summary>
-        /// <returns>Returns nullable float representing the Heading field</returns>
-        public float? GetHeading()
-        {
-            Object val = GetFieldValue(5, 0, Fit.SubfieldIndexMainField);
-            if(val == null)
-            {
-                return null;
-            }
+		///<summary>
+		/// Retrieves the EnhancedAltitude field
+		/// Units: m</summary>
+		/// <returns>Returns nullable float representing the EnhancedAltitude field</returns>
+		public float? EnhancedAltitude
+		{
+			get
+			{
+				Object val = GetFieldValue(3, 0, Fit.SubfieldIndexMainField);
+				if (val == null)
+				{
+					return null;
+				}
 
-            return (Convert.ToSingle(val));
-            
-        }
+				return (Convert.ToSingle(val));
 
-        /// <summary>
-        /// Set Heading field
-        /// Units: degrees</summary>
-        /// <param name="heading_">Nullable field value to be set</param>
-        public void SetHeading(float? heading_)
-        {
-            SetFieldValue(5, 0, heading_, Fit.SubfieldIndexMainField);
-        }
-        
-        ///<summary>
-        /// Retrieves the UtcTimestamp field
-        /// Units: s
-        /// Comment: Used to correlate UTC to system time if the timestamp of the message is in system time. This UTC time is derived from the GPS data.</summary>
-        /// <returns>Returns DateTime representing the UtcTimestamp field</returns>
-        public DateTime GetUtcTimestamp()
-        {
-            Object val = GetFieldValue(6, 0, Fit.SubfieldIndexMainField);
-            if(val == null)
-            {
-                return null;
-            }
+			}
+			set
+			{
+				SetFieldValue(3, 0, value, Fit.SubfieldIndexMainField);
+			}
+		}
 
-            return TimestampToDateTime(Convert.ToUInt32(val));
-            
-        }
+		///<summary>
+		/// Retrieves the EnhancedSpeed field
+		/// Units: m/s</summary>
+		/// <returns>Returns nullable float representing the EnhancedSpeed field</returns>
+		public float? EnhancedSpeed
+		{
+			get
+			{
+				Object val = GetFieldValue(4, 0, Fit.SubfieldIndexMainField);
+				if (val == null)
+				{
+					return null;
+				}
 
-        /// <summary>
-        /// Set UtcTimestamp field
-        /// Units: s
-        /// Comment: Used to correlate UTC to system time if the timestamp of the message is in system time. This UTC time is derived from the GPS data.</summary>
-        /// <param name="utcTimestamp_">Nullable field value to be set</param>
-        public void SetUtcTimestamp(DateTime utcTimestamp_)
-        {
-            SetFieldValue(6, 0, utcTimestamp_.GetTimeStamp(), Fit.SubfieldIndexMainField);
-        }
-        
-        
-        /// <summary>
-        ///
-        /// </summary>
-        /// <returns>returns number of elements in field Velocity</returns>
-        public int GetNumVelocity()
-        {
-            return GetNumFieldValues(7, Fit.SubfieldIndexMainField);
-        }
+				return (Convert.ToSingle(val));
 
-        ///<summary>
-        /// Retrieves the Velocity field
-        /// Units: m/s
-        /// Comment: velocity[0] is lon velocity. Velocity[1] is lat velocity. Velocity[2] is altitude velocity.</summary>
-        /// <param name="index">0 based index of Velocity element to retrieve</param>
-        /// <returns>Returns nullable float representing the Velocity field</returns>
-        public float? GetVelocity(int index)
-        {
-            Object val = GetFieldValue(7, index, Fit.SubfieldIndexMainField);
-            if(val == null)
-            {
-                return null;
-            }
+			}
+			set
+			{
+				SetFieldValue(4, 0, value, Fit.SubfieldIndexMainField);
+			}
+		}
 
-            return (Convert.ToSingle(val));
-            
-        }
+		///<summary>
+		/// Retrieves the Heading field
+		/// Units: degrees</summary>
+		/// <returns>Returns nullable float representing the Heading field</returns>
+		public float? Heading
+		{
+			get
+			{
+				Object val = GetFieldValue(5, 0, Fit.SubfieldIndexMainField);
+				if (val == null)
+				{
+					return null;
+				}
 
-        /// <summary>
-        /// Set Velocity field
-        /// Units: m/s
-        /// Comment: velocity[0] is lon velocity. Velocity[1] is lat velocity. Velocity[2] is altitude velocity.</summary>
-        /// <param name="index">0 based index of velocity</param>
-        /// <param name="velocity_">Nullable field value to be set</param>
-        public void SetVelocity(int index, float? velocity_)
-        {
-            SetFieldValue(7, index, velocity_, Fit.SubfieldIndexMainField);
-        }
-        
-        #endregion // Methods
-    } // Class
+				return (Convert.ToSingle(val));
+
+			}
+			set
+			{
+				SetFieldValue(5, 0, value, Fit.SubfieldIndexMainField);
+			}
+		}
+
+		///<summary>
+		/// Retrieves the UtcTimestamp field
+		/// Units: s
+		/// Comment: Used to correlate UTC to system time if the timestamp of the message is in system time. This UTC time is derived from the GPS data.</summary>
+		/// <returns>Returns DateTime representing the UtcTimestamp field</returns>
+		public DateTime UtcTimestamp
+		{
+			get
+			{
+				Object val = GetFieldValue(6, 0, Fit.SubfieldIndexMainField);
+				if (val == null)
+				{
+					return null;
+				}
+
+				return TimestampToDateTime(Convert.ToUInt32(val));
+
+			}
+			set
+			{
+				SetFieldValue(6, 0, value.GetTimeStamp(), Fit.SubfieldIndexMainField);
+			}
+		}
+
+
+		/// <summary>
+		///
+		/// </summary>
+		/// <returns>returns number of elements in field Velocity</returns>
+		public int GetNumVelocity()
+		{
+			return GetNumFieldValues(7, Fit.SubfieldIndexMainField);
+		}
+
+		///<summary>
+		/// Retrieves the Velocity field
+		/// Units: m/s
+		/// Comment: velocity[0] is lon velocity. Velocity[1] is lat velocity. Velocity[2] is altitude velocity.</summary>
+		/// <param name="index">0 based index of Velocity element to retrieve</param>
+		/// <returns>Returns nullable float representing the Velocity field</returns>
+		public float? GetVelocity(int index)
+		{
+			Object val = GetFieldValue(7, index, Fit.SubfieldIndexMainField);
+			if (val == null)
+			{
+				return null;
+			}
+
+			return (Convert.ToSingle(val));
+
+		}
+
+		/// <summary>
+		/// Set Velocity field
+		/// Units: m/s
+		/// Comment: velocity[0] is lon velocity. Velocity[1] is lat velocity. Velocity[2] is altitude velocity.</summary>
+		/// <param name="index">0 based index of velocity</param>
+		/// <param name="velocity_">Nullable field value to be set</param>
+		public void SetVelocity(int index, float? velocity_)
+		{
+			SetFieldValue(7, index, velocity_, Fit.SubfieldIndexMainField);
+		}
+
+		#endregion // Methods
+	} // Class
 } // namespace

--- a/Dynastream/Fit/Profile/Mesgs/GyroscopeDataMesg.cs
+++ b/Dynastream/Fit/Profile/Mesgs/GyroscopeDataMesg.cs
@@ -21,369 +21,363 @@ using System.Linq;
 
 namespace Dynastream.Fit
 {
-    /// <summary>
-    /// Implements the GyroscopeData profile message.
-    /// </summary>
-    public class GyroscopeDataMesg : Mesg
-    {
-        #region Fields
-        #endregion
+	/// <summary>
+	/// Implements the GyroscopeData profile message.
+	/// </summary>
+	public class GyroscopeDataMesg : Mesg
+	{
+		#region Fields
+		#endregion
 
-        /// <summary>
-        /// Field Numbers for <see cref="GyroscopeDataMesg"/>
-        /// </summary>
-        public sealed class FieldDefNum
-        {
-            public const byte Timestamp = 253;
-            public const byte TimestampMs = 0;
-            public const byte SampleTimeOffset = 1;
-            public const byte GyroX = 2;
-            public const byte GyroY = 3;
-            public const byte GyroZ = 4;
-            public const byte CalibratedGyroX = 5;
-            public const byte CalibratedGyroY = 6;
-            public const byte CalibratedGyroZ = 7;
-            public const byte Invalid = Fit.FieldNumInvalid;
-        }
+		/// <summary>
+		/// Field Numbers for <see cref="GyroscopeDataMesg"/>
+		/// </summary>
+		public sealed class FieldDefNum
+		{
+			public const byte Timestamp = 253;
+			public const byte TimestampMs = 0;
+			public const byte SampleTimeOffset = 1;
+			public const byte GyroX = 2;
+			public const byte GyroY = 3;
+			public const byte GyroZ = 4;
+			public const byte CalibratedGyroX = 5;
+			public const byte CalibratedGyroY = 6;
+			public const byte CalibratedGyroZ = 7;
+			public const byte Invalid = Fit.FieldNumInvalid;
+		}
 
-        #region Constructors
-        public GyroscopeDataMesg() : base(Profile.GetMesg(MesgNum.GyroscopeData))
-        {
-        }
+		#region Constructors
+		public GyroscopeDataMesg() : base(Profile.GetMesg(MesgNum.GyroscopeData))
+		{
+		}
 
-        public GyroscopeDataMesg(Mesg mesg) : base(mesg)
-        {
-        }
-        #endregion // Constructors
+		public GyroscopeDataMesg(Mesg mesg) : base(mesg)
+		{
+		}
+		#endregion // Constructors
 
-        #region Methods
-        ///<summary>
-        /// Retrieves the Timestamp field
-        /// Units: s
-        /// Comment: Whole second part of the timestamp</summary>
-        /// <returns>Returns DateTime representing the Timestamp field</returns>
-        public DateTime GetTimestamp()
-        {
-            Object val = GetFieldValue(253, 0, Fit.SubfieldIndexMainField);
-            if(val == null)
-            {
-                return null;
-            }
+		#region Methods
+		///<summary>
+		/// Retrieves the Timestamp field
+		/// Units: s
+		/// Comment: Whole second part of the timestamp</summary>
+		/// <returns>Returns DateTime representing the Timestamp field</returns>
+		public DateTime Timestamp
+		{
+			get
+			{
+				Object val = GetFieldValue(253, 0, Fit.SubfieldIndexMainField);
+				if (val == null)
+				{
+					return null;
+				}
 
-            return TimestampToDateTime(Convert.ToUInt32(val));
-            
-        }
+				return TimestampToDateTime(Convert.ToUInt32(val));
 
-        /// <summary>
-        /// Set Timestamp field
-        /// Units: s
-        /// Comment: Whole second part of the timestamp</summary>
-        /// <param name="timestamp_">Nullable field value to be set</param>
-        public void SetTimestamp(DateTime timestamp_)
-        {
-            SetFieldValue(253, 0, timestamp_.GetTimeStamp(), Fit.SubfieldIndexMainField);
-        }
-        
-        ///<summary>
-        /// Retrieves the TimestampMs field
-        /// Units: ms
-        /// Comment: Millisecond part of the timestamp.</summary>
-        /// <returns>Returns nullable ushort representing the TimestampMs field</returns>
-        public ushort? GetTimestampMs()
-        {
-            Object val = GetFieldValue(0, 0, Fit.SubfieldIndexMainField);
-            if(val == null)
-            {
-                return null;
-            }
+			}
+			set
+			{
+				SetFieldValue(253, 0, value.GetTimeStamp(), Fit.SubfieldIndexMainField);
+			}
+		}
 
-            return (Convert.ToUInt16(val));
-            
-        }
+		///<summary>
+		/// Retrieves the TimestampMs field
+		/// Units: ms
+		/// Comment: Millisecond part of the timestamp.</summary>
+		/// <returns>Returns nullable ushort representing the TimestampMs field</returns>
+		public ushort? TimestampMs
+		{
+			get
+			{
+				Object val = GetFieldValue(0, 0, Fit.SubfieldIndexMainField);
+				if (val == null)
+				{
+					return null;
+				}
 
-        /// <summary>
-        /// Set TimestampMs field
-        /// Units: ms
-        /// Comment: Millisecond part of the timestamp.</summary>
-        /// <param name="timestampMs_">Nullable field value to be set</param>
-        public void SetTimestampMs(ushort? timestampMs_)
-        {
-            SetFieldValue(0, 0, timestampMs_, Fit.SubfieldIndexMainField);
-        }
-        
-        
-        /// <summary>
-        ///
-        /// </summary>
-        /// <returns>returns number of elements in field SampleTimeOffset</returns>
-        public int GetNumSampleTimeOffset()
-        {
-            return GetNumFieldValues(1, Fit.SubfieldIndexMainField);
-        }
+				return (Convert.ToUInt16(val));
 
-        ///<summary>
-        /// Retrieves the SampleTimeOffset field
-        /// Units: ms
-        /// Comment: Each time in the array describes the time at which the gyro sample with the corrosponding index was taken. Limited to 30 samples in each message. The samples may span across seconds. Array size must match the number of samples in gyro_x and gyro_y and gyro_z</summary>
-        /// <param name="index">0 based index of SampleTimeOffset element to retrieve</param>
-        /// <returns>Returns nullable ushort representing the SampleTimeOffset field</returns>
-        public ushort? GetSampleTimeOffset(int index)
-        {
-            Object val = GetFieldValue(1, index, Fit.SubfieldIndexMainField);
-            if(val == null)
-            {
-                return null;
-            }
+			}
+			set
+			{
+				SetFieldValue(0, 0, value, Fit.SubfieldIndexMainField);
+			}
+		}
 
-            return (Convert.ToUInt16(val));
-            
-        }
 
-        /// <summary>
-        /// Set SampleTimeOffset field
-        /// Units: ms
-        /// Comment: Each time in the array describes the time at which the gyro sample with the corrosponding index was taken. Limited to 30 samples in each message. The samples may span across seconds. Array size must match the number of samples in gyro_x and gyro_y and gyro_z</summary>
-        /// <param name="index">0 based index of sample_time_offset</param>
-        /// <param name="sampleTimeOffset_">Nullable field value to be set</param>
-        public void SetSampleTimeOffset(int index, ushort? sampleTimeOffset_)
-        {
-            SetFieldValue(1, index, sampleTimeOffset_, Fit.SubfieldIndexMainField);
-        }
-        
-        
-        /// <summary>
-        ///
-        /// </summary>
-        /// <returns>returns number of elements in field GyroX</returns>
-        public int GetNumGyroX()
-        {
-            return GetNumFieldValues(2, Fit.SubfieldIndexMainField);
-        }
+		/// <summary>
+		///
+		/// </summary>
+		/// <returns>returns number of elements in field SampleTimeOffset</returns>
+		public int GetNumSampleTimeOffset()
+		{
+			return GetNumFieldValues(1, Fit.SubfieldIndexMainField);
+		}
 
-        ///<summary>
-        /// Retrieves the GyroX field
-        /// Units: counts
-        /// Comment: These are the raw ADC reading. Maximum number of samples is 30 in each message. The samples may span across seconds. A conversion will need to be done on this data once read.</summary>
-        /// <param name="index">0 based index of GyroX element to retrieve</param>
-        /// <returns>Returns nullable ushort representing the GyroX field</returns>
-        public ushort? GetGyroX(int index)
-        {
-            Object val = GetFieldValue(2, index, Fit.SubfieldIndexMainField);
-            if(val == null)
-            {
-                return null;
-            }
+		///<summary>
+		/// Retrieves the SampleTimeOffset field
+		/// Units: ms
+		/// Comment: Each time in the array describes the time at which the gyro sample with the corrosponding index was taken. Limited to 30 samples in each message. The samples may span across seconds. Array size must match the number of samples in gyro_x and gyro_y and gyro_z</summary>
+		/// <param name="index">0 based index of SampleTimeOffset element to retrieve</param>
+		/// <returns>Returns nullable ushort representing the SampleTimeOffset field</returns>
+		public ushort? GetSampleTimeOffset(int index)
+		{
+			Object val = GetFieldValue(1, index, Fit.SubfieldIndexMainField);
+			if (val == null)
+			{
+				return null;
+			}
 
-            return (Convert.ToUInt16(val));
-            
-        }
+			return (Convert.ToUInt16(val));
 
-        /// <summary>
-        /// Set GyroX field
-        /// Units: counts
-        /// Comment: These are the raw ADC reading. Maximum number of samples is 30 in each message. The samples may span across seconds. A conversion will need to be done on this data once read.</summary>
-        /// <param name="index">0 based index of gyro_x</param>
-        /// <param name="gyroX_">Nullable field value to be set</param>
-        public void SetGyroX(int index, ushort? gyroX_)
-        {
-            SetFieldValue(2, index, gyroX_, Fit.SubfieldIndexMainField);
-        }
-        
-        
-        /// <summary>
-        ///
-        /// </summary>
-        /// <returns>returns number of elements in field GyroY</returns>
-        public int GetNumGyroY()
-        {
-            return GetNumFieldValues(3, Fit.SubfieldIndexMainField);
-        }
+		}
 
-        ///<summary>
-        /// Retrieves the GyroY field
-        /// Units: counts
-        /// Comment: These are the raw ADC reading. Maximum number of samples is 30 in each message. The samples may span across seconds. A conversion will need to be done on this data once read.</summary>
-        /// <param name="index">0 based index of GyroY element to retrieve</param>
-        /// <returns>Returns nullable ushort representing the GyroY field</returns>
-        public ushort? GetGyroY(int index)
-        {
-            Object val = GetFieldValue(3, index, Fit.SubfieldIndexMainField);
-            if(val == null)
-            {
-                return null;
-            }
+		/// <summary>
+		/// Set SampleTimeOffset field
+		/// Units: ms
+		/// Comment: Each time in the array describes the time at which the gyro sample with the corrosponding index was taken. Limited to 30 samples in each message. The samples may span across seconds. Array size must match the number of samples in gyro_x and gyro_y and gyro_z</summary>
+		/// <param name="index">0 based index of sample_time_offset</param>
+		/// <param name="sampleTimeOffset_">Nullable field value to be set</param>
+		public void SetSampleTimeOffset(int index, ushort? sampleTimeOffset_)
+		{
+			SetFieldValue(1, index, sampleTimeOffset_, Fit.SubfieldIndexMainField);
+		}
 
-            return (Convert.ToUInt16(val));
-            
-        }
 
-        /// <summary>
-        /// Set GyroY field
-        /// Units: counts
-        /// Comment: These are the raw ADC reading. Maximum number of samples is 30 in each message. The samples may span across seconds. A conversion will need to be done on this data once read.</summary>
-        /// <param name="index">0 based index of gyro_y</param>
-        /// <param name="gyroY_">Nullable field value to be set</param>
-        public void SetGyroY(int index, ushort? gyroY_)
-        {
-            SetFieldValue(3, index, gyroY_, Fit.SubfieldIndexMainField);
-        }
-        
-        
-        /// <summary>
-        ///
-        /// </summary>
-        /// <returns>returns number of elements in field GyroZ</returns>
-        public int GetNumGyroZ()
-        {
-            return GetNumFieldValues(4, Fit.SubfieldIndexMainField);
-        }
+		/// <summary>
+		///
+		/// </summary>
+		/// <returns>returns number of elements in field GyroX</returns>
+		public int GetNumGyroX()
+		{
+			return GetNumFieldValues(2, Fit.SubfieldIndexMainField);
+		}
 
-        ///<summary>
-        /// Retrieves the GyroZ field
-        /// Units: counts
-        /// Comment: These are the raw ADC reading. Maximum number of samples is 30 in each message. The samples may span across seconds. A conversion will need to be done on this data once read.</summary>
-        /// <param name="index">0 based index of GyroZ element to retrieve</param>
-        /// <returns>Returns nullable ushort representing the GyroZ field</returns>
-        public ushort? GetGyroZ(int index)
-        {
-            Object val = GetFieldValue(4, index, Fit.SubfieldIndexMainField);
-            if(val == null)
-            {
-                return null;
-            }
+		///<summary>
+		/// Retrieves the GyroX field
+		/// Units: counts
+		/// Comment: These are the raw ADC reading. Maximum number of samples is 30 in each message. The samples may span across seconds. A conversion will need to be done on this data once read.</summary>
+		/// <param name="index">0 based index of GyroX element to retrieve</param>
+		/// <returns>Returns nullable ushort representing the GyroX field</returns>
+		public ushort? GetGyroX(int index)
+		{
+			Object val = GetFieldValue(2, index, Fit.SubfieldIndexMainField);
+			if (val == null)
+			{
+				return null;
+			}
 
-            return (Convert.ToUInt16(val));
-            
-        }
+			return (Convert.ToUInt16(val));
 
-        /// <summary>
-        /// Set GyroZ field
-        /// Units: counts
-        /// Comment: These are the raw ADC reading. Maximum number of samples is 30 in each message. The samples may span across seconds. A conversion will need to be done on this data once read.</summary>
-        /// <param name="index">0 based index of gyro_z</param>
-        /// <param name="gyroZ_">Nullable field value to be set</param>
-        public void SetGyroZ(int index, ushort? gyroZ_)
-        {
-            SetFieldValue(4, index, gyroZ_, Fit.SubfieldIndexMainField);
-        }
-        
-        
-        /// <summary>
-        ///
-        /// </summary>
-        /// <returns>returns number of elements in field CalibratedGyroX</returns>
-        public int GetNumCalibratedGyroX()
-        {
-            return GetNumFieldValues(5, Fit.SubfieldIndexMainField);
-        }
+		}
 
-        ///<summary>
-        /// Retrieves the CalibratedGyroX field
-        /// Units: deg/s
-        /// Comment: Calibrated gyro reading</summary>
-        /// <param name="index">0 based index of CalibratedGyroX element to retrieve</param>
-        /// <returns>Returns nullable float representing the CalibratedGyroX field</returns>
-        public float? GetCalibratedGyroX(int index)
-        {
-            Object val = GetFieldValue(5, index, Fit.SubfieldIndexMainField);
-            if(val == null)
-            {
-                return null;
-            }
+		/// <summary>
+		/// Set GyroX field
+		/// Units: counts
+		/// Comment: These are the raw ADC reading. Maximum number of samples is 30 in each message. The samples may span across seconds. A conversion will need to be done on this data once read.</summary>
+		/// <param name="index">0 based index of gyro_x</param>
+		/// <param name="gyroX_">Nullable field value to be set</param>
+		public void SetGyroX(int index, ushort? gyroX_)
+		{
+			SetFieldValue(2, index, gyroX_, Fit.SubfieldIndexMainField);
+		}
 
-            return (Convert.ToSingle(val));
-            
-        }
 
-        /// <summary>
-        /// Set CalibratedGyroX field
-        /// Units: deg/s
-        /// Comment: Calibrated gyro reading</summary>
-        /// <param name="index">0 based index of calibrated_gyro_x</param>
-        /// <param name="calibratedGyroX_">Nullable field value to be set</param>
-        public void SetCalibratedGyroX(int index, float? calibratedGyroX_)
-        {
-            SetFieldValue(5, index, calibratedGyroX_, Fit.SubfieldIndexMainField);
-        }
-        
-        
-        /// <summary>
-        ///
-        /// </summary>
-        /// <returns>returns number of elements in field CalibratedGyroY</returns>
-        public int GetNumCalibratedGyroY()
-        {
-            return GetNumFieldValues(6, Fit.SubfieldIndexMainField);
-        }
+		/// <summary>
+		///
+		/// </summary>
+		/// <returns>returns number of elements in field GyroY</returns>
+		public int GetNumGyroY()
+		{
+			return GetNumFieldValues(3, Fit.SubfieldIndexMainField);
+		}
 
-        ///<summary>
-        /// Retrieves the CalibratedGyroY field
-        /// Units: deg/s
-        /// Comment: Calibrated gyro reading</summary>
-        /// <param name="index">0 based index of CalibratedGyroY element to retrieve</param>
-        /// <returns>Returns nullable float representing the CalibratedGyroY field</returns>
-        public float? GetCalibratedGyroY(int index)
-        {
-            Object val = GetFieldValue(6, index, Fit.SubfieldIndexMainField);
-            if(val == null)
-            {
-                return null;
-            }
+		///<summary>
+		/// Retrieves the GyroY field
+		/// Units: counts
+		/// Comment: These are the raw ADC reading. Maximum number of samples is 30 in each message. The samples may span across seconds. A conversion will need to be done on this data once read.</summary>
+		/// <param name="index">0 based index of GyroY element to retrieve</param>
+		/// <returns>Returns nullable ushort representing the GyroY field</returns>
+		public ushort? GetGyroY(int index)
+		{
+			Object val = GetFieldValue(3, index, Fit.SubfieldIndexMainField);
+			if (val == null)
+			{
+				return null;
+			}
 
-            return (Convert.ToSingle(val));
-            
-        }
+			return (Convert.ToUInt16(val));
 
-        /// <summary>
-        /// Set CalibratedGyroY field
-        /// Units: deg/s
-        /// Comment: Calibrated gyro reading</summary>
-        /// <param name="index">0 based index of calibrated_gyro_y</param>
-        /// <param name="calibratedGyroY_">Nullable field value to be set</param>
-        public void SetCalibratedGyroY(int index, float? calibratedGyroY_)
-        {
-            SetFieldValue(6, index, calibratedGyroY_, Fit.SubfieldIndexMainField);
-        }
-        
-        
-        /// <summary>
-        ///
-        /// </summary>
-        /// <returns>returns number of elements in field CalibratedGyroZ</returns>
-        public int GetNumCalibratedGyroZ()
-        {
-            return GetNumFieldValues(7, Fit.SubfieldIndexMainField);
-        }
+		}
 
-        ///<summary>
-        /// Retrieves the CalibratedGyroZ field
-        /// Units: deg/s
-        /// Comment: Calibrated gyro reading</summary>
-        /// <param name="index">0 based index of CalibratedGyroZ element to retrieve</param>
-        /// <returns>Returns nullable float representing the CalibratedGyroZ field</returns>
-        public float? GetCalibratedGyroZ(int index)
-        {
-            Object val = GetFieldValue(7, index, Fit.SubfieldIndexMainField);
-            if(val == null)
-            {
-                return null;
-            }
+		/// <summary>
+		/// Set GyroY field
+		/// Units: counts
+		/// Comment: These are the raw ADC reading. Maximum number of samples is 30 in each message. The samples may span across seconds. A conversion will need to be done on this data once read.</summary>
+		/// <param name="index">0 based index of gyro_y</param>
+		/// <param name="gyroY_">Nullable field value to be set</param>
+		public void SetGyroY(int index, ushort? gyroY_)
+		{
+			SetFieldValue(3, index, gyroY_, Fit.SubfieldIndexMainField);
+		}
 
-            return (Convert.ToSingle(val));
-            
-        }
 
-        /// <summary>
-        /// Set CalibratedGyroZ field
-        /// Units: deg/s
-        /// Comment: Calibrated gyro reading</summary>
-        /// <param name="index">0 based index of calibrated_gyro_z</param>
-        /// <param name="calibratedGyroZ_">Nullable field value to be set</param>
-        public void SetCalibratedGyroZ(int index, float? calibratedGyroZ_)
-        {
-            SetFieldValue(7, index, calibratedGyroZ_, Fit.SubfieldIndexMainField);
-        }
-        
-        #endregion // Methods
-    } // Class
+		/// <summary>
+		///
+		/// </summary>
+		/// <returns>returns number of elements in field GyroZ</returns>
+		public int GetNumGyroZ()
+		{
+			return GetNumFieldValues(4, Fit.SubfieldIndexMainField);
+		}
+
+		///<summary>
+		/// Retrieves the GyroZ field
+		/// Units: counts
+		/// Comment: These are the raw ADC reading. Maximum number of samples is 30 in each message. The samples may span across seconds. A conversion will need to be done on this data once read.</summary>
+		/// <param name="index">0 based index of GyroZ element to retrieve</param>
+		/// <returns>Returns nullable ushort representing the GyroZ field</returns>
+		public ushort? GetGyroZ(int index)
+		{
+			Object val = GetFieldValue(4, index, Fit.SubfieldIndexMainField);
+			if (val == null)
+			{
+				return null;
+			}
+
+			return (Convert.ToUInt16(val));
+
+		}
+
+		/// <summary>
+		/// Set GyroZ field
+		/// Units: counts
+		/// Comment: These are the raw ADC reading. Maximum number of samples is 30 in each message. The samples may span across seconds. A conversion will need to be done on this data once read.</summary>
+		/// <param name="index">0 based index of gyro_z</param>
+		/// <param name="gyroZ_">Nullable field value to be set</param>
+		public void SetGyroZ(int index, ushort? gyroZ_)
+		{
+			SetFieldValue(4, index, gyroZ_, Fit.SubfieldIndexMainField);
+		}
+
+
+		/// <summary>
+		///
+		/// </summary>
+		/// <returns>returns number of elements in field CalibratedGyroX</returns>
+		public int GetNumCalibratedGyroX()
+		{
+			return GetNumFieldValues(5, Fit.SubfieldIndexMainField);
+		}
+
+		///<summary>
+		/// Retrieves the CalibratedGyroX field
+		/// Units: deg/s
+		/// Comment: Calibrated gyro reading</summary>
+		/// <param name="index">0 based index of CalibratedGyroX element to retrieve</param>
+		/// <returns>Returns nullable float representing the CalibratedGyroX field</returns>
+		public float? GetCalibratedGyroX(int index)
+		{
+			Object val = GetFieldValue(5, index, Fit.SubfieldIndexMainField);
+			if (val == null)
+			{
+				return null;
+			}
+
+			return (Convert.ToSingle(val));
+
+		}
+
+		/// <summary>
+		/// Set CalibratedGyroX field
+		/// Units: deg/s
+		/// Comment: Calibrated gyro reading</summary>
+		/// <param name="index">0 based index of calibrated_gyro_x</param>
+		/// <param name="calibratedGyroX_">Nullable field value to be set</param>
+		public void SetCalibratedGyroX(int index, float? calibratedGyroX_)
+		{
+			SetFieldValue(5, index, calibratedGyroX_, Fit.SubfieldIndexMainField);
+		}
+
+
+		/// <summary>
+		///
+		/// </summary>
+		/// <returns>returns number of elements in field CalibratedGyroY</returns>
+		public int GetNumCalibratedGyroY()
+		{
+			return GetNumFieldValues(6, Fit.SubfieldIndexMainField);
+		}
+
+		///<summary>
+		/// Retrieves the CalibratedGyroY field
+		/// Units: deg/s
+		/// Comment: Calibrated gyro reading</summary>
+		/// <param name="index">0 based index of CalibratedGyroY element to retrieve</param>
+		/// <returns>Returns nullable float representing the CalibratedGyroY field</returns>
+		public float? GetCalibratedGyroY(int index)
+		{
+			Object val = GetFieldValue(6, index, Fit.SubfieldIndexMainField);
+			if (val == null)
+			{
+				return null;
+			}
+
+			return (Convert.ToSingle(val));
+
+		}
+
+		/// <summary>
+		/// Set CalibratedGyroY field
+		/// Units: deg/s
+		/// Comment: Calibrated gyro reading</summary>
+		/// <param name="index">0 based index of calibrated_gyro_y</param>
+		/// <param name="calibratedGyroY_">Nullable field value to be set</param>
+		public void SetCalibratedGyroY(int index, float? calibratedGyroY_)
+		{
+			SetFieldValue(6, index, calibratedGyroY_, Fit.SubfieldIndexMainField);
+		}
+
+
+		/// <summary>
+		///
+		/// </summary>
+		/// <returns>returns number of elements in field CalibratedGyroZ</returns>
+		public int GetNumCalibratedGyroZ()
+		{
+			return GetNumFieldValues(7, Fit.SubfieldIndexMainField);
+		}
+
+		///<summary>
+		/// Retrieves the CalibratedGyroZ field
+		/// Units: deg/s
+		/// Comment: Calibrated gyro reading</summary>
+		/// <param name="index">0 based index of CalibratedGyroZ element to retrieve</param>
+		/// <returns>Returns nullable float representing the CalibratedGyroZ field</returns>
+		public float? GetCalibratedGyroZ(int index)
+		{
+			Object val = GetFieldValue(7, index, Fit.SubfieldIndexMainField);
+			if (val == null)
+			{
+				return null;
+			}
+
+			return (Convert.ToSingle(val));
+
+		}
+
+		/// <summary>
+		/// Set CalibratedGyroZ field
+		/// Units: deg/s
+		/// Comment: Calibrated gyro reading</summary>
+		/// <param name="index">0 based index of calibrated_gyro_z</param>
+		/// <param name="calibratedGyroZ_">Nullable field value to be set</param>
+		public void SetCalibratedGyroZ(int index, float? calibratedGyroZ_)
+		{
+			SetFieldValue(7, index, calibratedGyroZ_, Fit.SubfieldIndexMainField);
+		}
+
+		#endregion // Methods
+	} // Class
 } // namespace

--- a/Dynastream/Fit/Profile/Mesgs/HrMesg.cs
+++ b/Dynastream/Fit/Profile/Mesgs/HrMesg.cs
@@ -21,221 +21,216 @@ using System.Linq;
 
 namespace Dynastream.Fit
 {
-    /// <summary>
-    /// Implements the Hr profile message.
-    /// </summary>
-    public class HrMesg : Mesg
-    {
-        #region Fields
-        #endregion
+	/// <summary>
+	/// Implements the Hr profile message.
+	/// </summary>
+	public class HrMesg : Mesg
+	{
+		#region Fields
+		#endregion
 
-        /// <summary>
-        /// Field Numbers for <see cref="HrMesg"/>
-        /// </summary>
-        public sealed class FieldDefNum
-        {
-            public const byte Timestamp = 253;
-            public const byte FractionalTimestamp = 0;
-            public const byte Time256 = 1;
-            public const byte FilteredBpm = 6;
-            public const byte EventTimestamp = 9;
-            public const byte EventTimestamp12 = 10;
-            public const byte Invalid = Fit.FieldNumInvalid;
-        }
+		/// <summary>
+		/// Field Numbers for <see cref="HrMesg"/>
+		/// </summary>
+		public sealed class FieldDefNum
+		{
+			public const byte Timestamp = 253;
+			public const byte FractionalTimestamp = 0;
+			public const byte Time256 = 1;
+			public const byte FilteredBpm = 6;
+			public const byte EventTimestamp = 9;
+			public const byte EventTimestamp12 = 10;
+			public const byte Invalid = Fit.FieldNumInvalid;
+		}
 
-        #region Constructors
-        public HrMesg() : base(Profile.GetMesg(MesgNum.Hr))
-        {
-        }
+		#region Constructors
+		public HrMesg() : base(Profile.GetMesg(MesgNum.Hr))
+		{
+		}
 
-        public HrMesg(Mesg mesg) : base(mesg)
-        {
-        }
-        #endregion // Constructors
+		public HrMesg(Mesg mesg) : base(mesg)
+		{
+		}
+		#endregion // Constructors
 
-        #region Methods
-        ///<summary>
-        /// Retrieves the Timestamp field</summary>
-        /// <returns>Returns DateTime representing the Timestamp field</returns>
-        public DateTime GetTimestamp()
-        {
-            Object val = GetFieldValue(253, 0, Fit.SubfieldIndexMainField);
-            if(val == null)
-            {
-                return null;
-            }
+		#region Methods
+		///<summary>
+		/// Retrieves the Timestamp field</summary>
+		/// <returns>Returns DateTime representing the Timestamp field</returns>
+		public DateTime Timestamp
+		{
+			get
+			{
+				Object val = GetFieldValue(253, 0, Fit.SubfieldIndexMainField);
+				if (val == null)
+				{
+					return null;
+				}
 
-            return TimestampToDateTime(Convert.ToUInt32(val));
-            
-        }
+				return TimestampToDateTime(Convert.ToUInt32(val));
 
-        /// <summary>
-        /// Set Timestamp field</summary>
-        /// <param name="timestamp_">Nullable field value to be set</param>
-        public void SetTimestamp(DateTime timestamp_)
-        {
-            SetFieldValue(253, 0, timestamp_.GetTimeStamp(), Fit.SubfieldIndexMainField);
-        }
-        
-        ///<summary>
-        /// Retrieves the FractionalTimestamp field
-        /// Units: s</summary>
-        /// <returns>Returns nullable float representing the FractionalTimestamp field</returns>
-        public float? GetFractionalTimestamp()
-        {
-            Object val = GetFieldValue(0, 0, Fit.SubfieldIndexMainField);
-            if(val == null)
-            {
-                return null;
-            }
+			}
+			set
+			{
+				SetFieldValue(253, 0, value.GetTimeStamp(), Fit.SubfieldIndexMainField);
+			}
+		}
 
-            return (Convert.ToSingle(val));
-            
-        }
+		///<summary>
+		/// Retrieves the FractionalTimestamp field
+		/// Units: s</summary>
+		/// <returns>Returns nullable float representing the FractionalTimestamp field</returns>
+		public float? FractionalTimestamp
+		{
+			get
+			{
+				Object val = GetFieldValue(0, 0, Fit.SubfieldIndexMainField);
+				if (val == null)
+				{
+					return null;
+				}
 
-        /// <summary>
-        /// Set FractionalTimestamp field
-        /// Units: s</summary>
-        /// <param name="fractionalTimestamp_">Nullable field value to be set</param>
-        public void SetFractionalTimestamp(float? fractionalTimestamp_)
-        {
-            SetFieldValue(0, 0, fractionalTimestamp_, Fit.SubfieldIndexMainField);
-        }
-        
-        ///<summary>
-        /// Retrieves the Time256 field
-        /// Units: s</summary>
-        /// <returns>Returns nullable float representing the Time256 field</returns>
-        public float? GetTime256()
-        {
-            Object val = GetFieldValue(1, 0, Fit.SubfieldIndexMainField);
-            if(val == null)
-            {
-                return null;
-            }
+				return (Convert.ToSingle(val));
 
-            return (Convert.ToSingle(val));
-            
-        }
+			}
+			set
+			{
+				SetFieldValue(0, 0, value, Fit.SubfieldIndexMainField);
+			}
+		}
 
-        /// <summary>
-        /// Set Time256 field
-        /// Units: s</summary>
-        /// <param name="time256_">Nullable field value to be set</param>
-        public void SetTime256(float? time256_)
-        {
-            SetFieldValue(1, 0, time256_, Fit.SubfieldIndexMainField);
-        }
-        
-        
-        /// <summary>
-        ///
-        /// </summary>
-        /// <returns>returns number of elements in field FilteredBpm</returns>
-        public int GetNumFilteredBpm()
-        {
-            return GetNumFieldValues(6, Fit.SubfieldIndexMainField);
-        }
+		///<summary>
+		/// Retrieves the Time256 field
+		/// Units: s</summary>
+		/// <returns>Returns nullable float representing the Time256 field</returns>
+		public float? Time256
+		{
+			get
+			{
+				Object val = GetFieldValue(1, 0, Fit.SubfieldIndexMainField);
+				if (val == null)
+				{
+					return null;
+				}
 
-        ///<summary>
-        /// Retrieves the FilteredBpm field
-        /// Units: bpm</summary>
-        /// <param name="index">0 based index of FilteredBpm element to retrieve</param>
-        /// <returns>Returns nullable byte representing the FilteredBpm field</returns>
-        public byte? GetFilteredBpm(int index)
-        {
-            Object val = GetFieldValue(6, index, Fit.SubfieldIndexMainField);
-            if(val == null)
-            {
-                return null;
-            }
+				return (Convert.ToSingle(val));
 
-            return (Convert.ToByte(val));
-            
-        }
+			}
+			set
+			{
+				SetFieldValue(1, 0, value, Fit.SubfieldIndexMainField);
+			}
+		}
 
-        /// <summary>
-        /// Set FilteredBpm field
-        /// Units: bpm</summary>
-        /// <param name="index">0 based index of filtered_bpm</param>
-        /// <param name="filteredBpm_">Nullable field value to be set</param>
-        public void SetFilteredBpm(int index, byte? filteredBpm_)
-        {
-            SetFieldValue(6, index, filteredBpm_, Fit.SubfieldIndexMainField);
-        }
-        
-        
-        /// <summary>
-        ///
-        /// </summary>
-        /// <returns>returns number of elements in field EventTimestamp</returns>
-        public int GetNumEventTimestamp()
-        {
-            return GetNumFieldValues(9, Fit.SubfieldIndexMainField);
-        }
 
-        ///<summary>
-        /// Retrieves the EventTimestamp field
-        /// Units: s</summary>
-        /// <param name="index">0 based index of EventTimestamp element to retrieve</param>
-        /// <returns>Returns nullable float representing the EventTimestamp field</returns>
-        public float? GetEventTimestamp(int index)
-        {
-            Object val = GetFieldValue(9, index, Fit.SubfieldIndexMainField);
-            if(val == null)
-            {
-                return null;
-            }
+		/// <summary>
+		///
+		/// </summary>
+		/// <returns>returns number of elements in field FilteredBpm</returns>
+		public int GetNumFilteredBpm()
+		{
+			return GetNumFieldValues(6, Fit.SubfieldIndexMainField);
+		}
 
-            return (Convert.ToSingle(val));
-            
-        }
+		///<summary>
+		/// Retrieves the FilteredBpm field
+		/// Units: bpm</summary>
+		/// <param name="index">0 based index of FilteredBpm element to retrieve</param>
+		/// <returns>Returns nullable byte representing the FilteredBpm field</returns>
+		public byte? GetFilteredBpm(int index)
+		{
+			Object val = GetFieldValue(6, index, Fit.SubfieldIndexMainField);
+			if (val == null)
+			{
+				return null;
+			}
 
-        /// <summary>
-        /// Set EventTimestamp field
-        /// Units: s</summary>
-        /// <param name="index">0 based index of event_timestamp</param>
-        /// <param name="eventTimestamp_">Nullable field value to be set</param>
-        public void SetEventTimestamp(int index, float? eventTimestamp_)
-        {
-            SetFieldValue(9, index, eventTimestamp_, Fit.SubfieldIndexMainField);
-        }
-        
-        
-        /// <summary>
-        ///
-        /// </summary>
-        /// <returns>returns number of elements in field EventTimestamp12</returns>
-        public int GetNumEventTimestamp12()
-        {
-            return GetNumFieldValues(10, Fit.SubfieldIndexMainField);
-        }
+			return (Convert.ToByte(val));
 
-        ///<summary>
-        /// Retrieves the EventTimestamp12 field</summary>
-        /// <param name="index">0 based index of EventTimestamp12 element to retrieve</param>
-        /// <returns>Returns nullable byte representing the EventTimestamp12 field</returns>
-        public byte? GetEventTimestamp12(int index)
-        {
-            Object val = GetFieldValue(10, index, Fit.SubfieldIndexMainField);
-            if(val == null)
-            {
-                return null;
-            }
+		}
 
-            return (Convert.ToByte(val));
-            
-        }
+		/// <summary>
+		/// Set FilteredBpm field
+		/// Units: bpm</summary>
+		/// <param name="index">0 based index of filtered_bpm</param>
+		/// <param name="filteredBpm_">Nullable field value to be set</param>
+		public void SetFilteredBpm(int index, byte? filteredBpm_)
+		{
+			SetFieldValue(6, index, filteredBpm_, Fit.SubfieldIndexMainField);
+		}
 
-        /// <summary>
-        /// Set EventTimestamp12 field</summary>
-        /// <param name="index">0 based index of event_timestamp_12</param>
-        /// <param name="eventTimestamp12_">Nullable field value to be set</param>
-        public void SetEventTimestamp12(int index, byte? eventTimestamp12_)
-        {
-            SetFieldValue(10, index, eventTimestamp12_, Fit.SubfieldIndexMainField);
-        }
-        
-        #endregion // Methods
-    } // Class
+
+		/// <summary>
+		///
+		/// </summary>
+		/// <returns>returns number of elements in field EventTimestamp</returns>
+		public int GetNumEventTimestamp()
+		{
+			return GetNumFieldValues(9, Fit.SubfieldIndexMainField);
+		}
+
+		///<summary>
+		/// Retrieves the EventTimestamp field
+		/// Units: s</summary>
+		/// <param name="index">0 based index of EventTimestamp element to retrieve</param>
+		/// <returns>Returns nullable float representing the EventTimestamp field</returns>
+		public float? GetEventTimestamp(int index)
+		{
+			Object val = GetFieldValue(9, index, Fit.SubfieldIndexMainField);
+			if (val == null)
+			{
+				return null;
+			}
+
+			return (Convert.ToSingle(val));
+
+		}
+
+		/// <summary>
+		/// Set EventTimestamp field
+		/// Units: s</summary>
+		/// <param name="index">0 based index of event_timestamp</param>
+		/// <param name="eventTimestamp_">Nullable field value to be set</param>
+		public void SetEventTimestamp(int index, float? eventTimestamp_)
+		{
+			SetFieldValue(9, index, eventTimestamp_, Fit.SubfieldIndexMainField);
+		}
+
+
+		/// <summary>
+		///
+		/// </summary>
+		/// <returns>returns number of elements in field EventTimestamp12</returns>
+		public int GetNumEventTimestamp12()
+		{
+			return GetNumFieldValues(10, Fit.SubfieldIndexMainField);
+		}
+
+		///<summary>
+		/// Retrieves the EventTimestamp12 field</summary>
+		/// <param name="index">0 based index of EventTimestamp12 element to retrieve</param>
+		/// <returns>Returns nullable byte representing the EventTimestamp12 field</returns>
+		public byte? GetEventTimestamp12(int index)
+		{
+			Object val = GetFieldValue(10, index, Fit.SubfieldIndexMainField);
+			if (val == null)
+			{
+				return null;
+			}
+
+			return (Convert.ToByte(val));
+
+		}
+
+		/// <summary>
+		/// Set EventTimestamp12 field</summary>
+		/// <param name="index">0 based index of event_timestamp_12</param>
+		/// <param name="eventTimestamp12_">Nullable field value to be set</param>
+		public void SetEventTimestamp12(int index, byte? eventTimestamp12_)
+		{
+			SetFieldValue(10, index, eventTimestamp12_, Fit.SubfieldIndexMainField);
+		}
+
+		#endregion // Methods
+	} // Class
 } // namespace

--- a/Dynastream/Fit/Profile/Mesgs/HrZoneMesg.cs
+++ b/Dynastream/Fit/Profile/Mesgs/HrZoneMesg.cs
@@ -21,122 +21,117 @@ using System.Linq;
 
 namespace Dynastream.Fit
 {
-    /// <summary>
-    /// Implements the HrZone profile message.
-    /// </summary>
-    public class HrZoneMesg : Mesg
-    {
-        #region Fields
-        #endregion
+	/// <summary>
+	/// Implements the HrZone profile message.
+	/// </summary>
+	public class HrZoneMesg : Mesg
+	{
+		#region Fields
+		#endregion
 
-        /// <summary>
-        /// Field Numbers for <see cref="HrZoneMesg"/>
-        /// </summary>
-        public sealed class FieldDefNum
-        {
-            public const byte MessageIndex = 254;
-            public const byte HighBpm = 1;
-            public const byte Name = 2;
-            public const byte Invalid = Fit.FieldNumInvalid;
-        }
+		/// <summary>
+		/// Field Numbers for <see cref="HrZoneMesg"/>
+		/// </summary>
+		public sealed class FieldDefNum
+		{
+			public const byte MessageIndex = 254;
+			public const byte HighBpm = 1;
+			public const byte Name = 2;
+			public const byte Invalid = Fit.FieldNumInvalid;
+		}
 
-        #region Constructors
-        public HrZoneMesg() : base(Profile.GetMesg(MesgNum.HrZone))
-        {
-        }
+		#region Constructors
+		public HrZoneMesg() : base(Profile.GetMesg(MesgNum.HrZone))
+		{
+		}
 
-        public HrZoneMesg(Mesg mesg) : base(mesg)
-        {
-        }
-        #endregion // Constructors
+		public HrZoneMesg(Mesg mesg) : base(mesg)
+		{
+		}
+		#endregion // Constructors
 
-        #region Methods
-        ///<summary>
-        /// Retrieves the MessageIndex field</summary>
-        /// <returns>Returns nullable ushort representing the MessageIndex field</returns>
-        public ushort? GetMessageIndex()
-        {
-            Object val = GetFieldValue(254, 0, Fit.SubfieldIndexMainField);
-            if(val == null)
-            {
-                return null;
-            }
+		#region Methods
+		///<summary>
+		/// Retrieves the MessageIndex field</summary>
+		/// <returns>Returns nullable ushort representing the MessageIndex field</returns>
+		public ushort? MessageIndex
+		{
+			get
+			{
+				Object val = GetFieldValue(254, 0, Fit.SubfieldIndexMainField);
+				if (val == null)
+				{
+					return null;
+				}
 
-            return (Convert.ToUInt16(val));
-            
-        }
+				return (Convert.ToUInt16(val));
 
-        /// <summary>
-        /// Set MessageIndex field</summary>
-        /// <param name="messageIndex_">Nullable field value to be set</param>
-        public void SetMessageIndex(ushort? messageIndex_)
-        {
-            SetFieldValue(254, 0, messageIndex_, Fit.SubfieldIndexMainField);
-        }
-        
-        ///<summary>
-        /// Retrieves the HighBpm field
-        /// Units: bpm</summary>
-        /// <returns>Returns nullable byte representing the HighBpm field</returns>
-        public byte? GetHighBpm()
-        {
-            Object val = GetFieldValue(1, 0, Fit.SubfieldIndexMainField);
-            if(val == null)
-            {
-                return null;
-            }
+			}
+			set
+			{
+				SetFieldValue(254, 0, value, Fit.SubfieldIndexMainField);
+			}
+		}
 
-            return (Convert.ToByte(val));
-            
-        }
+		///<summary>
+		/// Retrieves the HighBpm field
+		/// Units: bpm</summary>
+		/// <returns>Returns nullable byte representing the HighBpm field</returns>
+		public byte? HighBpm
+		{
+			get
+			{
+				Object val = GetFieldValue(1, 0, Fit.SubfieldIndexMainField);
+				if (val == null)
+				{
+					return null;
+				}
 
-        /// <summary>
-        /// Set HighBpm field
-        /// Units: bpm</summary>
-        /// <param name="highBpm_">Nullable field value to be set</param>
-        public void SetHighBpm(byte? highBpm_)
-        {
-            SetFieldValue(1, 0, highBpm_, Fit.SubfieldIndexMainField);
-        }
-        
-        ///<summary>
-        /// Retrieves the Name field</summary>
-        /// <returns>Returns byte[] representing the Name field</returns>
-        public byte[] GetName()
-        {
-            byte[] data = (byte[])GetFieldValue(2, 0, Fit.SubfieldIndexMainField);
-            return data.Take(data.Length - 1).ToArray();
-        }
+				return (Convert.ToByte(val));
 
-        ///<summary>
-        /// Retrieves the Name field</summary>
-        /// <returns>Returns String representing the Name field</returns>
-        public String GetNameAsString()
-        {
-            byte[] data = (byte[])GetFieldValue(2, 0, Fit.SubfieldIndexMainField);
-            return data != null ? Encoding.UTF8.GetString(data, 0, data.Length - 1) : null;
-        }
+			}
+			set
+			{
+				SetFieldValue(1, 0, value, Fit.SubfieldIndexMainField);
+			}
+		}
 
-        ///<summary>
-        /// Set Name field</summary>
-        /// <param name="name_"> field value to be set</param>
-        public void SetName(String name_)
-        {
-            byte[] data = Encoding.UTF8.GetBytes(name_);
-            byte[] zdata = new byte[data.Length + 1];
-            data.CopyTo(zdata, 0);
-            SetFieldValue(2, 0, zdata, Fit.SubfieldIndexMainField);
-        }
+		///<summary>
+		/// Retrieves the Name field</summary>
+		/// <returns>Returns byte[] representing the Name field</returns>
+		public byte[] Name
+		{
+			get
+			{
+				byte[] data = (byte[])GetFieldValue(2, 0, Fit.SubfieldIndexMainField);
+				return data.Take(data.Length - 1).ToArray();
+			}
+			set
+			{
+				SetFieldValue(2, 0, value, Fit.SubfieldIndexMainField);
+			}
+		}
 
-        
-        /// <summary>
-        /// Set Name field</summary>
-        /// <param name="name_">field value to be set</param>
-        public void SetName(byte[] name_)
-        {
-            SetFieldValue(2, 0, name_, Fit.SubfieldIndexMainField);
-        }
-        
-        #endregion // Methods
-    } // Class
+		///<summary>
+		/// Retrieves the Name field</summary>
+		/// <returns>Returns String representing the Name field</returns>
+		public String GetNameAsString()
+		{
+			byte[] data = (byte[])GetFieldValue(2, 0, Fit.SubfieldIndexMainField);
+			return data != null ? Encoding.UTF8.GetString(data, 0, data.Length - 1) : null;
+		}
+
+		///<summary>
+		/// Set Name field</summary>
+		/// <param name="name_"> field value to be set</param>
+		public void SetName(String name_)
+		{
+			byte[] data = Encoding.UTF8.GetBytes(name_);
+			byte[] zdata = new byte[data.Length + 1];
+			data.CopyTo(zdata, 0);
+			SetFieldValue(2, 0, zdata, Fit.SubfieldIndexMainField);
+		}
+
+		#endregion // Methods
+	} // Class
 } // namespace

--- a/Dynastream/Fit/Profile/Mesgs/HrmProfileMesg.cs
+++ b/Dynastream/Fit/Profile/Mesgs/HrmProfileMesg.cs
@@ -21,143 +21,138 @@ using System.Linq;
 
 namespace Dynastream.Fit
 {
-    /// <summary>
-    /// Implements the HrmProfile profile message.
-    /// </summary>
-    public class HrmProfileMesg : Mesg
-    {
-        #region Fields
-        #endregion
+	/// <summary>
+	/// Implements the HrmProfile profile message.
+	/// </summary>
+	public class HrmProfileMesg : Mesg
+	{
+		#region Fields
+		#endregion
 
-        /// <summary>
-        /// Field Numbers for <see cref="HrmProfileMesg"/>
-        /// </summary>
-        public sealed class FieldDefNum
-        {
-            public const byte MessageIndex = 254;
-            public const byte Enabled = 0;
-            public const byte HrmAntId = 1;
-            public const byte LogHrv = 2;
-            public const byte HrmAntIdTransType = 3;
-            public const byte Invalid = Fit.FieldNumInvalid;
-        }
+		/// <summary>
+		/// Field Numbers for <see cref="HrmProfileMesg"/>
+		/// </summary>
+		public sealed class FieldDefNum
+		{
+			public const byte MessageIndex = 254;
+			public const byte Enabled = 0;
+			public const byte HrmAntId = 1;
+			public const byte LogHrv = 2;
+			public const byte HrmAntIdTransType = 3;
+			public const byte Invalid = Fit.FieldNumInvalid;
+		}
 
-        #region Constructors
-        public HrmProfileMesg() : base(Profile.GetMesg(MesgNum.HrmProfile))
-        {
-        }
+		#region Constructors
+		public HrmProfileMesg() : base(Profile.GetMesg(MesgNum.HrmProfile))
+		{
+		}
 
-        public HrmProfileMesg(Mesg mesg) : base(mesg)
-        {
-        }
-        #endregion // Constructors
+		public HrmProfileMesg(Mesg mesg) : base(mesg)
+		{
+		}
+		#endregion // Constructors
 
-        #region Methods
-        ///<summary>
-        /// Retrieves the MessageIndex field</summary>
-        /// <returns>Returns nullable ushort representing the MessageIndex field</returns>
-        public ushort? GetMessageIndex()
-        {
-            Object val = GetFieldValue(254, 0, Fit.SubfieldIndexMainField);
-            if(val == null)
-            {
-                return null;
-            }
+		#region Methods
+		///<summary>
+		/// Retrieves the MessageIndex field</summary>
+		/// <returns>Returns nullable ushort representing the MessageIndex field</returns>
+		public ushort? MessageIndex
+		{
+			get
+			{
+				Object val = GetFieldValue(254, 0, Fit.SubfieldIndexMainField);
+				if (val == null)
+				{
+					return null;
+				}
 
-            return (Convert.ToUInt16(val));
-            
-        }
+				return (Convert.ToUInt16(val));
 
-        /// <summary>
-        /// Set MessageIndex field</summary>
-        /// <param name="messageIndex_">Nullable field value to be set</param>
-        public void SetMessageIndex(ushort? messageIndex_)
-        {
-            SetFieldValue(254, 0, messageIndex_, Fit.SubfieldIndexMainField);
-        }
-        
-        ///<summary>
-        /// Retrieves the Enabled field</summary>
-        /// <returns>Returns nullable Bool enum representing the Enabled field</returns>
-        public Bool? GetEnabled()
-        {
-            object obj = GetFieldValue(0, 0, Fit.SubfieldIndexMainField);
-            Bool? value = obj == null ? (Bool?)null : (Bool)obj;
-            return value;
-        }
+			}
+			set
+			{
+				SetFieldValue(254, 0, value, Fit.SubfieldIndexMainField);
+			}
+		}
 
-        /// <summary>
-        /// Set Enabled field</summary>
-        /// <param name="enabled_">Nullable field value to be set</param>
-        public void SetEnabled(Bool? enabled_)
-        {
-            SetFieldValue(0, 0, enabled_, Fit.SubfieldIndexMainField);
-        }
-        
-        ///<summary>
-        /// Retrieves the HrmAntId field</summary>
-        /// <returns>Returns nullable ushort representing the HrmAntId field</returns>
-        public ushort? GetHrmAntId()
-        {
-            Object val = GetFieldValue(1, 0, Fit.SubfieldIndexMainField);
-            if(val == null)
-            {
-                return null;
-            }
+		///<summary>
+		/// Retrieves the Enabled field</summary>
+		/// <returns>Returns nullable Bool enum representing the Enabled field</returns>
+		public Bool? Enabled
+		{
+			get
+			{
+				object obj = GetFieldValue(0, 0, Fit.SubfieldIndexMainField);
+				Bool? value = obj == null ? (Bool?)null : (Bool)obj;
+				return value;
+			}
+			set
+			{
+				SetFieldValue(0, 0, value, Fit.SubfieldIndexMainField);
+			}
+		}
 
-            return (Convert.ToUInt16(val));
-            
-        }
+		///<summary>
+		/// Retrieves the HrmAntId field</summary>
+		/// <returns>Returns nullable ushort representing the HrmAntId field</returns>
+		public ushort? HrmAntId
+		{
+			get
+			{
+				Object val = GetFieldValue(1, 0, Fit.SubfieldIndexMainField);
+				if (val == null)
+				{
+					return null;
+				}
 
-        /// <summary>
-        /// Set HrmAntId field</summary>
-        /// <param name="hrmAntId_">Nullable field value to be set</param>
-        public void SetHrmAntId(ushort? hrmAntId_)
-        {
-            SetFieldValue(1, 0, hrmAntId_, Fit.SubfieldIndexMainField);
-        }
-        
-        ///<summary>
-        /// Retrieves the LogHrv field</summary>
-        /// <returns>Returns nullable Bool enum representing the LogHrv field</returns>
-        public Bool? GetLogHrv()
-        {
-            object obj = GetFieldValue(2, 0, Fit.SubfieldIndexMainField);
-            Bool? value = obj == null ? (Bool?)null : (Bool)obj;
-            return value;
-        }
+				return (Convert.ToUInt16(val));
 
-        /// <summary>
-        /// Set LogHrv field</summary>
-        /// <param name="logHrv_">Nullable field value to be set</param>
-        public void SetLogHrv(Bool? logHrv_)
-        {
-            SetFieldValue(2, 0, logHrv_, Fit.SubfieldIndexMainField);
-        }
-        
-        ///<summary>
-        /// Retrieves the HrmAntIdTransType field</summary>
-        /// <returns>Returns nullable byte representing the HrmAntIdTransType field</returns>
-        public byte? GetHrmAntIdTransType()
-        {
-            Object val = GetFieldValue(3, 0, Fit.SubfieldIndexMainField);
-            if(val == null)
-            {
-                return null;
-            }
+			}
+			set
+			{
+				SetFieldValue(1, 0, value, Fit.SubfieldIndexMainField);
+			}
+		}
 
-            return (Convert.ToByte(val));
-            
-        }
+		///<summary>
+		/// Retrieves the LogHrv field</summary>
+		/// <returns>Returns nullable Bool enum representing the LogHrv field</returns>
+		public Bool? LogHrv
+		{
+			get
+			{
+				object obj = GetFieldValue(2, 0, Fit.SubfieldIndexMainField);
+				Bool? value = obj == null ? (Bool?)null : (Bool)obj;
+				return value;
+			}
+			set
+			{
+				SetFieldValue(2, 0, value, Fit.SubfieldIndexMainField);
+			}
+		}
 
-        /// <summary>
-        /// Set HrmAntIdTransType field</summary>
-        /// <param name="hrmAntIdTransType_">Nullable field value to be set</param>
-        public void SetHrmAntIdTransType(byte? hrmAntIdTransType_)
-        {
-            SetFieldValue(3, 0, hrmAntIdTransType_, Fit.SubfieldIndexMainField);
-        }
-        
-        #endregion // Methods
-    } // Class
+		///<summary>
+		/// Retrieves the HrmAntIdTransType field</summary>
+		/// <returns>Returns nullable byte representing the HrmAntIdTransType field</returns>
+		public byte? HrmAntIdTransType
+		{
+			get
+			{
+				Object val = GetFieldValue(3, 0, Fit.SubfieldIndexMainField);
+				if (val == null)
+				{
+					return null;
+				}
+
+				return (Convert.ToByte(val));
+
+			}
+			set
+			{
+				SetFieldValue(3, 0, value, Fit.SubfieldIndexMainField);
+			}
+		}
+
+		#endregion // Methods
+	} // Class
 } // namespace

--- a/Dynastream/Fit/Profile/Mesgs/HrvMesg.cs
+++ b/Dynastream/Fit/Profile/Mesgs/HrvMesg.cs
@@ -21,73 +21,73 @@ using System.Linq;
 
 namespace Dynastream.Fit
 {
-    /// <summary>
-    /// Implements the Hrv profile message.
-    /// </summary>
-    public class HrvMesg : Mesg
-    {
-        #region Fields
-        #endregion
+	/// <summary>
+	/// Implements the Hrv profile message.
+	/// </summary>
+	public class HrvMesg : Mesg
+	{
+		#region Fields
+		#endregion
 
-        /// <summary>
-        /// Field Numbers for <see cref="HrvMesg"/>
-        /// </summary>
-        public sealed class FieldDefNum
-        {
-            public const byte Time = 0;
-            public const byte Invalid = Fit.FieldNumInvalid;
-        }
+		/// <summary>
+		/// Field Numbers for <see cref="HrvMesg"/>
+		/// </summary>
+		public sealed class FieldDefNum
+		{
+			public const byte Time = 0;
+			public const byte Invalid = Fit.FieldNumInvalid;
+		}
 
-        #region Constructors
-        public HrvMesg() : base(Profile.GetMesg(MesgNum.Hrv))
-        {
-        }
+		#region Constructors
+		public HrvMesg() : base(Profile.GetMesg(MesgNum.Hrv))
+		{
+		}
 
-        public HrvMesg(Mesg mesg) : base(mesg)
-        {
-        }
-        #endregion // Constructors
+		public HrvMesg(Mesg mesg) : base(mesg)
+		{
+		}
+		#endregion // Constructors
 
-        #region Methods
-        
-        /// <summary>
-        ///
-        /// </summary>
-        /// <returns>returns number of elements in field Time</returns>
-        public int GetNumTime()
-        {
-            return GetNumFieldValues(0, Fit.SubfieldIndexMainField);
-        }
+		#region Methods
 
-        ///<summary>
-        /// Retrieves the Time field
-        /// Units: s
-        /// Comment: Time between beats</summary>
-        /// <param name="index">0 based index of Time element to retrieve</param>
-        /// <returns>Returns nullable float representing the Time field</returns>
-        public float? GetTime(int index)
-        {
-            Object val = GetFieldValue(0, index, Fit.SubfieldIndexMainField);
-            if(val == null)
-            {
-                return null;
-            }
+		/// <summary>
+		///
+		/// </summary>
+		/// <returns>returns number of elements in field Time</returns>
+		public int GetNumTime()
+		{
+			return GetNumFieldValues(0, Fit.SubfieldIndexMainField);
+		}
 
-            return (Convert.ToSingle(val));
-            
-        }
+		///<summary>
+		/// Retrieves the Time field
+		/// Units: s
+		/// Comment: Time between beats</summary>
+		/// <param name="index">0 based index of Time element to retrieve</param>
+		/// <returns>Returns nullable float representing the Time field</returns>
+		public float? GetTime(int index)
+		{
+			Object val = GetFieldValue(0, index, Fit.SubfieldIndexMainField);
+			if (val == null)
+			{
+				return null;
+			}
 
-        /// <summary>
-        /// Set Time field
-        /// Units: s
-        /// Comment: Time between beats</summary>
-        /// <param name="index">0 based index of time</param>
-        /// <param name="time_">Nullable field value to be set</param>
-        public void SetTime(int index, float? time_)
-        {
-            SetFieldValue(0, index, time_, Fit.SubfieldIndexMainField);
-        }
-        
-        #endregion // Methods
-    } // Class
+			return (Convert.ToSingle(val));
+
+		}
+
+		/// <summary>
+		/// Set Time field
+		/// Units: s
+		/// Comment: Time between beats</summary>
+		/// <param name="index">0 based index of time</param>
+		/// <param name="time_">Nullable field value to be set</param>
+		public void SetTime(int index, float? time_)
+		{
+			SetFieldValue(0, index, time_, Fit.SubfieldIndexMainField);
+		}
+
+		#endregion // Methods
+	} // Class
 } // namespace

--- a/Dynastream/Fit/Profile/Mesgs/HrvStatusSummaryMesg.cs
+++ b/Dynastream/Fit/Profile/Mesgs/HrvStatusSummaryMesg.cs
@@ -21,244 +21,224 @@ using System.Linq;
 
 namespace Dynastream.Fit
 {
-    /// <summary>
-    /// Implements the HrvStatusSummary profile message.
-    /// </summary>
-    public class HrvStatusSummaryMesg : Mesg
-    {
-        #region Fields
-        #endregion
+	/// <summary>
+	/// Implements the HrvStatusSummary profile message.
+	/// </summary>
+	public class HrvStatusSummaryMesg : Mesg
+	{
+		#region Fields
+		#endregion
 
-        /// <summary>
-        /// Field Numbers for <see cref="HrvStatusSummaryMesg"/>
-        /// </summary>
-        public sealed class FieldDefNum
-        {
-            public const byte Timestamp = 253;
-            public const byte WeeklyAverage = 0;
-            public const byte LastNightAverage = 1;
-            public const byte LastNight5MinHigh = 2;
-            public const byte BaselineLowUpper = 3;
-            public const byte BaselineBalancedLower = 4;
-            public const byte BaselineBalancedUpper = 5;
-            public const byte Status = 6;
-            public const byte Invalid = Fit.FieldNumInvalid;
-        }
+		/// <summary>
+		/// Field Numbers for <see cref="HrvStatusSummaryMesg"/>
+		/// </summary>
+		public sealed class FieldDefNum
+		{
+			public const byte Timestamp = 253;
+			public const byte WeeklyAverage = 0;
+			public const byte LastNightAverage = 1;
+			public const byte LastNight5MinHigh = 2;
+			public const byte BaselineLowUpper = 3;
+			public const byte BaselineBalancedLower = 4;
+			public const byte BaselineBalancedUpper = 5;
+			public const byte Status = 6;
+			public const byte Invalid = Fit.FieldNumInvalid;
+		}
 
-        #region Constructors
-        public HrvStatusSummaryMesg() : base(Profile.GetMesg(MesgNum.HrvStatusSummary))
-        {
-        }
+		#region Constructors
+		public HrvStatusSummaryMesg() : base(Profile.GetMesg(MesgNum.HrvStatusSummary))
+		{
+		}
 
-        public HrvStatusSummaryMesg(Mesg mesg) : base(mesg)
-        {
-        }
-        #endregion // Constructors
+		public HrvStatusSummaryMesg(Mesg mesg) : base(mesg)
+		{
+		}
+		#endregion // Constructors
 
-        #region Methods
-        ///<summary>
-        /// Retrieves the Timestamp field</summary>
-        /// <returns>Returns DateTime representing the Timestamp field</returns>
-        public DateTime GetTimestamp()
-        {
-            Object val = GetFieldValue(253, 0, Fit.SubfieldIndexMainField);
-            if(val == null)
-            {
-                return null;
-            }
+		#region Methods
+		///<summary>
+		/// Retrieves the Timestamp field</summary>
+		/// <returns>Returns DateTime representing the Timestamp field</returns>
+		public DateTime Timestamp
+		{
+			get
+			{
+				Object val = GetFieldValue(253, 0, Fit.SubfieldIndexMainField);
+				if (val == null)
+				{
+					return null;
+				}
 
-            return TimestampToDateTime(Convert.ToUInt32(val));
-            
-        }
+				return TimestampToDateTime(Convert.ToUInt32(val));
 
-        /// <summary>
-        /// Set Timestamp field</summary>
-        /// <param name="timestamp_">Nullable field value to be set</param>
-        public void SetTimestamp(DateTime timestamp_)
-        {
-            SetFieldValue(253, 0, timestamp_.GetTimeStamp(), Fit.SubfieldIndexMainField);
-        }
-        
-        ///<summary>
-        /// Retrieves the WeeklyAverage field
-        /// Units: ms
-        /// Comment: 7 day RMSSD average over sleep</summary>
-        /// <returns>Returns nullable float representing the WeeklyAverage field</returns>
-        public float? GetWeeklyAverage()
-        {
-            Object val = GetFieldValue(0, 0, Fit.SubfieldIndexMainField);
-            if(val == null)
-            {
-                return null;
-            }
+			}
+			set
+			{
+				SetFieldValue(253, 0, value.GetTimeStamp(), Fit.SubfieldIndexMainField);
+			}
+		}
 
-            return (Convert.ToSingle(val));
-            
-        }
+		///<summary>
+		/// Retrieves the WeeklyAverage field
+		/// Units: ms
+		/// Comment: 7 day RMSSD average over sleep</summary>
+		/// <returns>Returns nullable float representing the WeeklyAverage field</returns>
+		public float? WeeklyAverage
+		{
+			get
+			{
+				Object val = GetFieldValue(0, 0, Fit.SubfieldIndexMainField);
+				if (val == null)
+				{
+					return null;
+				}
 
-        /// <summary>
-        /// Set WeeklyAverage field
-        /// Units: ms
-        /// Comment: 7 day RMSSD average over sleep</summary>
-        /// <param name="weeklyAverage_">Nullable field value to be set</param>
-        public void SetWeeklyAverage(float? weeklyAverage_)
-        {
-            SetFieldValue(0, 0, weeklyAverage_, Fit.SubfieldIndexMainField);
-        }
-        
-        ///<summary>
-        /// Retrieves the LastNightAverage field
-        /// Units: ms
-        /// Comment: Last night RMSSD average over sleep</summary>
-        /// <returns>Returns nullable float representing the LastNightAverage field</returns>
-        public float? GetLastNightAverage()
-        {
-            Object val = GetFieldValue(1, 0, Fit.SubfieldIndexMainField);
-            if(val == null)
-            {
-                return null;
-            }
+				return (Convert.ToSingle(val));
 
-            return (Convert.ToSingle(val));
-            
-        }
+			}
+			set
+			{
+				SetFieldValue(0, 0, value, Fit.SubfieldIndexMainField);
+			}
+		}
 
-        /// <summary>
-        /// Set LastNightAverage field
-        /// Units: ms
-        /// Comment: Last night RMSSD average over sleep</summary>
-        /// <param name="lastNightAverage_">Nullable field value to be set</param>
-        public void SetLastNightAverage(float? lastNightAverage_)
-        {
-            SetFieldValue(1, 0, lastNightAverage_, Fit.SubfieldIndexMainField);
-        }
-        
-        ///<summary>
-        /// Retrieves the LastNight5MinHigh field
-        /// Units: ms
-        /// Comment: 5 minute high RMSSD value over sleep</summary>
-        /// <returns>Returns nullable float representing the LastNight5MinHigh field</returns>
-        public float? GetLastNight5MinHigh()
-        {
-            Object val = GetFieldValue(2, 0, Fit.SubfieldIndexMainField);
-            if(val == null)
-            {
-                return null;
-            }
+		///<summary>
+		/// Retrieves the LastNightAverage field
+		/// Units: ms
+		/// Comment: Last night RMSSD average over sleep</summary>
+		/// <returns>Returns nullable float representing the LastNightAverage field</returns>
+		public float? LastNightAverage
+		{
+			get
+			{
+				Object val = GetFieldValue(1, 0, Fit.SubfieldIndexMainField);
+				if (val == null)
+				{
+					return null;
+				}
 
-            return (Convert.ToSingle(val));
-            
-        }
+				return (Convert.ToSingle(val));
 
-        /// <summary>
-        /// Set LastNight5MinHigh field
-        /// Units: ms
-        /// Comment: 5 minute high RMSSD value over sleep</summary>
-        /// <param name="lastNight5MinHigh_">Nullable field value to be set</param>
-        public void SetLastNight5MinHigh(float? lastNight5MinHigh_)
-        {
-            SetFieldValue(2, 0, lastNight5MinHigh_, Fit.SubfieldIndexMainField);
-        }
-        
-        ///<summary>
-        /// Retrieves the BaselineLowUpper field
-        /// Units: ms
-        /// Comment: 3 week baseline, upper boundary of low HRV status</summary>
-        /// <returns>Returns nullable float representing the BaselineLowUpper field</returns>
-        public float? GetBaselineLowUpper()
-        {
-            Object val = GetFieldValue(3, 0, Fit.SubfieldIndexMainField);
-            if(val == null)
-            {
-                return null;
-            }
+			}
+			set
+			{
+				SetFieldValue(1, 0, value, Fit.SubfieldIndexMainField);
+			}
+		}
 
-            return (Convert.ToSingle(val));
-            
-        }
+		///<summary>
+		/// Retrieves the LastNight5MinHigh field
+		/// Units: ms
+		/// Comment: 5 minute high RMSSD value over sleep</summary>
+		/// <returns>Returns nullable float representing the LastNight5MinHigh field</returns>
+		public float? LastNight5MinHigh
+		{
+			get
+			{
+				Object val = GetFieldValue(2, 0, Fit.SubfieldIndexMainField);
+				if (val == null)
+				{
+					return null;
+				}
 
-        /// <summary>
-        /// Set BaselineLowUpper field
-        /// Units: ms
-        /// Comment: 3 week baseline, upper boundary of low HRV status</summary>
-        /// <param name="baselineLowUpper_">Nullable field value to be set</param>
-        public void SetBaselineLowUpper(float? baselineLowUpper_)
-        {
-            SetFieldValue(3, 0, baselineLowUpper_, Fit.SubfieldIndexMainField);
-        }
-        
-        ///<summary>
-        /// Retrieves the BaselineBalancedLower field
-        /// Units: ms
-        /// Comment: 3 week baseline, lower boundary of balanced HRV status</summary>
-        /// <returns>Returns nullable float representing the BaselineBalancedLower field</returns>
-        public float? GetBaselineBalancedLower()
-        {
-            Object val = GetFieldValue(4, 0, Fit.SubfieldIndexMainField);
-            if(val == null)
-            {
-                return null;
-            }
+				return (Convert.ToSingle(val));
 
-            return (Convert.ToSingle(val));
-            
-        }
+			}
+			set
+			{
+				SetFieldValue(2, 0, value, Fit.SubfieldIndexMainField);
+			}
+		}
 
-        /// <summary>
-        /// Set BaselineBalancedLower field
-        /// Units: ms
-        /// Comment: 3 week baseline, lower boundary of balanced HRV status</summary>
-        /// <param name="baselineBalancedLower_">Nullable field value to be set</param>
-        public void SetBaselineBalancedLower(float? baselineBalancedLower_)
-        {
-            SetFieldValue(4, 0, baselineBalancedLower_, Fit.SubfieldIndexMainField);
-        }
-        
-        ///<summary>
-        /// Retrieves the BaselineBalancedUpper field
-        /// Units: ms
-        /// Comment: 3 week baseline, upper boundary of balanced HRV status</summary>
-        /// <returns>Returns nullable float representing the BaselineBalancedUpper field</returns>
-        public float? GetBaselineBalancedUpper()
-        {
-            Object val = GetFieldValue(5, 0, Fit.SubfieldIndexMainField);
-            if(val == null)
-            {
-                return null;
-            }
+		///<summary>
+		/// Retrieves the BaselineLowUpper field
+		/// Units: ms
+		/// Comment: 3 week baseline, upper boundary of low HRV status</summary>
+		/// <returns>Returns nullable float representing the BaselineLowUpper field</returns>
+		public float? BaselineLowUpper
+		{
+			get
+			{
+				Object val = GetFieldValue(3, 0, Fit.SubfieldIndexMainField);
+				if (val == null)
+				{
+					return null;
+				}
 
-            return (Convert.ToSingle(val));
-            
-        }
+				return (Convert.ToSingle(val));
 
-        /// <summary>
-        /// Set BaselineBalancedUpper field
-        /// Units: ms
-        /// Comment: 3 week baseline, upper boundary of balanced HRV status</summary>
-        /// <param name="baselineBalancedUpper_">Nullable field value to be set</param>
-        public void SetBaselineBalancedUpper(float? baselineBalancedUpper_)
-        {
-            SetFieldValue(5, 0, baselineBalancedUpper_, Fit.SubfieldIndexMainField);
-        }
-        
-        ///<summary>
-        /// Retrieves the Status field</summary>
-        /// <returns>Returns nullable HrvStatus enum representing the Status field</returns>
-        public HrvStatus? GetStatus()
-        {
-            object obj = GetFieldValue(6, 0, Fit.SubfieldIndexMainField);
-            HrvStatus? value = obj == null ? (HrvStatus?)null : (HrvStatus)obj;
-            return value;
-        }
+			}
+			set
+			{
+				SetFieldValue(3, 0, value, Fit.SubfieldIndexMainField);
+			}
+		}
 
-        /// <summary>
-        /// Set Status field</summary>
-        /// <param name="status_">Nullable field value to be set</param>
-        public void SetStatus(HrvStatus? status_)
-        {
-            SetFieldValue(6, 0, status_, Fit.SubfieldIndexMainField);
-        }
-        
-        #endregion // Methods
-    } // Class
+		///<summary>
+		/// Retrieves the BaselineBalancedLower field
+		/// Units: ms
+		/// Comment: 3 week baseline, lower boundary of balanced HRV status</summary>
+		/// <returns>Returns nullable float representing the BaselineBalancedLower field</returns>
+		public float? BaselineBalancedLower
+		{
+			get
+			{
+				Object val = GetFieldValue(4, 0, Fit.SubfieldIndexMainField);
+				if (val == null)
+				{
+					return null;
+				}
+
+				return (Convert.ToSingle(val));
+
+			}
+			set
+			{
+				SetFieldValue(4, 0, value, Fit.SubfieldIndexMainField);
+			}
+		}
+
+		///<summary>
+		/// Retrieves the BaselineBalancedUpper field
+		/// Units: ms
+		/// Comment: 3 week baseline, upper boundary of balanced HRV status</summary>
+		/// <returns>Returns nullable float representing the BaselineBalancedUpper field</returns>
+		public float? BaselineBalancedUpper
+		{
+			get
+			{
+				Object val = GetFieldValue(5, 0, Fit.SubfieldIndexMainField);
+				if (val == null)
+				{
+					return null;
+				}
+
+				return (Convert.ToSingle(val));
+
+			}
+			set
+			{
+				SetFieldValue(5, 0, value, Fit.SubfieldIndexMainField);
+			}
+		}
+
+		///<summary>
+		/// Retrieves the Status field</summary>
+		/// <returns>Returns nullable HrvStatus enum representing the Status field</returns>
+		public HrvStatus? Status
+		{
+			get
+			{
+				object obj = GetFieldValue(6, 0, Fit.SubfieldIndexMainField);
+				HrvStatus? value = obj == null ? (HrvStatus?)null : (HrvStatus)obj;
+				return value;
+			}
+			set
+			{
+				SetFieldValue(6, 0, value, Fit.SubfieldIndexMainField);
+			}
+		}
+
+		#endregion // Methods
+	} // Class
 } // namespace

--- a/Dynastream/Fit/Profile/Mesgs/HrvValueMesg.cs
+++ b/Dynastream/Fit/Profile/Mesgs/HrvValueMesg.cs
@@ -21,85 +21,81 @@ using System.Linq;
 
 namespace Dynastream.Fit
 {
-    /// <summary>
-    /// Implements the HrvValue profile message.
-    /// </summary>
-    public class HrvValueMesg : Mesg
-    {
-        #region Fields
-        #endregion
+	/// <summary>
+	/// Implements the HrvValue profile message.
+	/// </summary>
+	public class HrvValueMesg : Mesg
+	{
+		#region Fields
+		#endregion
 
-        /// <summary>
-        /// Field Numbers for <see cref="HrvValueMesg"/>
-        /// </summary>
-        public sealed class FieldDefNum
-        {
-            public const byte Timestamp = 253;
-            public const byte Value = 0;
-            public const byte Invalid = Fit.FieldNumInvalid;
-        }
+		/// <summary>
+		/// Field Numbers for <see cref="HrvValueMesg"/>
+		/// </summary>
+		public sealed class FieldDefNum
+		{
+			public const byte Timestamp = 253;
+			public const byte Value = 0;
+			public const byte Invalid = Fit.FieldNumInvalid;
+		}
 
-        #region Constructors
-        public HrvValueMesg() : base(Profile.GetMesg(MesgNum.HrvValue))
-        {
-        }
+		#region Constructors
+		public HrvValueMesg() : base(Profile.GetMesg(MesgNum.HrvValue))
+		{
+		}
 
-        public HrvValueMesg(Mesg mesg) : base(mesg)
-        {
-        }
-        #endregion // Constructors
+		public HrvValueMesg(Mesg mesg) : base(mesg)
+		{
+		}
+		#endregion // Constructors
 
-        #region Methods
-        ///<summary>
-        /// Retrieves the Timestamp field</summary>
-        /// <returns>Returns DateTime representing the Timestamp field</returns>
-        public DateTime GetTimestamp()
-        {
-            Object val = GetFieldValue(253, 0, Fit.SubfieldIndexMainField);
-            if(val == null)
-            {
-                return null;
-            }
+		#region Methods
+		///<summary>
+		/// Retrieves the Timestamp field</summary>
+		/// <returns>Returns DateTime representing the Timestamp field</returns>
+		public DateTime Timestamp
+		{
+			get
+			{
+				Object val = GetFieldValue(253, 0, Fit.SubfieldIndexMainField);
+				if (val == null)
+				{
+					return null;
+				}
 
-            return TimestampToDateTime(Convert.ToUInt32(val));
-            
-        }
+				return TimestampToDateTime(Convert.ToUInt32(val));
 
-        /// <summary>
-        /// Set Timestamp field</summary>
-        /// <param name="timestamp_">Nullable field value to be set</param>
-        public void SetTimestamp(DateTime timestamp_)
-        {
-            SetFieldValue(253, 0, timestamp_.GetTimeStamp(), Fit.SubfieldIndexMainField);
-        }
-        
-        ///<summary>
-        /// Retrieves the Value field
-        /// Units: ms
-        /// Comment: 5 minute RMSSD</summary>
-        /// <returns>Returns nullable float representing the Value field</returns>
-        public float? GetValue()
-        {
-            Object val = GetFieldValue(0, 0, Fit.SubfieldIndexMainField);
-            if(val == null)
-            {
-                return null;
-            }
+			}
+			set
+			{
+				SetFieldValue(253, 0, value.GetTimeStamp(), Fit.SubfieldIndexMainField);
+			}
+		}
 
-            return (Convert.ToSingle(val));
-            
-        }
+		///<summary>
+		/// Retrieves the Value field
+		/// Units: ms
+		/// Comment: 5 minute RMSSD</summary>
+		/// <returns>Returns nullable float representing the Value field</returns>
+		public float? Value
+		{
+			get
+			{
+				Object val = GetFieldValue(0, 0, Fit.SubfieldIndexMainField);
+				if (val == null)
+				{
+					return null;
+				}
 
-        /// <summary>
-        /// Set Value field
-        /// Units: ms
-        /// Comment: 5 minute RMSSD</summary>
-        /// <param name="value_">Nullable field value to be set</param>
-        public void SetValue(float? value_)
-        {
-            SetFieldValue(0, 0, value_, Fit.SubfieldIndexMainField);
-        }
-        
-        #endregion // Methods
-    } // Class
+				return (Convert.ToSingle(val));
+
+			}
+			set
+			{
+				SetFieldValue(0, 0, value, Fit.SubfieldIndexMainField);
+			}
+		}
+
+		#endregion // Methods
+	} // Class
 } // namespace

--- a/Dynastream/Fit/Profile/Mesgs/HsaAccelerometerDataMesg.cs
+++ b/Dynastream/Fit/Profile/Mesgs/HsaAccelerometerDataMesg.cs
@@ -21,261 +21,251 @@ using System.Linq;
 
 namespace Dynastream.Fit
 {
-    /// <summary>
-    /// Implements the HsaAccelerometerData profile message.
-    /// </summary>
-    public class HsaAccelerometerDataMesg : Mesg
-    {
-        #region Fields
-        #endregion
+	/// <summary>
+	/// Implements the HsaAccelerometerData profile message.
+	/// </summary>
+	public class HsaAccelerometerDataMesg : Mesg
+	{
+		#region Fields
+		#endregion
 
-        /// <summary>
-        /// Field Numbers for <see cref="HsaAccelerometerDataMesg"/>
-        /// </summary>
-        public sealed class FieldDefNum
-        {
-            public const byte Timestamp = 253;
-            public const byte TimestampMs = 0;
-            public const byte SamplingInterval = 1;
-            public const byte AccelX = 2;
-            public const byte AccelY = 3;
-            public const byte AccelZ = 4;
-            public const byte Timestamp32k = 5;
-            public const byte Invalid = Fit.FieldNumInvalid;
-        }
+		/// <summary>
+		/// Field Numbers for <see cref="HsaAccelerometerDataMesg"/>
+		/// </summary>
+		public sealed class FieldDefNum
+		{
+			public const byte Timestamp = 253;
+			public const byte TimestampMs = 0;
+			public const byte SamplingInterval = 1;
+			public const byte AccelX = 2;
+			public const byte AccelY = 3;
+			public const byte AccelZ = 4;
+			public const byte Timestamp32k = 5;
+			public const byte Invalid = Fit.FieldNumInvalid;
+		}
 
-        #region Constructors
-        public HsaAccelerometerDataMesg() : base(Profile.GetMesg(MesgNum.HsaAccelerometerData))
-        {
-        }
+		#region Constructors
+		public HsaAccelerometerDataMesg() : base(Profile.GetMesg(MesgNum.HsaAccelerometerData))
+		{
+		}
 
-        public HsaAccelerometerDataMesg(Mesg mesg) : base(mesg)
-        {
-        }
-        #endregion // Constructors
+		public HsaAccelerometerDataMesg(Mesg mesg) : base(mesg)
+		{
+		}
+		#endregion // Constructors
 
-        #region Methods
-        ///<summary>
-        /// Retrieves the Timestamp field
-        /// Units: s</summary>
-        /// <returns>Returns DateTime representing the Timestamp field</returns>
-        public DateTime GetTimestamp()
-        {
-            Object val = GetFieldValue(253, 0, Fit.SubfieldIndexMainField);
-            if(val == null)
-            {
-                return null;
-            }
+		#region Methods
+		///<summary>
+		/// Retrieves the Timestamp field
+		/// Units: s</summary>
+		/// <returns>Returns DateTime representing the Timestamp field</returns>
+		public DateTime Timestamp
+		{
+			get
+			{
+				Object val = GetFieldValue(253, 0, Fit.SubfieldIndexMainField);
+				if (val == null)
+				{
+					return null;
+				}
 
-            return TimestampToDateTime(Convert.ToUInt32(val));
-            
-        }
+				return TimestampToDateTime(Convert.ToUInt32(val));
 
-        /// <summary>
-        /// Set Timestamp field
-        /// Units: s</summary>
-        /// <param name="timestamp_">Nullable field value to be set</param>
-        public void SetTimestamp(DateTime timestamp_)
-        {
-            SetFieldValue(253, 0, timestamp_.GetTimeStamp(), Fit.SubfieldIndexMainField);
-        }
-        
-        ///<summary>
-        /// Retrieves the TimestampMs field
-        /// Units: ms
-        /// Comment: Millisecond resolution of the timestamp</summary>
-        /// <returns>Returns nullable ushort representing the TimestampMs field</returns>
-        public ushort? GetTimestampMs()
-        {
-            Object val = GetFieldValue(0, 0, Fit.SubfieldIndexMainField);
-            if(val == null)
-            {
-                return null;
-            }
+			}
+			set
+			{
+				SetFieldValue(253, 0, value.GetTimeStamp(), Fit.SubfieldIndexMainField);
+			}
+		}
 
-            return (Convert.ToUInt16(val));
-            
-        }
+		///<summary>
+		/// Retrieves the TimestampMs field
+		/// Units: ms
+		/// Comment: Millisecond resolution of the timestamp</summary>
+		/// <returns>Returns nullable ushort representing the TimestampMs field</returns>
+		public ushort? TimestampMs
+		{
+			get
+			{
+				Object val = GetFieldValue(0, 0, Fit.SubfieldIndexMainField);
+				if (val == null)
+				{
+					return null;
+				}
 
-        /// <summary>
-        /// Set TimestampMs field
-        /// Units: ms
-        /// Comment: Millisecond resolution of the timestamp</summary>
-        /// <param name="timestampMs_">Nullable field value to be set</param>
-        public void SetTimestampMs(ushort? timestampMs_)
-        {
-            SetFieldValue(0, 0, timestampMs_, Fit.SubfieldIndexMainField);
-        }
-        
-        ///<summary>
-        /// Retrieves the SamplingInterval field
-        /// Units: ms
-        /// Comment: Sampling Interval in Milliseconds</summary>
-        /// <returns>Returns nullable ushort representing the SamplingInterval field</returns>
-        public ushort? GetSamplingInterval()
-        {
-            Object val = GetFieldValue(1, 0, Fit.SubfieldIndexMainField);
-            if(val == null)
-            {
-                return null;
-            }
+				return (Convert.ToUInt16(val));
 
-            return (Convert.ToUInt16(val));
-            
-        }
+			}
+			set
+			{
+				SetFieldValue(0, 0, value, Fit.SubfieldIndexMainField);
+			}
+		}
 
-        /// <summary>
-        /// Set SamplingInterval field
-        /// Units: ms
-        /// Comment: Sampling Interval in Milliseconds</summary>
-        /// <param name="samplingInterval_">Nullable field value to be set</param>
-        public void SetSamplingInterval(ushort? samplingInterval_)
-        {
-            SetFieldValue(1, 0, samplingInterval_, Fit.SubfieldIndexMainField);
-        }
-        
-        
-        /// <summary>
-        ///
-        /// </summary>
-        /// <returns>returns number of elements in field AccelX</returns>
-        public int GetNumAccelX()
-        {
-            return GetNumFieldValues(2, Fit.SubfieldIndexMainField);
-        }
+		///<summary>
+		/// Retrieves the SamplingInterval field
+		/// Units: ms
+		/// Comment: Sampling Interval in Milliseconds</summary>
+		/// <returns>Returns nullable ushort representing the SamplingInterval field</returns>
+		public ushort? SamplingInterval
+		{
+			get
+			{
+				Object val = GetFieldValue(1, 0, Fit.SubfieldIndexMainField);
+				if (val == null)
+				{
+					return null;
+				}
 
-        ///<summary>
-        /// Retrieves the AccelX field
-        /// Units: mG
-        /// Comment: X-Axis Measurement</summary>
-        /// <param name="index">0 based index of AccelX element to retrieve</param>
-        /// <returns>Returns nullable float representing the AccelX field</returns>
-        public float? GetAccelX(int index)
-        {
-            Object val = GetFieldValue(2, index, Fit.SubfieldIndexMainField);
-            if(val == null)
-            {
-                return null;
-            }
+				return (Convert.ToUInt16(val));
 
-            return (Convert.ToSingle(val));
-            
-        }
+			}
+			set
+			{
+				SetFieldValue(1, 0, value, Fit.SubfieldIndexMainField);
+			}
+		}
 
-        /// <summary>
-        /// Set AccelX field
-        /// Units: mG
-        /// Comment: X-Axis Measurement</summary>
-        /// <param name="index">0 based index of accel_x</param>
-        /// <param name="accelX_">Nullable field value to be set</param>
-        public void SetAccelX(int index, float? accelX_)
-        {
-            SetFieldValue(2, index, accelX_, Fit.SubfieldIndexMainField);
-        }
-        
-        
-        /// <summary>
-        ///
-        /// </summary>
-        /// <returns>returns number of elements in field AccelY</returns>
-        public int GetNumAccelY()
-        {
-            return GetNumFieldValues(3, Fit.SubfieldIndexMainField);
-        }
 
-        ///<summary>
-        /// Retrieves the AccelY field
-        /// Units: mG
-        /// Comment: Y-Axis Measurement</summary>
-        /// <param name="index">0 based index of AccelY element to retrieve</param>
-        /// <returns>Returns nullable float representing the AccelY field</returns>
-        public float? GetAccelY(int index)
-        {
-            Object val = GetFieldValue(3, index, Fit.SubfieldIndexMainField);
-            if(val == null)
-            {
-                return null;
-            }
+		/// <summary>
+		///
+		/// </summary>
+		/// <returns>returns number of elements in field AccelX</returns>
+		public int GetNumAccelX()
+		{
+			return GetNumFieldValues(2, Fit.SubfieldIndexMainField);
+		}
 
-            return (Convert.ToSingle(val));
-            
-        }
+		///<summary>
+		/// Retrieves the AccelX field
+		/// Units: mG
+		/// Comment: X-Axis Measurement</summary>
+		/// <param name="index">0 based index of AccelX element to retrieve</param>
+		/// <returns>Returns nullable float representing the AccelX field</returns>
+		public float? GetAccelX(int index)
+		{
+			Object val = GetFieldValue(2, index, Fit.SubfieldIndexMainField);
+			if (val == null)
+			{
+				return null;
+			}
 
-        /// <summary>
-        /// Set AccelY field
-        /// Units: mG
-        /// Comment: Y-Axis Measurement</summary>
-        /// <param name="index">0 based index of accel_y</param>
-        /// <param name="accelY_">Nullable field value to be set</param>
-        public void SetAccelY(int index, float? accelY_)
-        {
-            SetFieldValue(3, index, accelY_, Fit.SubfieldIndexMainField);
-        }
-        
-        
-        /// <summary>
-        ///
-        /// </summary>
-        /// <returns>returns number of elements in field AccelZ</returns>
-        public int GetNumAccelZ()
-        {
-            return GetNumFieldValues(4, Fit.SubfieldIndexMainField);
-        }
+			return (Convert.ToSingle(val));
 
-        ///<summary>
-        /// Retrieves the AccelZ field
-        /// Units: mG
-        /// Comment: Z-Axis Measurement</summary>
-        /// <param name="index">0 based index of AccelZ element to retrieve</param>
-        /// <returns>Returns nullable float representing the AccelZ field</returns>
-        public float? GetAccelZ(int index)
-        {
-            Object val = GetFieldValue(4, index, Fit.SubfieldIndexMainField);
-            if(val == null)
-            {
-                return null;
-            }
+		}
 
-            return (Convert.ToSingle(val));
-            
-        }
+		/// <summary>
+		/// Set AccelX field
+		/// Units: mG
+		/// Comment: X-Axis Measurement</summary>
+		/// <param name="index">0 based index of accel_x</param>
+		/// <param name="accelX_">Nullable field value to be set</param>
+		public void SetAccelX(int index, float? accelX_)
+		{
+			SetFieldValue(2, index, accelX_, Fit.SubfieldIndexMainField);
+		}
 
-        /// <summary>
-        /// Set AccelZ field
-        /// Units: mG
-        /// Comment: Z-Axis Measurement</summary>
-        /// <param name="index">0 based index of accel_z</param>
-        /// <param name="accelZ_">Nullable field value to be set</param>
-        public void SetAccelZ(int index, float? accelZ_)
-        {
-            SetFieldValue(4, index, accelZ_, Fit.SubfieldIndexMainField);
-        }
-        
-        ///<summary>
-        /// Retrieves the Timestamp32k field
-        /// Comment: 32 kHz timestamp</summary>
-        /// <returns>Returns nullable uint representing the Timestamp32k field</returns>
-        public uint? GetTimestamp32k()
-        {
-            Object val = GetFieldValue(5, 0, Fit.SubfieldIndexMainField);
-            if(val == null)
-            {
-                return null;
-            }
 
-            return (Convert.ToUInt32(val));
-            
-        }
+		/// <summary>
+		///
+		/// </summary>
+		/// <returns>returns number of elements in field AccelY</returns>
+		public int GetNumAccelY()
+		{
+			return GetNumFieldValues(3, Fit.SubfieldIndexMainField);
+		}
 
-        /// <summary>
-        /// Set Timestamp32k field
-        /// Comment: 32 kHz timestamp</summary>
-        /// <param name="timestamp32k_">Nullable field value to be set</param>
-        public void SetTimestamp32k(uint? timestamp32k_)
-        {
-            SetFieldValue(5, 0, timestamp32k_, Fit.SubfieldIndexMainField);
-        }
-        
-        #endregion // Methods
-    } // Class
+		///<summary>
+		/// Retrieves the AccelY field
+		/// Units: mG
+		/// Comment: Y-Axis Measurement</summary>
+		/// <param name="index">0 based index of AccelY element to retrieve</param>
+		/// <returns>Returns nullable float representing the AccelY field</returns>
+		public float? GetAccelY(int index)
+		{
+			Object val = GetFieldValue(3, index, Fit.SubfieldIndexMainField);
+			if (val == null)
+			{
+				return null;
+			}
+
+			return (Convert.ToSingle(val));
+
+		}
+
+		/// <summary>
+		/// Set AccelY field
+		/// Units: mG
+		/// Comment: Y-Axis Measurement</summary>
+		/// <param name="index">0 based index of accel_y</param>
+		/// <param name="accelY_">Nullable field value to be set</param>
+		public void SetAccelY(int index, float? accelY_)
+		{
+			SetFieldValue(3, index, accelY_, Fit.SubfieldIndexMainField);
+		}
+
+
+		/// <summary>
+		///
+		/// </summary>
+		/// <returns>returns number of elements in field AccelZ</returns>
+		public int GetNumAccelZ()
+		{
+			return GetNumFieldValues(4, Fit.SubfieldIndexMainField);
+		}
+
+		///<summary>
+		/// Retrieves the AccelZ field
+		/// Units: mG
+		/// Comment: Z-Axis Measurement</summary>
+		/// <param name="index">0 based index of AccelZ element to retrieve</param>
+		/// <returns>Returns nullable float representing the AccelZ field</returns>
+		public float? GetAccelZ(int index)
+		{
+			Object val = GetFieldValue(4, index, Fit.SubfieldIndexMainField);
+			if (val == null)
+			{
+				return null;
+			}
+
+			return (Convert.ToSingle(val));
+
+		}
+
+		/// <summary>
+		/// Set AccelZ field
+		/// Units: mG
+		/// Comment: Z-Axis Measurement</summary>
+		/// <param name="index">0 based index of accel_z</param>
+		/// <param name="accelZ_">Nullable field value to be set</param>
+		public void SetAccelZ(int index, float? accelZ_)
+		{
+			SetFieldValue(4, index, accelZ_, Fit.SubfieldIndexMainField);
+		}
+
+		///<summary>
+		/// Retrieves the Timestamp32k field
+		/// Comment: 32 kHz timestamp</summary>
+		/// <returns>Returns nullable uint representing the Timestamp32k field</returns>
+		public uint? Timestamp32k
+		{
+			get
+			{
+				Object val = GetFieldValue(5, 0, Fit.SubfieldIndexMainField);
+				if (val == null)
+				{
+					return null;
+				}
+
+				return (Convert.ToUInt32(val));
+
+			}
+			set
+			{
+				SetFieldValue(5, 0, value, Fit.SubfieldIndexMainField);
+			}
+		}
+
+		#endregion // Methods
+	} // Class
 } // namespace

--- a/Dynastream/Fit/Profile/Mesgs/HsaBodyBatteryDataMesg.cs
+++ b/Dynastream/Fit/Profile/Mesgs/HsaBodyBatteryDataMesg.cs
@@ -21,203 +21,198 @@ using System.Linq;
 
 namespace Dynastream.Fit
 {
-    /// <summary>
-    /// Implements the HsaBodyBatteryData profile message.
-    /// </summary>
-    public class HsaBodyBatteryDataMesg : Mesg
-    {
-        #region Fields
-        #endregion
+	/// <summary>
+	/// Implements the HsaBodyBatteryData profile message.
+	/// </summary>
+	public class HsaBodyBatteryDataMesg : Mesg
+	{
+		#region Fields
+		#endregion
 
-        /// <summary>
-        /// Field Numbers for <see cref="HsaBodyBatteryDataMesg"/>
-        /// </summary>
-        public sealed class FieldDefNum
-        {
-            public const byte Timestamp = 253;
-            public const byte ProcessingInterval = 0;
-            public const byte Level = 1;
-            public const byte Charged = 2;
-            public const byte Uncharged = 3;
-            public const byte Invalid = Fit.FieldNumInvalid;
-        }
+		/// <summary>
+		/// Field Numbers for <see cref="HsaBodyBatteryDataMesg"/>
+		/// </summary>
+		public sealed class FieldDefNum
+		{
+			public const byte Timestamp = 253;
+			public const byte ProcessingInterval = 0;
+			public const byte Level = 1;
+			public const byte Charged = 2;
+			public const byte Uncharged = 3;
+			public const byte Invalid = Fit.FieldNumInvalid;
+		}
 
-        #region Constructors
-        public HsaBodyBatteryDataMesg() : base(Profile.GetMesg(MesgNum.HsaBodyBatteryData))
-        {
-        }
+		#region Constructors
+		public HsaBodyBatteryDataMesg() : base(Profile.GetMesg(MesgNum.HsaBodyBatteryData))
+		{
+		}
 
-        public HsaBodyBatteryDataMesg(Mesg mesg) : base(mesg)
-        {
-        }
-        #endregion // Constructors
+		public HsaBodyBatteryDataMesg(Mesg mesg) : base(mesg)
+		{
+		}
+		#endregion // Constructors
 
-        #region Methods
-        ///<summary>
-        /// Retrieves the Timestamp field
-        /// Units: s</summary>
-        /// <returns>Returns DateTime representing the Timestamp field</returns>
-        public DateTime GetTimestamp()
-        {
-            Object val = GetFieldValue(253, 0, Fit.SubfieldIndexMainField);
-            if(val == null)
-            {
-                return null;
-            }
+		#region Methods
+		///<summary>
+		/// Retrieves the Timestamp field
+		/// Units: s</summary>
+		/// <returns>Returns DateTime representing the Timestamp field</returns>
+		public DateTime Timestamp
+		{
+			get
+			{
+				Object val = GetFieldValue(253, 0, Fit.SubfieldIndexMainField);
+				if (val == null)
+				{
+					return null;
+				}
 
-            return TimestampToDateTime(Convert.ToUInt32(val));
-            
-        }
+				return TimestampToDateTime(Convert.ToUInt32(val));
 
-        /// <summary>
-        /// Set Timestamp field
-        /// Units: s</summary>
-        /// <param name="timestamp_">Nullable field value to be set</param>
-        public void SetTimestamp(DateTime timestamp_)
-        {
-            SetFieldValue(253, 0, timestamp_.GetTimeStamp(), Fit.SubfieldIndexMainField);
-        }
-        
-        ///<summary>
-        /// Retrieves the ProcessingInterval field
-        /// Units: s
-        /// Comment: Processing interval length in seconds</summary>
-        /// <returns>Returns nullable ushort representing the ProcessingInterval field</returns>
-        public ushort? GetProcessingInterval()
-        {
-            Object val = GetFieldValue(0, 0, Fit.SubfieldIndexMainField);
-            if(val == null)
-            {
-                return null;
-            }
+			}
+			set
+			{
+				SetFieldValue(253, 0, value.GetTimeStamp(), Fit.SubfieldIndexMainField);
+			}
+		}
 
-            return (Convert.ToUInt16(val));
-            
-        }
+		///<summary>
+		/// Retrieves the ProcessingInterval field
+		/// Units: s
+		/// Comment: Processing interval length in seconds</summary>
+		/// <returns>Returns nullable ushort representing the ProcessingInterval field</returns>
+		public ushort? ProcessingInterval
+		{
+			get
+			{
+				Object val = GetFieldValue(0, 0, Fit.SubfieldIndexMainField);
+				if (val == null)
+				{
+					return null;
+				}
 
-        /// <summary>
-        /// Set ProcessingInterval field
-        /// Units: s
-        /// Comment: Processing interval length in seconds</summary>
-        /// <param name="processingInterval_">Nullable field value to be set</param>
-        public void SetProcessingInterval(ushort? processingInterval_)
-        {
-            SetFieldValue(0, 0, processingInterval_, Fit.SubfieldIndexMainField);
-        }
-        
-        
-        /// <summary>
-        ///
-        /// </summary>
-        /// <returns>returns number of elements in field Level</returns>
-        public int GetNumLevel()
-        {
-            return GetNumFieldValues(1, Fit.SubfieldIndexMainField);
-        }
+				return (Convert.ToUInt16(val));
 
-        ///<summary>
-        /// Retrieves the Level field
-        /// Units: percent
-        /// Comment: Body battery level: [0,100] Blank: -16</summary>
-        /// <param name="index">0 based index of Level element to retrieve</param>
-        /// <returns>Returns nullable sbyte representing the Level field</returns>
-        public sbyte? GetLevel(int index)
-        {
-            Object val = GetFieldValue(1, index, Fit.SubfieldIndexMainField);
-            if(val == null)
-            {
-                return null;
-            }
+			}
+			set
+			{
+				SetFieldValue(0, 0, value, Fit.SubfieldIndexMainField);
+			}
+		}
 
-            return (Convert.ToSByte(val));
-            
-        }
 
-        /// <summary>
-        /// Set Level field
-        /// Units: percent
-        /// Comment: Body battery level: [0,100] Blank: -16</summary>
-        /// <param name="index">0 based index of level</param>
-        /// <param name="level_">Nullable field value to be set</param>
-        public void SetLevel(int index, sbyte? level_)
-        {
-            SetFieldValue(1, index, level_, Fit.SubfieldIndexMainField);
-        }
-        
-        
-        /// <summary>
-        ///
-        /// </summary>
-        /// <returns>returns number of elements in field Charged</returns>
-        public int GetNumCharged()
-        {
-            return GetNumFieldValues(2, Fit.SubfieldIndexMainField);
-        }
+		/// <summary>
+		///
+		/// </summary>
+		/// <returns>returns number of elements in field Level</returns>
+		public int GetNumLevel()
+		{
+			return GetNumFieldValues(1, Fit.SubfieldIndexMainField);
+		}
 
-        ///<summary>
-        /// Retrieves the Charged field
-        /// Comment: Body battery charged value</summary>
-        /// <param name="index">0 based index of Charged element to retrieve</param>
-        /// <returns>Returns nullable short representing the Charged field</returns>
-        public short? GetCharged(int index)
-        {
-            Object val = GetFieldValue(2, index, Fit.SubfieldIndexMainField);
-            if(val == null)
-            {
-                return null;
-            }
+		///<summary>
+		/// Retrieves the Level field
+		/// Units: percent
+		/// Comment: Body battery level: [0,100] Blank: -16</summary>
+		/// <param name="index">0 based index of Level element to retrieve</param>
+		/// <returns>Returns nullable sbyte representing the Level field</returns>
+		public sbyte? GetLevel(int index)
+		{
+			Object val = GetFieldValue(1, index, Fit.SubfieldIndexMainField);
+			if (val == null)
+			{
+				return null;
+			}
 
-            return (Convert.ToInt16(val));
-            
-        }
+			return (Convert.ToSByte(val));
 
-        /// <summary>
-        /// Set Charged field
-        /// Comment: Body battery charged value</summary>
-        /// <param name="index">0 based index of charged</param>
-        /// <param name="charged_">Nullable field value to be set</param>
-        public void SetCharged(int index, short? charged_)
-        {
-            SetFieldValue(2, index, charged_, Fit.SubfieldIndexMainField);
-        }
-        
-        
-        /// <summary>
-        ///
-        /// </summary>
-        /// <returns>returns number of elements in field Uncharged</returns>
-        public int GetNumUncharged()
-        {
-            return GetNumFieldValues(3, Fit.SubfieldIndexMainField);
-        }
+		}
 
-        ///<summary>
-        /// Retrieves the Uncharged field
-        /// Comment: Body battery uncharged value</summary>
-        /// <param name="index">0 based index of Uncharged element to retrieve</param>
-        /// <returns>Returns nullable short representing the Uncharged field</returns>
-        public short? GetUncharged(int index)
-        {
-            Object val = GetFieldValue(3, index, Fit.SubfieldIndexMainField);
-            if(val == null)
-            {
-                return null;
-            }
+		/// <summary>
+		/// Set Level field
+		/// Units: percent
+		/// Comment: Body battery level: [0,100] Blank: -16</summary>
+		/// <param name="index">0 based index of level</param>
+		/// <param name="level_">Nullable field value to be set</param>
+		public void SetLevel(int index, sbyte? level_)
+		{
+			SetFieldValue(1, index, level_, Fit.SubfieldIndexMainField);
+		}
 
-            return (Convert.ToInt16(val));
-            
-        }
 
-        /// <summary>
-        /// Set Uncharged field
-        /// Comment: Body battery uncharged value</summary>
-        /// <param name="index">0 based index of uncharged</param>
-        /// <param name="uncharged_">Nullable field value to be set</param>
-        public void SetUncharged(int index, short? uncharged_)
-        {
-            SetFieldValue(3, index, uncharged_, Fit.SubfieldIndexMainField);
-        }
-        
-        #endregion // Methods
-    } // Class
+		/// <summary>
+		///
+		/// </summary>
+		/// <returns>returns number of elements in field Charged</returns>
+		public int GetNumCharged()
+		{
+			return GetNumFieldValues(2, Fit.SubfieldIndexMainField);
+		}
+
+		///<summary>
+		/// Retrieves the Charged field
+		/// Comment: Body battery charged value</summary>
+		/// <param name="index">0 based index of Charged element to retrieve</param>
+		/// <returns>Returns nullable short representing the Charged field</returns>
+		public short? GetCharged(int index)
+		{
+			Object val = GetFieldValue(2, index, Fit.SubfieldIndexMainField);
+			if (val == null)
+			{
+				return null;
+			}
+
+			return (Convert.ToInt16(val));
+
+		}
+
+		/// <summary>
+		/// Set Charged field
+		/// Comment: Body battery charged value</summary>
+		/// <param name="index">0 based index of charged</param>
+		/// <param name="charged_">Nullable field value to be set</param>
+		public void SetCharged(int index, short? charged_)
+		{
+			SetFieldValue(2, index, charged_, Fit.SubfieldIndexMainField);
+		}
+
+
+		/// <summary>
+		///
+		/// </summary>
+		/// <returns>returns number of elements in field Uncharged</returns>
+		public int GetNumUncharged()
+		{
+			return GetNumFieldValues(3, Fit.SubfieldIndexMainField);
+		}
+
+		///<summary>
+		/// Retrieves the Uncharged field
+		/// Comment: Body battery uncharged value</summary>
+		/// <param name="index">0 based index of Uncharged element to retrieve</param>
+		/// <returns>Returns nullable short representing the Uncharged field</returns>
+		public short? GetUncharged(int index)
+		{
+			Object val = GetFieldValue(3, index, Fit.SubfieldIndexMainField);
+			if (val == null)
+			{
+				return null;
+			}
+
+			return (Convert.ToInt16(val));
+
+		}
+
+		/// <summary>
+		/// Set Uncharged field
+		/// Comment: Body battery uncharged value</summary>
+		/// <param name="index">0 based index of uncharged</param>
+		/// <param name="uncharged_">Nullable field value to be set</param>
+		public void SetUncharged(int index, short? uncharged_)
+		{
+			SetFieldValue(3, index, uncharged_, Fit.SubfieldIndexMainField);
+		}
+
+		#endregion // Methods
+	} // Class
 } // namespace

--- a/Dynastream/Fit/Profile/Mesgs/HsaConfigurationDataMesg.cs
+++ b/Dynastream/Fit/Profile/Mesgs/HsaConfigurationDataMesg.cs
@@ -21,125 +21,120 @@ using System.Linq;
 
 namespace Dynastream.Fit
 {
-    /// <summary>
-    /// Implements the HsaConfigurationData profile message.
-    /// </summary>
-    public class HsaConfigurationDataMesg : Mesg
-    {
-        #region Fields
-        #endregion
+	/// <summary>
+	/// Implements the HsaConfigurationData profile message.
+	/// </summary>
+	public class HsaConfigurationDataMesg : Mesg
+	{
+		#region Fields
+		#endregion
 
-        /// <summary>
-        /// Field Numbers for <see cref="HsaConfigurationDataMesg"/>
-        /// </summary>
-        public sealed class FieldDefNum
-        {
-            public const byte Timestamp = 253;
-            public const byte Data = 0;
-            public const byte DataSize = 1;
-            public const byte Invalid = Fit.FieldNumInvalid;
-        }
+		/// <summary>
+		/// Field Numbers for <see cref="HsaConfigurationDataMesg"/>
+		/// </summary>
+		public sealed class FieldDefNum
+		{
+			public const byte Timestamp = 253;
+			public const byte Data = 0;
+			public const byte DataSize = 1;
+			public const byte Invalid = Fit.FieldNumInvalid;
+		}
 
-        #region Constructors
-        public HsaConfigurationDataMesg() : base(Profile.GetMesg(MesgNum.HsaConfigurationData))
-        {
-        }
+		#region Constructors
+		public HsaConfigurationDataMesg() : base(Profile.GetMesg(MesgNum.HsaConfigurationData))
+		{
+		}
 
-        public HsaConfigurationDataMesg(Mesg mesg) : base(mesg)
-        {
-        }
-        #endregion // Constructors
+		public HsaConfigurationDataMesg(Mesg mesg) : base(mesg)
+		{
+		}
+		#endregion // Constructors
 
-        #region Methods
-        ///<summary>
-        /// Retrieves the Timestamp field
-        /// Units: s
-        /// Comment: Encoded configuration data</summary>
-        /// <returns>Returns DateTime representing the Timestamp field</returns>
-        public DateTime GetTimestamp()
-        {
-            Object val = GetFieldValue(253, 0, Fit.SubfieldIndexMainField);
-            if(val == null)
-            {
-                return null;
-            }
+		#region Methods
+		///<summary>
+		/// Retrieves the Timestamp field
+		/// Units: s
+		/// Comment: Encoded configuration data</summary>
+		/// <returns>Returns DateTime representing the Timestamp field</returns>
+		public DateTime Timestamp
+		{
+			get
+			{
+				Object val = GetFieldValue(253, 0, Fit.SubfieldIndexMainField);
+				if (val == null)
+				{
+					return null;
+				}
 
-            return TimestampToDateTime(Convert.ToUInt32(val));
-            
-        }
+				return TimestampToDateTime(Convert.ToUInt32(val));
 
-        /// <summary>
-        /// Set Timestamp field
-        /// Units: s
-        /// Comment: Encoded configuration data</summary>
-        /// <param name="timestamp_">Nullable field value to be set</param>
-        public void SetTimestamp(DateTime timestamp_)
-        {
-            SetFieldValue(253, 0, timestamp_.GetTimeStamp(), Fit.SubfieldIndexMainField);
-        }
-        
-        
-        /// <summary>
-        ///
-        /// </summary>
-        /// <returns>returns number of elements in field Data</returns>
-        public int GetNumData()
-        {
-            return GetNumFieldValues(0, Fit.SubfieldIndexMainField);
-        }
+			}
+			set
+			{
+				SetFieldValue(253, 0, value.GetTimeStamp(), Fit.SubfieldIndexMainField);
+			}
+		}
 
-        ///<summary>
-        /// Retrieves the Data field
-        /// Comment: Encoded configuration data. Health SDK use only</summary>
-        /// <param name="index">0 based index of Data element to retrieve</param>
-        /// <returns>Returns nullable byte representing the Data field</returns>
-        public byte? GetData(int index)
-        {
-            Object val = GetFieldValue(0, index, Fit.SubfieldIndexMainField);
-            if(val == null)
-            {
-                return null;
-            }
 
-            return (Convert.ToByte(val));
-            
-        }
+		/// <summary>
+		///
+		/// </summary>
+		/// <returns>returns number of elements in field Data</returns>
+		public int GetNumData()
+		{
+			return GetNumFieldValues(0, Fit.SubfieldIndexMainField);
+		}
 
-        /// <summary>
-        /// Set Data field
-        /// Comment: Encoded configuration data. Health SDK use only</summary>
-        /// <param name="index">0 based index of data</param>
-        /// <param name="data_">Nullable field value to be set</param>
-        public void SetData(int index, byte? data_)
-        {
-            SetFieldValue(0, index, data_, Fit.SubfieldIndexMainField);
-        }
-        
-        ///<summary>
-        /// Retrieves the DataSize field
-        /// Comment: Size in bytes of data field</summary>
-        /// <returns>Returns nullable byte representing the DataSize field</returns>
-        public byte? GetDataSize()
-        {
-            Object val = GetFieldValue(1, 0, Fit.SubfieldIndexMainField);
-            if(val == null)
-            {
-                return null;
-            }
+		///<summary>
+		/// Retrieves the Data field
+		/// Comment: Encoded configuration data. Health SDK use only</summary>
+		/// <param name="index">0 based index of Data element to retrieve</param>
+		/// <returns>Returns nullable byte representing the Data field</returns>
+		public byte? GetData(int index)
+		{
+			Object val = GetFieldValue(0, index, Fit.SubfieldIndexMainField);
+			if (val == null)
+			{
+				return null;
+			}
 
-            return (Convert.ToByte(val));
-            
-        }
+			return (Convert.ToByte(val));
 
-        /// <summary>
-        /// Set DataSize field
-        /// Comment: Size in bytes of data field</summary>
-        /// <param name="dataSize_">Nullable field value to be set</param>
-        public void SetDataSize(byte? dataSize_)
-        {
-            SetFieldValue(1, 0, dataSize_, Fit.SubfieldIndexMainField);
-        }
-        
-        #endregion // Methods
-    } // Class
+		}
+
+		/// <summary>
+		/// Set Data field
+		/// Comment: Encoded configuration data. Health SDK use only</summary>
+		/// <param name="index">0 based index of data</param>
+		/// <param name="data_">Nullable field value to be set</param>
+		public void SetData(int index, byte? data_)
+		{
+			SetFieldValue(0, index, data_, Fit.SubfieldIndexMainField);
+		}
+
+		///<summary>
+		/// Retrieves the DataSize field
+		/// Comment: Size in bytes of data field</summary>
+		/// <returns>Returns nullable byte representing the DataSize field</returns>
+		public byte? DataSize
+		{
+			get
+			{
+				Object val = GetFieldValue(1, 0, Fit.SubfieldIndexMainField);
+				if (val == null)
+				{
+					return null;
+				}
+
+				return (Convert.ToByte(val));
+
+			}
+			set
+			{
+				SetFieldValue(1, 0, value, Fit.SubfieldIndexMainField);
+			}
+		}
+
+		#endregion // Methods
+	} // Class
 } // namespace

--- a/Dynastream/Fit/Profile/Mesgs/HsaEventMesg.cs
+++ b/Dynastream/Fit/Profile/Mesgs/HsaEventMesg.cs
@@ -21,85 +21,81 @@ using System.Linq;
 
 namespace Dynastream.Fit
 {
-    /// <summary>
-    /// Implements the HsaEvent profile message.
-    /// </summary>
-    public class HsaEventMesg : Mesg
-    {
-        #region Fields
-        #endregion
+	/// <summary>
+	/// Implements the HsaEvent profile message.
+	/// </summary>
+	public class HsaEventMesg : Mesg
+	{
+		#region Fields
+		#endregion
 
-        /// <summary>
-        /// Field Numbers for <see cref="HsaEventMesg"/>
-        /// </summary>
-        public sealed class FieldDefNum
-        {
-            public const byte Timestamp = 253;
-            public const byte EventId = 0;
-            public const byte Invalid = Fit.FieldNumInvalid;
-        }
+		/// <summary>
+		/// Field Numbers for <see cref="HsaEventMesg"/>
+		/// </summary>
+		public sealed class FieldDefNum
+		{
+			public const byte Timestamp = 253;
+			public const byte EventId = 0;
+			public const byte Invalid = Fit.FieldNumInvalid;
+		}
 
-        #region Constructors
-        public HsaEventMesg() : base(Profile.GetMesg(MesgNum.HsaEvent))
-        {
-        }
+		#region Constructors
+		public HsaEventMesg() : base(Profile.GetMesg(MesgNum.HsaEvent))
+		{
+		}
 
-        public HsaEventMesg(Mesg mesg) : base(mesg)
-        {
-        }
-        #endregion // Constructors
+		public HsaEventMesg(Mesg mesg) : base(mesg)
+		{
+		}
+		#endregion // Constructors
 
-        #region Methods
-        ///<summary>
-        /// Retrieves the Timestamp field
-        /// Units: s</summary>
-        /// <returns>Returns DateTime representing the Timestamp field</returns>
-        public DateTime GetTimestamp()
-        {
-            Object val = GetFieldValue(253, 0, Fit.SubfieldIndexMainField);
-            if(val == null)
-            {
-                return null;
-            }
+		#region Methods
+		///<summary>
+		/// Retrieves the Timestamp field
+		/// Units: s</summary>
+		/// <returns>Returns DateTime representing the Timestamp field</returns>
+		public DateTime Timestamp
+		{
+			get
+			{
+				Object val = GetFieldValue(253, 0, Fit.SubfieldIndexMainField);
+				if (val == null)
+				{
+					return null;
+				}
 
-            return TimestampToDateTime(Convert.ToUInt32(val));
-            
-        }
+				return TimestampToDateTime(Convert.ToUInt32(val));
 
-        /// <summary>
-        /// Set Timestamp field
-        /// Units: s</summary>
-        /// <param name="timestamp_">Nullable field value to be set</param>
-        public void SetTimestamp(DateTime timestamp_)
-        {
-            SetFieldValue(253, 0, timestamp_.GetTimeStamp(), Fit.SubfieldIndexMainField);
-        }
-        
-        ///<summary>
-        /// Retrieves the EventId field
-        /// Comment: Event ID. Health SDK use only</summary>
-        /// <returns>Returns nullable byte representing the EventId field</returns>
-        public byte? GetEventId()
-        {
-            Object val = GetFieldValue(0, 0, Fit.SubfieldIndexMainField);
-            if(val == null)
-            {
-                return null;
-            }
+			}
+			set
+			{
+				SetFieldValue(253, 0, value.GetTimeStamp(), Fit.SubfieldIndexMainField);
+			}
+		}
 
-            return (Convert.ToByte(val));
-            
-        }
+		///<summary>
+		/// Retrieves the EventId field
+		/// Comment: Event ID. Health SDK use only</summary>
+		/// <returns>Returns nullable byte representing the EventId field</returns>
+		public byte? EventId
+		{
+			get
+			{
+				Object val = GetFieldValue(0, 0, Fit.SubfieldIndexMainField);
+				if (val == null)
+				{
+					return null;
+				}
 
-        /// <summary>
-        /// Set EventId field
-        /// Comment: Event ID. Health SDK use only</summary>
-        /// <param name="eventId_">Nullable field value to be set</param>
-        public void SetEventId(byte? eventId_)
-        {
-            SetFieldValue(0, 0, eventId_, Fit.SubfieldIndexMainField);
-        }
-        
-        #endregion // Methods
-    } // Class
+				return (Convert.ToByte(val));
+
+			}
+			set
+			{
+				SetFieldValue(0, 0, value, Fit.SubfieldIndexMainField);
+			}
+		}
+
+		#endregion // Methods
+	} // Class
 } // namespace

--- a/Dynastream/Fit/Profile/Mesgs/HsaGyroscopeDataMesg.cs
+++ b/Dynastream/Fit/Profile/Mesgs/HsaGyroscopeDataMesg.cs
@@ -21,263 +21,252 @@ using System.Linq;
 
 namespace Dynastream.Fit
 {
-    /// <summary>
-    /// Implements the HsaGyroscopeData profile message.
-    /// </summary>
-    public class HsaGyroscopeDataMesg : Mesg
-    {
-        #region Fields
-        #endregion
+	/// <summary>
+	/// Implements the HsaGyroscopeData profile message.
+	/// </summary>
+	public class HsaGyroscopeDataMesg : Mesg
+	{
+		#region Fields
+		#endregion
 
-        /// <summary>
-        /// Field Numbers for <see cref="HsaGyroscopeDataMesg"/>
-        /// </summary>
-        public sealed class FieldDefNum
-        {
-            public const byte Timestamp = 253;
-            public const byte TimestampMs = 0;
-            public const byte SamplingInterval = 1;
-            public const byte GyroX = 2;
-            public const byte GyroY = 3;
-            public const byte GyroZ = 4;
-            public const byte Timestamp32k = 5;
-            public const byte Invalid = Fit.FieldNumInvalid;
-        }
+		/// <summary>
+		/// Field Numbers for <see cref="HsaGyroscopeDataMesg"/>
+		/// </summary>
+		public sealed class FieldDefNum
+		{
+			public const byte Timestamp = 253;
+			public const byte TimestampMs = 0;
+			public const byte SamplingInterval = 1;
+			public const byte GyroX = 2;
+			public const byte GyroY = 3;
+			public const byte GyroZ = 4;
+			public const byte Timestamp32k = 5;
+			public const byte Invalid = Fit.FieldNumInvalid;
+		}
 
-        #region Constructors
-        public HsaGyroscopeDataMesg() : base(Profile.GetMesg(MesgNum.HsaGyroscopeData))
-        {
-        }
+		#region Constructors
+		public HsaGyroscopeDataMesg() : base(Profile.GetMesg(MesgNum.HsaGyroscopeData))
+		{
+		}
 
-        public HsaGyroscopeDataMesg(Mesg mesg) : base(mesg)
-        {
-        }
-        #endregion // Constructors
+		public HsaGyroscopeDataMesg(Mesg mesg) : base(mesg)
+		{
+		}
+		#endregion // Constructors
 
-        #region Methods
-        ///<summary>
-        /// Retrieves the Timestamp field
-        /// Units: s</summary>
-        /// <returns>Returns DateTime representing the Timestamp field</returns>
-        public DateTime GetTimestamp()
-        {
-            Object val = GetFieldValue(253, 0, Fit.SubfieldIndexMainField);
-            if(val == null)
-            {
-                return null;
-            }
+		#region Methods
+		///<summary>
+		/// Retrieves the Timestamp field
+		/// Units: s</summary>
+		/// <returns>Returns DateTime representing the Timestamp field</returns>
+		public DateTime Timestamp
+		{
+			get
+			{
+				Object val = GetFieldValue(253, 0, Fit.SubfieldIndexMainField);
+				if (val == null)
+				{
+					return null;
+				}
 
-            return TimestampToDateTime(Convert.ToUInt32(val));
-            
-        }
+				return TimestampToDateTime(Convert.ToUInt32(val));
 
-        /// <summary>
-        /// Set Timestamp field
-        /// Units: s</summary>
-        /// <param name="timestamp_">Nullable field value to be set</param>
-        public void SetTimestamp(DateTime timestamp_)
-        {
-            SetFieldValue(253, 0, timestamp_.GetTimeStamp(), Fit.SubfieldIndexMainField);
-        }
-        
-        ///<summary>
-        /// Retrieves the TimestampMs field
-        /// Units: ms
-        /// Comment: Millisecond resolution of the timestamp</summary>
-        /// <returns>Returns nullable ushort representing the TimestampMs field</returns>
-        public ushort? GetTimestampMs()
-        {
-            Object val = GetFieldValue(0, 0, Fit.SubfieldIndexMainField);
-            if(val == null)
-            {
-                return null;
-            }
+			}
+			set
+			{
+				SetFieldValue(253, 0, value.GetTimeStamp(), Fit.SubfieldIndexMainField);
+			}
+		}
 
-            return (Convert.ToUInt16(val));
-            
-        }
+		///<summary>
+		/// Retrieves the TimestampMs field
+		/// Units: ms
+		/// Comment: Millisecond resolution of the timestamp</summary>
+		/// <returns>Returns nullable ushort representing the TimestampMs field</returns>
+		public ushort? TimestampMs
+		{
+			get
+			{
+				Object val = GetFieldValue(0, 0, Fit.SubfieldIndexMainField);
+				if (val == null)
+				{
+					return null;
+				}
 
-        /// <summary>
-        /// Set TimestampMs field
-        /// Units: ms
-        /// Comment: Millisecond resolution of the timestamp</summary>
-        /// <param name="timestampMs_">Nullable field value to be set</param>
-        public void SetTimestampMs(ushort? timestampMs_)
-        {
-            SetFieldValue(0, 0, timestampMs_, Fit.SubfieldIndexMainField);
-        }
-        
-        ///<summary>
-        /// Retrieves the SamplingInterval field
-        /// Units: 1/32768 s
-        /// Comment: Sampling Interval in 32 kHz timescale</summary>
-        /// <returns>Returns nullable ushort representing the SamplingInterval field</returns>
-        public ushort? GetSamplingInterval()
-        {
-            Object val = GetFieldValue(1, 0, Fit.SubfieldIndexMainField);
-            if(val == null)
-            {
-                return null;
-            }
+				return (Convert.ToUInt16(val));
 
-            return (Convert.ToUInt16(val));
-            
-        }
+			}
+			set
+			{
+				SetFieldValue(0, 0, value, Fit.SubfieldIndexMainField);
+			}
+		}
 
-        /// <summary>
-        /// Set SamplingInterval field
-        /// Units: 1/32768 s
-        /// Comment: Sampling Interval in 32 kHz timescale</summary>
-        /// <param name="samplingInterval_">Nullable field value to be set</param>
-        public void SetSamplingInterval(ushort? samplingInterval_)
-        {
-            SetFieldValue(1, 0, samplingInterval_, Fit.SubfieldIndexMainField);
-        }
-        
-        
-        /// <summary>
-        ///
-        /// </summary>
-        /// <returns>returns number of elements in field GyroX</returns>
-        public int GetNumGyroX()
-        {
-            return GetNumFieldValues(2, Fit.SubfieldIndexMainField);
-        }
+		///<summary>
+		/// Retrieves the SamplingInterval field
+		/// Units: 1/32768 s
+		/// Comment: Sampling Interval in 32 kHz timescale</summary>
+		/// <returns>Returns nullable ushort representing the SamplingInterval field</returns>
+		public ushort? SamplingInterval
+		{
+			get
+			{
+				Object val = GetFieldValue(1, 0, Fit.SubfieldIndexMainField);
+				if (val == null)
+				{
+					return null;
+				}
 
-        ///<summary>
-        /// Retrieves the GyroX field
-        /// Units: deg/s
-        /// Comment: X-Axis Measurement</summary>
-        /// <param name="index">0 based index of GyroX element to retrieve</param>
-        /// <returns>Returns nullable float representing the GyroX field</returns>
-        public float? GetGyroX(int index)
-        {
-            Object val = GetFieldValue(2, index, Fit.SubfieldIndexMainField);
-            if(val == null)
-            {
-                return null;
-            }
+				return (Convert.ToUInt16(val));
 
-            return (Convert.ToSingle(val));
-            
-        }
+			}
+			set
+			{
+				SetFieldValue(1, 0, value, Fit.SubfieldIndexMainField);
+			}
+		}
 
-        /// <summary>
-        /// Set GyroX field
-        /// Units: deg/s
-        /// Comment: X-Axis Measurement</summary>
-        /// <param name="index">0 based index of gyro_x</param>
-        /// <param name="gyroX_">Nullable field value to be set</param>
-        public void SetGyroX(int index, float? gyroX_)
-        {
-            SetFieldValue(2, index, gyroX_, Fit.SubfieldIndexMainField);
-        }
-        
-        
-        /// <summary>
-        ///
-        /// </summary>
-        /// <returns>returns number of elements in field GyroY</returns>
-        public int GetNumGyroY()
-        {
-            return GetNumFieldValues(3, Fit.SubfieldIndexMainField);
-        }
 
-        ///<summary>
-        /// Retrieves the GyroY field
-        /// Units: deg/s
-        /// Comment: Y-Axis Measurement</summary>
-        /// <param name="index">0 based index of GyroY element to retrieve</param>
-        /// <returns>Returns nullable float representing the GyroY field</returns>
-        public float? GetGyroY(int index)
-        {
-            Object val = GetFieldValue(3, index, Fit.SubfieldIndexMainField);
-            if(val == null)
-            {
-                return null;
-            }
+		/// <summary>
+		///
+		/// </summary>
+		/// <returns>returns number of elements in field GyroX</returns>
+		public int GetNumGyroX()
+		{
+			return GetNumFieldValues(2, Fit.SubfieldIndexMainField);
+		}
 
-            return (Convert.ToSingle(val));
-            
-        }
+		///<summary>
+		/// Retrieves the GyroX field
+		/// Units: deg/s
+		/// Comment: X-Axis Measurement</summary>
+		/// <param name="index">0 based index of GyroX element to retrieve</param>
+		/// <returns>Returns nullable float representing the GyroX field</returns>
+		public float? GetGyroX(int index)
+		{
+			Object val = GetFieldValue(2, index, Fit.SubfieldIndexMainField);
+			if (val == null)
+			{
+				return null;
+			}
 
-        /// <summary>
-        /// Set GyroY field
-        /// Units: deg/s
-        /// Comment: Y-Axis Measurement</summary>
-        /// <param name="index">0 based index of gyro_y</param>
-        /// <param name="gyroY_">Nullable field value to be set</param>
-        public void SetGyroY(int index, float? gyroY_)
-        {
-            SetFieldValue(3, index, gyroY_, Fit.SubfieldIndexMainField);
-        }
-        
-        
-        /// <summary>
-        ///
-        /// </summary>
-        /// <returns>returns number of elements in field GyroZ</returns>
-        public int GetNumGyroZ()
-        {
-            return GetNumFieldValues(4, Fit.SubfieldIndexMainField);
-        }
+			return (Convert.ToSingle(val));
 
-        ///<summary>
-        /// Retrieves the GyroZ field
-        /// Units: deg/s
-        /// Comment: Z-Axis Measurement</summary>
-        /// <param name="index">0 based index of GyroZ element to retrieve</param>
-        /// <returns>Returns nullable float representing the GyroZ field</returns>
-        public float? GetGyroZ(int index)
-        {
-            Object val = GetFieldValue(4, index, Fit.SubfieldIndexMainField);
-            if(val == null)
-            {
-                return null;
-            }
+		}
 
-            return (Convert.ToSingle(val));
-            
-        }
+		/// <summary>
+		/// Set GyroX field
+		/// Units: deg/s
+		/// Comment: X-Axis Measurement</summary>
+		/// <param name="index">0 based index of gyro_x</param>
+		/// <param name="gyroX_">Nullable field value to be set</param>
+		public void SetGyroX(int index, float? gyroX_)
+		{
+			SetFieldValue(2, index, gyroX_, Fit.SubfieldIndexMainField);
+		}
 
-        /// <summary>
-        /// Set GyroZ field
-        /// Units: deg/s
-        /// Comment: Z-Axis Measurement</summary>
-        /// <param name="index">0 based index of gyro_z</param>
-        /// <param name="gyroZ_">Nullable field value to be set</param>
-        public void SetGyroZ(int index, float? gyroZ_)
-        {
-            SetFieldValue(4, index, gyroZ_, Fit.SubfieldIndexMainField);
-        }
-        
-        ///<summary>
-        /// Retrieves the Timestamp32k field
-        /// Units: 1/32768 s
-        /// Comment: 32 kHz timestamp</summary>
-        /// <returns>Returns nullable uint representing the Timestamp32k field</returns>
-        public uint? GetTimestamp32k()
-        {
-            Object val = GetFieldValue(5, 0, Fit.SubfieldIndexMainField);
-            if(val == null)
-            {
-                return null;
-            }
 
-            return (Convert.ToUInt32(val));
-            
-        }
+		/// <summary>
+		///
+		/// </summary>
+		/// <returns>returns number of elements in field GyroY</returns>
+		public int GetNumGyroY()
+		{
+			return GetNumFieldValues(3, Fit.SubfieldIndexMainField);
+		}
 
-        /// <summary>
-        /// Set Timestamp32k field
-        /// Units: 1/32768 s
-        /// Comment: 32 kHz timestamp</summary>
-        /// <param name="timestamp32k_">Nullable field value to be set</param>
-        public void SetTimestamp32k(uint? timestamp32k_)
-        {
-            SetFieldValue(5, 0, timestamp32k_, Fit.SubfieldIndexMainField);
-        }
-        
-        #endregion // Methods
-    } // Class
+		///<summary>
+		/// Retrieves the GyroY field
+		/// Units: deg/s
+		/// Comment: Y-Axis Measurement</summary>
+		/// <param name="index">0 based index of GyroY element to retrieve</param>
+		/// <returns>Returns nullable float representing the GyroY field</returns>
+		public float? GetGyroY(int index)
+		{
+			Object val = GetFieldValue(3, index, Fit.SubfieldIndexMainField);
+			if (val == null)
+			{
+				return null;
+			}
+
+			return (Convert.ToSingle(val));
+
+		}
+
+		/// <summary>
+		/// Set GyroY field
+		/// Units: deg/s
+		/// Comment: Y-Axis Measurement</summary>
+		/// <param name="index">0 based index of gyro_y</param>
+		/// <param name="gyroY_">Nullable field value to be set</param>
+		public void SetGyroY(int index, float? gyroY_)
+		{
+			SetFieldValue(3, index, gyroY_, Fit.SubfieldIndexMainField);
+		}
+
+
+		/// <summary>
+		///
+		/// </summary>
+		/// <returns>returns number of elements in field GyroZ</returns>
+		public int GetNumGyroZ()
+		{
+			return GetNumFieldValues(4, Fit.SubfieldIndexMainField);
+		}
+
+		///<summary>
+		/// Retrieves the GyroZ field
+		/// Units: deg/s
+		/// Comment: Z-Axis Measurement</summary>
+		/// <param name="index">0 based index of GyroZ element to retrieve</param>
+		/// <returns>Returns nullable float representing the GyroZ field</returns>
+		public float? GetGyroZ(int index)
+		{
+			Object val = GetFieldValue(4, index, Fit.SubfieldIndexMainField);
+			if (val == null)
+			{
+				return null;
+			}
+
+			return (Convert.ToSingle(val));
+
+		}
+
+		/// <summary>
+		/// Set GyroZ field
+		/// Units: deg/s
+		/// Comment: Z-Axis Measurement</summary>
+		/// <param name="index">0 based index of gyro_z</param>
+		/// <param name="gyroZ_">Nullable field value to be set</param>
+		public void SetGyroZ(int index, float? gyroZ_)
+		{
+			SetFieldValue(4, index, gyroZ_, Fit.SubfieldIndexMainField);
+		}
+
+		///<summary>
+		/// Retrieves the Timestamp32k field
+		/// Units: 1/32768 s
+		/// Comment: 32 kHz timestamp</summary>
+		/// <returns>Returns nullable uint representing the Timestamp32k field</returns>
+		public uint? Timestamp32k
+		{
+			get
+			{
+				Object val = GetFieldValue(5, 0, Fit.SubfieldIndexMainField);
+				if (val == null)
+				{
+					return null;
+				}
+
+				return (Convert.ToUInt32(val));
+
+			}
+			set
+			{
+				SetFieldValue(5, 0, value, Fit.SubfieldIndexMainField);
+			}
+		}
+
+		#endregion // Methods
+	} // Class
 } // namespace

--- a/Dynastream/Fit/Profile/Mesgs/HsaHeartRateDataMesg.cs
+++ b/Dynastream/Fit/Profile/Mesgs/HsaHeartRateDataMesg.cs
@@ -21,153 +21,146 @@ using System.Linq;
 
 namespace Dynastream.Fit
 {
-    /// <summary>
-    /// Implements the HsaHeartRateData profile message.
-    /// </summary>
-    public class HsaHeartRateDataMesg : Mesg
-    {
-        #region Fields
-        #endregion
+	/// <summary>
+	/// Implements the HsaHeartRateData profile message.
+	/// </summary>
+	public class HsaHeartRateDataMesg : Mesg
+	{
+		#region Fields
+		#endregion
 
-        /// <summary>
-        /// Field Numbers for <see cref="HsaHeartRateDataMesg"/>
-        /// </summary>
-        public sealed class FieldDefNum
-        {
-            public const byte Timestamp = 253;
-            public const byte ProcessingInterval = 0;
-            public const byte Status = 1;
-            public const byte HeartRate = 2;
-            public const byte Invalid = Fit.FieldNumInvalid;
-        }
+		/// <summary>
+		/// Field Numbers for <see cref="HsaHeartRateDataMesg"/>
+		/// </summary>
+		public sealed class FieldDefNum
+		{
+			public const byte Timestamp = 253;
+			public const byte ProcessingInterval = 0;
+			public const byte Status = 1;
+			public const byte HeartRate = 2;
+			public const byte Invalid = Fit.FieldNumInvalid;
+		}
 
-        #region Constructors
-        public HsaHeartRateDataMesg() : base(Profile.GetMesg(MesgNum.HsaHeartRateData))
-        {
-        }
+		#region Constructors
+		public HsaHeartRateDataMesg() : base(Profile.GetMesg(MesgNum.HsaHeartRateData))
+		{
+		}
 
-        public HsaHeartRateDataMesg(Mesg mesg) : base(mesg)
-        {
-        }
-        #endregion // Constructors
+		public HsaHeartRateDataMesg(Mesg mesg) : base(mesg)
+		{
+		}
+		#endregion // Constructors
 
-        #region Methods
-        ///<summary>
-        /// Retrieves the Timestamp field
-        /// Units: s</summary>
-        /// <returns>Returns DateTime representing the Timestamp field</returns>
-        public DateTime GetTimestamp()
-        {
-            Object val = GetFieldValue(253, 0, Fit.SubfieldIndexMainField);
-            if(val == null)
-            {
-                return null;
-            }
+		#region Methods
+		///<summary>
+		/// Retrieves the Timestamp field
+		/// Units: s</summary>
+		/// <returns>Returns DateTime representing the Timestamp field</returns>
+		public DateTime Timestamp
+		{
+			get
+			{
+				Object val = GetFieldValue(253, 0, Fit.SubfieldIndexMainField);
+				if (val == null)
+				{
+					return null;
+				}
 
-            return TimestampToDateTime(Convert.ToUInt32(val));
-            
-        }
+				return TimestampToDateTime(Convert.ToUInt32(val));
 
-        /// <summary>
-        /// Set Timestamp field
-        /// Units: s</summary>
-        /// <param name="timestamp_">Nullable field value to be set</param>
-        public void SetTimestamp(DateTime timestamp_)
-        {
-            SetFieldValue(253, 0, timestamp_.GetTimeStamp(), Fit.SubfieldIndexMainField);
-        }
-        
-        ///<summary>
-        /// Retrieves the ProcessingInterval field
-        /// Units: s
-        /// Comment: Processing interval length in seconds</summary>
-        /// <returns>Returns nullable ushort representing the ProcessingInterval field</returns>
-        public ushort? GetProcessingInterval()
-        {
-            Object val = GetFieldValue(0, 0, Fit.SubfieldIndexMainField);
-            if(val == null)
-            {
-                return null;
-            }
+			}
+			set
+			{
+				SetFieldValue(253, 0, value.GetTimeStamp(), Fit.SubfieldIndexMainField);
+			}
+		}
 
-            return (Convert.ToUInt16(val));
-            
-        }
+		///<summary>
+		/// Retrieves the ProcessingInterval field
+		/// Units: s
+		/// Comment: Processing interval length in seconds</summary>
+		/// <returns>Returns nullable ushort representing the ProcessingInterval field</returns>
+		public ushort? ProcessingInterval
+		{
+			get
+			{
+				Object val = GetFieldValue(0, 0, Fit.SubfieldIndexMainField);
+				if (val == null)
+				{
+					return null;
+				}
 
-        /// <summary>
-        /// Set ProcessingInterval field
-        /// Units: s
-        /// Comment: Processing interval length in seconds</summary>
-        /// <param name="processingInterval_">Nullable field value to be set</param>
-        public void SetProcessingInterval(ushort? processingInterval_)
-        {
-            SetFieldValue(0, 0, processingInterval_, Fit.SubfieldIndexMainField);
-        }
-        
-        ///<summary>
-        /// Retrieves the Status field
-        /// Comment: Status of measurements in buffer - 0 indicates SEARCHING 1 indicates LOCKED</summary>
-        /// <returns>Returns nullable byte representing the Status field</returns>
-        public byte? GetStatus()
-        {
-            Object val = GetFieldValue(1, 0, Fit.SubfieldIndexMainField);
-            if(val == null)
-            {
-                return null;
-            }
+				return (Convert.ToUInt16(val));
 
-            return (Convert.ToByte(val));
-            
-        }
+			}
+			set
+			{
+				SetFieldValue(0, 0, value, Fit.SubfieldIndexMainField);
+			}
+		}
 
-        /// <summary>
-        /// Set Status field
-        /// Comment: Status of measurements in buffer - 0 indicates SEARCHING 1 indicates LOCKED</summary>
-        /// <param name="status_">Nullable field value to be set</param>
-        public void SetStatus(byte? status_)
-        {
-            SetFieldValue(1, 0, status_, Fit.SubfieldIndexMainField);
-        }
-        
-        
-        /// <summary>
-        ///
-        /// </summary>
-        /// <returns>returns number of elements in field HeartRate</returns>
-        public int GetNumHeartRate()
-        {
-            return GetNumFieldValues(2, Fit.SubfieldIndexMainField);
-        }
+		///<summary>
+		/// Retrieves the Status field
+		/// Comment: Status of measurements in buffer - 0 indicates SEARCHING 1 indicates LOCKED</summary>
+		/// <returns>Returns nullable byte representing the Status field</returns>
+		public byte? Status
+		{
+			get
+			{
+				Object val = GetFieldValue(1, 0, Fit.SubfieldIndexMainField);
+				if (val == null)
+				{
+					return null;
+				}
 
-        ///<summary>
-        /// Retrieves the HeartRate field
-        /// Units: bpm
-        /// Comment: Beats / min. Blank: 0</summary>
-        /// <param name="index">0 based index of HeartRate element to retrieve</param>
-        /// <returns>Returns nullable byte representing the HeartRate field</returns>
-        public byte? GetHeartRate(int index)
-        {
-            Object val = GetFieldValue(2, index, Fit.SubfieldIndexMainField);
-            if(val == null)
-            {
-                return null;
-            }
+				return (Convert.ToByte(val));
 
-            return (Convert.ToByte(val));
-            
-        }
+			}
+			set
+			{
+				SetFieldValue(1, 0, value, Fit.SubfieldIndexMainField);
+			}
+		}
 
-        /// <summary>
-        /// Set HeartRate field
-        /// Units: bpm
-        /// Comment: Beats / min. Blank: 0</summary>
-        /// <param name="index">0 based index of heart_rate</param>
-        /// <param name="heartRate_">Nullable field value to be set</param>
-        public void SetHeartRate(int index, byte? heartRate_)
-        {
-            SetFieldValue(2, index, heartRate_, Fit.SubfieldIndexMainField);
-        }
-        
-        #endregion // Methods
-    } // Class
+
+		/// <summary>
+		///
+		/// </summary>
+		/// <returns>returns number of elements in field HeartRate</returns>
+		public int GetNumHeartRate()
+		{
+			return GetNumFieldValues(2, Fit.SubfieldIndexMainField);
+		}
+
+		///<summary>
+		/// Retrieves the HeartRate field
+		/// Units: bpm
+		/// Comment: Beats / min. Blank: 0</summary>
+		/// <param name="index">0 based index of HeartRate element to retrieve</param>
+		/// <returns>Returns nullable byte representing the HeartRate field</returns>
+		public byte? GetHeartRate(int index)
+		{
+			Object val = GetFieldValue(2, index, Fit.SubfieldIndexMainField);
+			if (val == null)
+			{
+				return null;
+			}
+
+			return (Convert.ToByte(val));
+
+		}
+
+		/// <summary>
+		/// Set HeartRate field
+		/// Units: bpm
+		/// Comment: Beats / min. Blank: 0</summary>
+		/// <param name="index">0 based index of heart_rate</param>
+		/// <param name="heartRate_">Nullable field value to be set</param>
+		public void SetHeartRate(int index, byte? heartRate_)
+		{
+			SetFieldValue(2, index, heartRate_, Fit.SubfieldIndexMainField);
+		}
+
+		#endregion // Methods
+	} // Class
 } // namespace

--- a/Dynastream/Fit/Profile/Mesgs/HsaRespirationDataMesg.cs
+++ b/Dynastream/Fit/Profile/Mesgs/HsaRespirationDataMesg.cs
@@ -21,127 +21,122 @@ using System.Linq;
 
 namespace Dynastream.Fit
 {
-    /// <summary>
-    /// Implements the HsaRespirationData profile message.
-    /// </summary>
-    public class HsaRespirationDataMesg : Mesg
-    {
-        #region Fields
-        #endregion
+	/// <summary>
+	/// Implements the HsaRespirationData profile message.
+	/// </summary>
+	public class HsaRespirationDataMesg : Mesg
+	{
+		#region Fields
+		#endregion
 
-        /// <summary>
-        /// Field Numbers for <see cref="HsaRespirationDataMesg"/>
-        /// </summary>
-        public sealed class FieldDefNum
-        {
-            public const byte Timestamp = 253;
-            public const byte ProcessingInterval = 0;
-            public const byte RespirationRate = 1;
-            public const byte Invalid = Fit.FieldNumInvalid;
-        }
+		/// <summary>
+		/// Field Numbers for <see cref="HsaRespirationDataMesg"/>
+		/// </summary>
+		public sealed class FieldDefNum
+		{
+			public const byte Timestamp = 253;
+			public const byte ProcessingInterval = 0;
+			public const byte RespirationRate = 1;
+			public const byte Invalid = Fit.FieldNumInvalid;
+		}
 
-        #region Constructors
-        public HsaRespirationDataMesg() : base(Profile.GetMesg(MesgNum.HsaRespirationData))
-        {
-        }
+		#region Constructors
+		public HsaRespirationDataMesg() : base(Profile.GetMesg(MesgNum.HsaRespirationData))
+		{
+		}
 
-        public HsaRespirationDataMesg(Mesg mesg) : base(mesg)
-        {
-        }
-        #endregion // Constructors
+		public HsaRespirationDataMesg(Mesg mesg) : base(mesg)
+		{
+		}
+		#endregion // Constructors
 
-        #region Methods
-        ///<summary>
-        /// Retrieves the Timestamp field
-        /// Units: s</summary>
-        /// <returns>Returns DateTime representing the Timestamp field</returns>
-        public DateTime GetTimestamp()
-        {
-            Object val = GetFieldValue(253, 0, Fit.SubfieldIndexMainField);
-            if(val == null)
-            {
-                return null;
-            }
+		#region Methods
+		///<summary>
+		/// Retrieves the Timestamp field
+		/// Units: s</summary>
+		/// <returns>Returns DateTime representing the Timestamp field</returns>
+		public DateTime Timestamp
+		{
+			get
+			{
+				Object val = GetFieldValue(253, 0, Fit.SubfieldIndexMainField);
+				if (val == null)
+				{
+					return null;
+				}
 
-            return TimestampToDateTime(Convert.ToUInt32(val));
-            
-        }
+				return TimestampToDateTime(Convert.ToUInt32(val));
 
-        /// <summary>
-        /// Set Timestamp field
-        /// Units: s</summary>
-        /// <param name="timestamp_">Nullable field value to be set</param>
-        public void SetTimestamp(DateTime timestamp_)
-        {
-            SetFieldValue(253, 0, timestamp_.GetTimeStamp(), Fit.SubfieldIndexMainField);
-        }
-        
-        ///<summary>
-        /// Retrieves the ProcessingInterval field
-        /// Units: s
-        /// Comment: Processing interval length in seconds</summary>
-        /// <returns>Returns nullable ushort representing the ProcessingInterval field</returns>
-        public ushort? GetProcessingInterval()
-        {
-            Object val = GetFieldValue(0, 0, Fit.SubfieldIndexMainField);
-            if(val == null)
-            {
-                return null;
-            }
+			}
+			set
+			{
+				SetFieldValue(253, 0, value.GetTimeStamp(), Fit.SubfieldIndexMainField);
+			}
+		}
 
-            return (Convert.ToUInt16(val));
-            
-        }
+		///<summary>
+		/// Retrieves the ProcessingInterval field
+		/// Units: s
+		/// Comment: Processing interval length in seconds</summary>
+		/// <returns>Returns nullable ushort representing the ProcessingInterval field</returns>
+		public ushort? ProcessingInterval
+		{
+			get
+			{
+				Object val = GetFieldValue(0, 0, Fit.SubfieldIndexMainField);
+				if (val == null)
+				{
+					return null;
+				}
 
-        /// <summary>
-        /// Set ProcessingInterval field
-        /// Units: s
-        /// Comment: Processing interval length in seconds</summary>
-        /// <param name="processingInterval_">Nullable field value to be set</param>
-        public void SetProcessingInterval(ushort? processingInterval_)
-        {
-            SetFieldValue(0, 0, processingInterval_, Fit.SubfieldIndexMainField);
-        }
-        
-        
-        /// <summary>
-        ///
-        /// </summary>
-        /// <returns>returns number of elements in field RespirationRate</returns>
-        public int GetNumRespirationRate()
-        {
-            return GetNumFieldValues(1, Fit.SubfieldIndexMainField);
-        }
+				return (Convert.ToUInt16(val));
 
-        ///<summary>
-        /// Retrieves the RespirationRate field
-        /// Units: breaths/min
-        /// Comment: Breaths / min: [1,100] Invalid: 255 Excess motion: 254 Off wrist: 253 Not available: 252 Blank: 2.4</summary>
-        /// <param name="index">0 based index of RespirationRate element to retrieve</param>
-        /// <returns>Returns nullable float representing the RespirationRate field</returns>
-        public float? GetRespirationRate(int index)
-        {
-            Object val = GetFieldValue(1, index, Fit.SubfieldIndexMainField);
-            if(val == null)
-            {
-                return null;
-            }
+			}
+			set
+			{
+				SetFieldValue(0, 0, value, Fit.SubfieldIndexMainField);
+			}
+		}
 
-            return (Convert.ToSingle(val));
-            
-        }
 
-        /// <summary>
-        /// Set RespirationRate field
-        /// Units: breaths/min
-        /// Comment: Breaths / min: [1,100] Invalid: 255 Excess motion: 254 Off wrist: 253 Not available: 252 Blank: 2.4</summary>
-        /// <param name="index">0 based index of respiration_rate</param>
-        /// <param name="respirationRate_">Nullable field value to be set</param>
-        public void SetRespirationRate(int index, float? respirationRate_)
-        {
-            SetFieldValue(1, index, respirationRate_, Fit.SubfieldIndexMainField);
-        }
-        
-        #endregion // Methods
-    } // Class
+		/// <summary>
+		///
+		/// </summary>
+		/// <returns>returns number of elements in field RespirationRate</returns>
+		public int GetNumRespirationRate()
+		{
+			return GetNumFieldValues(1, Fit.SubfieldIndexMainField);
+		}
+
+		///<summary>
+		/// Retrieves the RespirationRate field
+		/// Units: breaths/min
+		/// Comment: Breaths / min: [1,100] Invalid: 255 Excess motion: 254 Off wrist: 253 Not available: 252 Blank: 2.4</summary>
+		/// <param name="index">0 based index of RespirationRate element to retrieve</param>
+		/// <returns>Returns nullable float representing the RespirationRate field</returns>
+		public float? GetRespirationRate(int index)
+		{
+			Object val = GetFieldValue(1, index, Fit.SubfieldIndexMainField);
+			if (val == null)
+			{
+				return null;
+			}
+
+			return (Convert.ToSingle(val));
+
+		}
+
+		/// <summary>
+		/// Set RespirationRate field
+		/// Units: breaths/min
+		/// Comment: Breaths / min: [1,100] Invalid: 255 Excess motion: 254 Off wrist: 253 Not available: 252 Blank: 2.4</summary>
+		/// <param name="index">0 based index of respiration_rate</param>
+		/// <param name="respirationRate_">Nullable field value to be set</param>
+		public void SetRespirationRate(int index, float? respirationRate_)
+		{
+			SetFieldValue(1, index, respirationRate_, Fit.SubfieldIndexMainField);
+		}
+
+		#endregion // Methods
+	} // Class
 } // namespace

--- a/Dynastream/Fit/Profile/Mesgs/HsaSpo2DataMesg.cs
+++ b/Dynastream/Fit/Profile/Mesgs/HsaSpo2DataMesg.cs
@@ -21,165 +21,160 @@ using System.Linq;
 
 namespace Dynastream.Fit
 {
-    /// <summary>
-    /// Implements the HsaSpo2Data profile message.
-    /// </summary>
-    public class HsaSpo2DataMesg : Mesg
-    {
-        #region Fields
-        #endregion
+	/// <summary>
+	/// Implements the HsaSpo2Data profile message.
+	/// </summary>
+	public class HsaSpo2DataMesg : Mesg
+	{
+		#region Fields
+		#endregion
 
-        /// <summary>
-        /// Field Numbers for <see cref="HsaSpo2DataMesg"/>
-        /// </summary>
-        public sealed class FieldDefNum
-        {
-            public const byte Timestamp = 253;
-            public const byte ProcessingInterval = 0;
-            public const byte ReadingSpo2 = 1;
-            public const byte Confidence = 2;
-            public const byte Invalid = Fit.FieldNumInvalid;
-        }
+		/// <summary>
+		/// Field Numbers for <see cref="HsaSpo2DataMesg"/>
+		/// </summary>
+		public sealed class FieldDefNum
+		{
+			public const byte Timestamp = 253;
+			public const byte ProcessingInterval = 0;
+			public const byte ReadingSpo2 = 1;
+			public const byte Confidence = 2;
+			public const byte Invalid = Fit.FieldNumInvalid;
+		}
 
-        #region Constructors
-        public HsaSpo2DataMesg() : base(Profile.GetMesg(MesgNum.HsaSpo2Data))
-        {
-        }
+		#region Constructors
+		public HsaSpo2DataMesg() : base(Profile.GetMesg(MesgNum.HsaSpo2Data))
+		{
+		}
 
-        public HsaSpo2DataMesg(Mesg mesg) : base(mesg)
-        {
-        }
-        #endregion // Constructors
+		public HsaSpo2DataMesg(Mesg mesg) : base(mesg)
+		{
+		}
+		#endregion // Constructors
 
-        #region Methods
-        ///<summary>
-        /// Retrieves the Timestamp field
-        /// Units: s</summary>
-        /// <returns>Returns DateTime representing the Timestamp field</returns>
-        public DateTime GetTimestamp()
-        {
-            Object val = GetFieldValue(253, 0, Fit.SubfieldIndexMainField);
-            if(val == null)
-            {
-                return null;
-            }
+		#region Methods
+		///<summary>
+		/// Retrieves the Timestamp field
+		/// Units: s</summary>
+		/// <returns>Returns DateTime representing the Timestamp field</returns>
+		public DateTime Timestamp
+		{
+			get
+			{
+				Object val = GetFieldValue(253, 0, Fit.SubfieldIndexMainField);
+				if (val == null)
+				{
+					return null;
+				}
 
-            return TimestampToDateTime(Convert.ToUInt32(val));
-            
-        }
+				return TimestampToDateTime(Convert.ToUInt32(val));
 
-        /// <summary>
-        /// Set Timestamp field
-        /// Units: s</summary>
-        /// <param name="timestamp_">Nullable field value to be set</param>
-        public void SetTimestamp(DateTime timestamp_)
-        {
-            SetFieldValue(253, 0, timestamp_.GetTimeStamp(), Fit.SubfieldIndexMainField);
-        }
-        
-        ///<summary>
-        /// Retrieves the ProcessingInterval field
-        /// Units: s
-        /// Comment: Processing interval length in seconds</summary>
-        /// <returns>Returns nullable ushort representing the ProcessingInterval field</returns>
-        public ushort? GetProcessingInterval()
-        {
-            Object val = GetFieldValue(0, 0, Fit.SubfieldIndexMainField);
-            if(val == null)
-            {
-                return null;
-            }
+			}
+			set
+			{
+				SetFieldValue(253, 0, value.GetTimeStamp(), Fit.SubfieldIndexMainField);
+			}
+		}
 
-            return (Convert.ToUInt16(val));
-            
-        }
+		///<summary>
+		/// Retrieves the ProcessingInterval field
+		/// Units: s
+		/// Comment: Processing interval length in seconds</summary>
+		/// <returns>Returns nullable ushort representing the ProcessingInterval field</returns>
+		public ushort? ProcessingInterval
+		{
+			get
+			{
+				Object val = GetFieldValue(0, 0, Fit.SubfieldIndexMainField);
+				if (val == null)
+				{
+					return null;
+				}
 
-        /// <summary>
-        /// Set ProcessingInterval field
-        /// Units: s
-        /// Comment: Processing interval length in seconds</summary>
-        /// <param name="processingInterval_">Nullable field value to be set</param>
-        public void SetProcessingInterval(ushort? processingInterval_)
-        {
-            SetFieldValue(0, 0, processingInterval_, Fit.SubfieldIndexMainField);
-        }
-        
-        
-        /// <summary>
-        ///
-        /// </summary>
-        /// <returns>returns number of elements in field ReadingSpo2</returns>
-        public int GetNumReadingSpo2()
-        {
-            return GetNumFieldValues(1, Fit.SubfieldIndexMainField);
-        }
+				return (Convert.ToUInt16(val));
 
-        ///<summary>
-        /// Retrieves the ReadingSpo2 field
-        /// Units: percent
-        /// Comment: SpO2 Reading: [70,100] Blank: 240</summary>
-        /// <param name="index">0 based index of ReadingSpo2 element to retrieve</param>
-        /// <returns>Returns nullable byte representing the ReadingSpo2 field</returns>
-        public byte? GetReadingSpo2(int index)
-        {
-            Object val = GetFieldValue(1, index, Fit.SubfieldIndexMainField);
-            if(val == null)
-            {
-                return null;
-            }
+			}
+			set
+			{
+				SetFieldValue(0, 0, value, Fit.SubfieldIndexMainField);
+			}
+		}
 
-            return (Convert.ToByte(val));
-            
-        }
 
-        /// <summary>
-        /// Set ReadingSpo2 field
-        /// Units: percent
-        /// Comment: SpO2 Reading: [70,100] Blank: 240</summary>
-        /// <param name="index">0 based index of reading_spo2</param>
-        /// <param name="readingSpo2_">Nullable field value to be set</param>
-        public void SetReadingSpo2(int index, byte? readingSpo2_)
-        {
-            SetFieldValue(1, index, readingSpo2_, Fit.SubfieldIndexMainField);
-        }
-        
-        
-        /// <summary>
-        ///
-        /// </summary>
-        /// <returns>returns number of elements in field Confidence</returns>
-        public int GetNumConfidence()
-        {
-            return GetNumFieldValues(2, Fit.SubfieldIndexMainField);
-        }
+		/// <summary>
+		///
+		/// </summary>
+		/// <returns>returns number of elements in field ReadingSpo2</returns>
+		public int GetNumReadingSpo2()
+		{
+			return GetNumFieldValues(1, Fit.SubfieldIndexMainField);
+		}
 
-        ///<summary>
-        /// Retrieves the Confidence field
-        /// Comment: SpO2 Confidence: [0,254]</summary>
-        /// <param name="index">0 based index of Confidence element to retrieve</param>
-        /// <returns>Returns nullable byte representing the Confidence field</returns>
-        public byte? GetConfidence(int index)
-        {
-            Object val = GetFieldValue(2, index, Fit.SubfieldIndexMainField);
-            if(val == null)
-            {
-                return null;
-            }
+		///<summary>
+		/// Retrieves the ReadingSpo2 field
+		/// Units: percent
+		/// Comment: SpO2 Reading: [70,100] Blank: 240</summary>
+		/// <param name="index">0 based index of ReadingSpo2 element to retrieve</param>
+		/// <returns>Returns nullable byte representing the ReadingSpo2 field</returns>
+		public byte? GetReadingSpo2(int index)
+		{
+			Object val = GetFieldValue(1, index, Fit.SubfieldIndexMainField);
+			if (val == null)
+			{
+				return null;
+			}
 
-            return (Convert.ToByte(val));
-            
-        }
+			return (Convert.ToByte(val));
 
-        /// <summary>
-        /// Set Confidence field
-        /// Comment: SpO2 Confidence: [0,254]</summary>
-        /// <param name="index">0 based index of confidence</param>
-        /// <param name="confidence_">Nullable field value to be set</param>
-        public void SetConfidence(int index, byte? confidence_)
-        {
-            SetFieldValue(2, index, confidence_, Fit.SubfieldIndexMainField);
-        }
-        
-        #endregion // Methods
-    } // Class
+		}
+
+		/// <summary>
+		/// Set ReadingSpo2 field
+		/// Units: percent
+		/// Comment: SpO2 Reading: [70,100] Blank: 240</summary>
+		/// <param name="index">0 based index of reading_spo2</param>
+		/// <param name="readingSpo2_">Nullable field value to be set</param>
+		public void SetReadingSpo2(int index, byte? readingSpo2_)
+		{
+			SetFieldValue(1, index, readingSpo2_, Fit.SubfieldIndexMainField);
+		}
+
+
+		/// <summary>
+		///
+		/// </summary>
+		/// <returns>returns number of elements in field Confidence</returns>
+		public int GetNumConfidence()
+		{
+			return GetNumFieldValues(2, Fit.SubfieldIndexMainField);
+		}
+
+		///<summary>
+		/// Retrieves the Confidence field
+		/// Comment: SpO2 Confidence: [0,254]</summary>
+		/// <param name="index">0 based index of Confidence element to retrieve</param>
+		/// <returns>Returns nullable byte representing the Confidence field</returns>
+		public byte? GetConfidence(int index)
+		{
+			Object val = GetFieldValue(2, index, Fit.SubfieldIndexMainField);
+			if (val == null)
+			{
+				return null;
+			}
+
+			return (Convert.ToByte(val));
+
+		}
+
+		/// <summary>
+		/// Set Confidence field
+		/// Comment: SpO2 Confidence: [0,254]</summary>
+		/// <param name="index">0 based index of confidence</param>
+		/// <param name="confidence_">Nullable field value to be set</param>
+		public void SetConfidence(int index, byte? confidence_)
+		{
+			SetFieldValue(2, index, confidence_, Fit.SubfieldIndexMainField);
+		}
+
+		#endregion // Methods
+	} // Class
 } // namespace

--- a/Dynastream/Fit/Profile/Mesgs/HsaStepDataMesg.cs
+++ b/Dynastream/Fit/Profile/Mesgs/HsaStepDataMesg.cs
@@ -21,127 +21,122 @@ using System.Linq;
 
 namespace Dynastream.Fit
 {
-    /// <summary>
-    /// Implements the HsaStepData profile message.
-    /// </summary>
-    public class HsaStepDataMesg : Mesg
-    {
-        #region Fields
-        #endregion
+	/// <summary>
+	/// Implements the HsaStepData profile message.
+	/// </summary>
+	public class HsaStepDataMesg : Mesg
+	{
+		#region Fields
+		#endregion
 
-        /// <summary>
-        /// Field Numbers for <see cref="HsaStepDataMesg"/>
-        /// </summary>
-        public sealed class FieldDefNum
-        {
-            public const byte Timestamp = 253;
-            public const byte ProcessingInterval = 0;
-            public const byte Steps = 1;
-            public const byte Invalid = Fit.FieldNumInvalid;
-        }
+		/// <summary>
+		/// Field Numbers for <see cref="HsaStepDataMesg"/>
+		/// </summary>
+		public sealed class FieldDefNum
+		{
+			public const byte Timestamp = 253;
+			public const byte ProcessingInterval = 0;
+			public const byte Steps = 1;
+			public const byte Invalid = Fit.FieldNumInvalid;
+		}
 
-        #region Constructors
-        public HsaStepDataMesg() : base(Profile.GetMesg(MesgNum.HsaStepData))
-        {
-        }
+		#region Constructors
+		public HsaStepDataMesg() : base(Profile.GetMesg(MesgNum.HsaStepData))
+		{
+		}
 
-        public HsaStepDataMesg(Mesg mesg) : base(mesg)
-        {
-        }
-        #endregion // Constructors
+		public HsaStepDataMesg(Mesg mesg) : base(mesg)
+		{
+		}
+		#endregion // Constructors
 
-        #region Methods
-        ///<summary>
-        /// Retrieves the Timestamp field
-        /// Units: s</summary>
-        /// <returns>Returns DateTime representing the Timestamp field</returns>
-        public DateTime GetTimestamp()
-        {
-            Object val = GetFieldValue(253, 0, Fit.SubfieldIndexMainField);
-            if(val == null)
-            {
-                return null;
-            }
+		#region Methods
+		///<summary>
+		/// Retrieves the Timestamp field
+		/// Units: s</summary>
+		/// <returns>Returns DateTime representing the Timestamp field</returns>
+		public DateTime Timestamp
+		{
+			get
+			{
+				Object val = GetFieldValue(253, 0, Fit.SubfieldIndexMainField);
+				if (val == null)
+				{
+					return null;
+				}
 
-            return TimestampToDateTime(Convert.ToUInt32(val));
-            
-        }
+				return TimestampToDateTime(Convert.ToUInt32(val));
 
-        /// <summary>
-        /// Set Timestamp field
-        /// Units: s</summary>
-        /// <param name="timestamp_">Nullable field value to be set</param>
-        public void SetTimestamp(DateTime timestamp_)
-        {
-            SetFieldValue(253, 0, timestamp_.GetTimeStamp(), Fit.SubfieldIndexMainField);
-        }
-        
-        ///<summary>
-        /// Retrieves the ProcessingInterval field
-        /// Units: s
-        /// Comment: Processing interval length in seconds. File start: 0xFFFFFFEF File stop: 0xFFFFFFEE</summary>
-        /// <returns>Returns nullable ushort representing the ProcessingInterval field</returns>
-        public ushort? GetProcessingInterval()
-        {
-            Object val = GetFieldValue(0, 0, Fit.SubfieldIndexMainField);
-            if(val == null)
-            {
-                return null;
-            }
+			}
+			set
+			{
+				SetFieldValue(253, 0, value.GetTimeStamp(), Fit.SubfieldIndexMainField);
+			}
+		}
 
-            return (Convert.ToUInt16(val));
-            
-        }
+		///<summary>
+		/// Retrieves the ProcessingInterval field
+		/// Units: s
+		/// Comment: Processing interval length in seconds. File start: 0xFFFFFFEF File stop: 0xFFFFFFEE</summary>
+		/// <returns>Returns nullable ushort representing the ProcessingInterval field</returns>
+		public ushort? ProcessingInterval
+		{
+			get
+			{
+				Object val = GetFieldValue(0, 0, Fit.SubfieldIndexMainField);
+				if (val == null)
+				{
+					return null;
+				}
 
-        /// <summary>
-        /// Set ProcessingInterval field
-        /// Units: s
-        /// Comment: Processing interval length in seconds. File start: 0xFFFFFFEF File stop: 0xFFFFFFEE</summary>
-        /// <param name="processingInterval_">Nullable field value to be set</param>
-        public void SetProcessingInterval(ushort? processingInterval_)
-        {
-            SetFieldValue(0, 0, processingInterval_, Fit.SubfieldIndexMainField);
-        }
-        
-        
-        /// <summary>
-        ///
-        /// </summary>
-        /// <returns>returns number of elements in field Steps</returns>
-        public int GetNumSteps()
-        {
-            return GetNumFieldValues(1, Fit.SubfieldIndexMainField);
-        }
+				return (Convert.ToUInt16(val));
 
-        ///<summary>
-        /// Retrieves the Steps field
-        /// Units: steps
-        /// Comment: Total step sum</summary>
-        /// <param name="index">0 based index of Steps element to retrieve</param>
-        /// <returns>Returns nullable uint representing the Steps field</returns>
-        public uint? GetSteps(int index)
-        {
-            Object val = GetFieldValue(1, index, Fit.SubfieldIndexMainField);
-            if(val == null)
-            {
-                return null;
-            }
+			}
+			set
+			{
+				SetFieldValue(0, 0, value, Fit.SubfieldIndexMainField);
+			}
+		}
 
-            return (Convert.ToUInt32(val));
-            
-        }
 
-        /// <summary>
-        /// Set Steps field
-        /// Units: steps
-        /// Comment: Total step sum</summary>
-        /// <param name="index">0 based index of steps</param>
-        /// <param name="steps_">Nullable field value to be set</param>
-        public void SetSteps(int index, uint? steps_)
-        {
-            SetFieldValue(1, index, steps_, Fit.SubfieldIndexMainField);
-        }
-        
-        #endregion // Methods
-    } // Class
+		/// <summary>
+		///
+		/// </summary>
+		/// <returns>returns number of elements in field Steps</returns>
+		public int GetNumSteps()
+		{
+			return GetNumFieldValues(1, Fit.SubfieldIndexMainField);
+		}
+
+		///<summary>
+		/// Retrieves the Steps field
+		/// Units: steps
+		/// Comment: Total step sum</summary>
+		/// <param name="index">0 based index of Steps element to retrieve</param>
+		/// <returns>Returns nullable uint representing the Steps field</returns>
+		public uint? GetSteps(int index)
+		{
+			Object val = GetFieldValue(1, index, Fit.SubfieldIndexMainField);
+			if (val == null)
+			{
+				return null;
+			}
+
+			return (Convert.ToUInt32(val));
+
+		}
+
+		/// <summary>
+		/// Set Steps field
+		/// Units: steps
+		/// Comment: Total step sum</summary>
+		/// <param name="index">0 based index of steps</param>
+		/// <param name="steps_">Nullable field value to be set</param>
+		public void SetSteps(int index, uint? steps_)
+		{
+			SetFieldValue(1, index, steps_, Fit.SubfieldIndexMainField);
+		}
+
+		#endregion // Methods
+	} // Class
 } // namespace

--- a/Dynastream/Fit/Profile/Mesgs/HsaStressDataMesg.cs
+++ b/Dynastream/Fit/Profile/Mesgs/HsaStressDataMesg.cs
@@ -21,125 +21,121 @@ using System.Linq;
 
 namespace Dynastream.Fit
 {
-    /// <summary>
-    /// Implements the HsaStressData profile message.
-    /// </summary>
-    public class HsaStressDataMesg : Mesg
-    {
-        #region Fields
-        #endregion
+	/// <summary>
+	/// Implements the HsaStressData profile message.
+	/// </summary>
+	public class HsaStressDataMesg : Mesg
+	{
+		#region Fields
+		#endregion
 
-        /// <summary>
-        /// Field Numbers for <see cref="HsaStressDataMesg"/>
-        /// </summary>
-        public sealed class FieldDefNum
-        {
-            public const byte Timestamp = 253;
-            public const byte ProcessingInterval = 0;
-            public const byte StressLevel = 1;
-            public const byte Invalid = Fit.FieldNumInvalid;
-        }
+		/// <summary>
+		/// Field Numbers for <see cref="HsaStressDataMesg"/>
+		/// </summary>
+		public sealed class FieldDefNum
+		{
+			public const byte Timestamp = 253;
+			public const byte ProcessingInterval = 0;
+			public const byte StressLevel = 1;
+			public const byte Invalid = Fit.FieldNumInvalid;
+		}
 
-        #region Constructors
-        public HsaStressDataMesg() : base(Profile.GetMesg(MesgNum.HsaStressData))
-        {
-        }
+		#region Constructors
+		public HsaStressDataMesg() : base(Profile.GetMesg(MesgNum.HsaStressData))
+		{
+		}
 
-        public HsaStressDataMesg(Mesg mesg) : base(mesg)
-        {
-        }
-        #endregion // Constructors
+		public HsaStressDataMesg(Mesg mesg) : base(mesg)
+		{
+		}
+		#endregion // Constructors
 
-        #region Methods
-        ///<summary>
-        /// Retrieves the Timestamp field</summary>
-        /// <returns>Returns DateTime representing the Timestamp field</returns>
-        public DateTime GetTimestamp()
-        {
-            Object val = GetFieldValue(253, 0, Fit.SubfieldIndexMainField);
-            if(val == null)
-            {
-                return null;
-            }
+		#region Methods
+		///<summary>
+		/// Retrieves the Timestamp field</summary>
+		/// <returns>Returns DateTime representing the Timestamp field</returns>
+		public DateTime Timestamp
+		{
+			get
+			{
+				Object val = GetFieldValue(253, 0, Fit.SubfieldIndexMainField);
+				if (val == null)
+				{
+					return null;
+				}
 
-            return TimestampToDateTime(Convert.ToUInt32(val));
-            
-        }
+				return TimestampToDateTime(Convert.ToUInt32(val));
 
-        /// <summary>
-        /// Set Timestamp field</summary>
-        /// <param name="timestamp_">Nullable field value to be set</param>
-        public void SetTimestamp(DateTime timestamp_)
-        {
-            SetFieldValue(253, 0, timestamp_.GetTimeStamp(), Fit.SubfieldIndexMainField);
-        }
-        
-        ///<summary>
-        /// Retrieves the ProcessingInterval field
-        /// Units: s
-        /// Comment: Processing interval length in seconds</summary>
-        /// <returns>Returns nullable ushort representing the ProcessingInterval field</returns>
-        public ushort? GetProcessingInterval()
-        {
-            Object val = GetFieldValue(0, 0, Fit.SubfieldIndexMainField);
-            if(val == null)
-            {
-                return null;
-            }
+			}
+			set
+			{
+				SetFieldValue(253, 0, value.GetTimeStamp(), Fit.SubfieldIndexMainField);
+			}
+		}
 
-            return (Convert.ToUInt16(val));
-            
-        }
+		///<summary>
+		/// Retrieves the ProcessingInterval field
+		/// Units: s
+		/// Comment: Processing interval length in seconds</summary>
+		/// <returns>Returns nullable ushort representing the ProcessingInterval field</returns>
+		public ushort? ProcessingInterval
+		{
+			get
+			{
+				Object val = GetFieldValue(0, 0, Fit.SubfieldIndexMainField);
+				if (val == null)
+				{
+					return null;
+				}
 
-        /// <summary>
-        /// Set ProcessingInterval field
-        /// Units: s
-        /// Comment: Processing interval length in seconds</summary>
-        /// <param name="processingInterval_">Nullable field value to be set</param>
-        public void SetProcessingInterval(ushort? processingInterval_)
-        {
-            SetFieldValue(0, 0, processingInterval_, Fit.SubfieldIndexMainField);
-        }
-        
-        
-        /// <summary>
-        ///
-        /// </summary>
-        /// <returns>returns number of elements in field StressLevel</returns>
-        public int GetNumStressLevel()
-        {
-            return GetNumFieldValues(1, Fit.SubfieldIndexMainField);
-        }
+				return (Convert.ToUInt16(val));
 
-        ///<summary>
-        /// Retrieves the StressLevel field
-        /// Units: s
-        /// Comment: Stress Level: [0,100] Off wrist: -1 Excess motion: -2 Not enough data: -3 Recovering from exercise: -4 Unidentified: -5 Blank: -16</summary>
-        /// <param name="index">0 based index of StressLevel element to retrieve</param>
-        /// <returns>Returns nullable sbyte representing the StressLevel field</returns>
-        public sbyte? GetStressLevel(int index)
-        {
-            Object val = GetFieldValue(1, index, Fit.SubfieldIndexMainField);
-            if(val == null)
-            {
-                return null;
-            }
+			}
+			set
+			{
+				SetFieldValue(0, 0, value, Fit.SubfieldIndexMainField);
+			}
+		}
 
-            return (Convert.ToSByte(val));
-            
-        }
 
-        /// <summary>
-        /// Set StressLevel field
-        /// Units: s
-        /// Comment: Stress Level: [0,100] Off wrist: -1 Excess motion: -2 Not enough data: -3 Recovering from exercise: -4 Unidentified: -5 Blank: -16</summary>
-        /// <param name="index">0 based index of stress_level</param>
-        /// <param name="stressLevel_">Nullable field value to be set</param>
-        public void SetStressLevel(int index, sbyte? stressLevel_)
-        {
-            SetFieldValue(1, index, stressLevel_, Fit.SubfieldIndexMainField);
-        }
-        
-        #endregion // Methods
-    } // Class
+		/// <summary>
+		///
+		/// </summary>
+		/// <returns>returns number of elements in field StressLevel</returns>
+		public int GetNumStressLevel()
+		{
+			return GetNumFieldValues(1, Fit.SubfieldIndexMainField);
+		}
+
+		///<summary>
+		/// Retrieves the StressLevel field
+		/// Units: s
+		/// Comment: Stress Level: [0,100] Off wrist: -1 Excess motion: -2 Not enough data: -3 Recovering from exercise: -4 Unidentified: -5 Blank: -16</summary>
+		/// <param name="index">0 based index of StressLevel element to retrieve</param>
+		/// <returns>Returns nullable sbyte representing the StressLevel field</returns>
+		public sbyte? GetStressLevel(int index)
+		{
+			Object val = GetFieldValue(1, index, Fit.SubfieldIndexMainField);
+			if (val == null)
+			{
+				return null;
+			}
+
+			return (Convert.ToSByte(val));
+
+		}
+
+		/// <summary>
+		/// Set StressLevel field
+		/// Units: s
+		/// Comment: Stress Level: [0,100] Off wrist: -1 Excess motion: -2 Not enough data: -3 Recovering from exercise: -4 Unidentified: -5 Blank: -16</summary>
+		/// <param name="index">0 based index of stress_level</param>
+		/// <param name="stressLevel_">Nullable field value to be set</param>
+		public void SetStressLevel(int index, sbyte? stressLevel_)
+		{
+			SetFieldValue(1, index, stressLevel_, Fit.SubfieldIndexMainField);
+		}
+
+		#endregion // Methods
+	} // Class
 } // namespace

--- a/Dynastream/Fit/Profile/Mesgs/HsaWristTemperatureDataMesg.cs
+++ b/Dynastream/Fit/Profile/Mesgs/HsaWristTemperatureDataMesg.cs
@@ -21,127 +21,122 @@ using System.Linq;
 
 namespace Dynastream.Fit
 {
-    /// <summary>
-    /// Implements the HsaWristTemperatureData profile message.
-    /// </summary>
-    public class HsaWristTemperatureDataMesg : Mesg
-    {
-        #region Fields
-        #endregion
+	/// <summary>
+	/// Implements the HsaWristTemperatureData profile message.
+	/// </summary>
+	public class HsaWristTemperatureDataMesg : Mesg
+	{
+		#region Fields
+		#endregion
 
-        /// <summary>
-        /// Field Numbers for <see cref="HsaWristTemperatureDataMesg"/>
-        /// </summary>
-        public sealed class FieldDefNum
-        {
-            public const byte Timestamp = 253;
-            public const byte ProcessingInterval = 0;
-            public const byte Value = 1;
-            public const byte Invalid = Fit.FieldNumInvalid;
-        }
+		/// <summary>
+		/// Field Numbers for <see cref="HsaWristTemperatureDataMesg"/>
+		/// </summary>
+		public sealed class FieldDefNum
+		{
+			public const byte Timestamp = 253;
+			public const byte ProcessingInterval = 0;
+			public const byte Value = 1;
+			public const byte Invalid = Fit.FieldNumInvalid;
+		}
 
-        #region Constructors
-        public HsaWristTemperatureDataMesg() : base(Profile.GetMesg(MesgNum.HsaWristTemperatureData))
-        {
-        }
+		#region Constructors
+		public HsaWristTemperatureDataMesg() : base(Profile.GetMesg(MesgNum.HsaWristTemperatureData))
+		{
+		}
 
-        public HsaWristTemperatureDataMesg(Mesg mesg) : base(mesg)
-        {
-        }
-        #endregion // Constructors
+		public HsaWristTemperatureDataMesg(Mesg mesg) : base(mesg)
+		{
+		}
+		#endregion // Constructors
 
-        #region Methods
-        ///<summary>
-        /// Retrieves the Timestamp field
-        /// Units: s</summary>
-        /// <returns>Returns DateTime representing the Timestamp field</returns>
-        public DateTime GetTimestamp()
-        {
-            Object val = GetFieldValue(253, 0, Fit.SubfieldIndexMainField);
-            if(val == null)
-            {
-                return null;
-            }
+		#region Methods
+		///<summary>
+		/// Retrieves the Timestamp field
+		/// Units: s</summary>
+		/// <returns>Returns DateTime representing the Timestamp field</returns>
+		public DateTime Timestamp
+		{
+			get
+			{
+				Object val = GetFieldValue(253, 0, Fit.SubfieldIndexMainField);
+				if (val == null)
+				{
+					return null;
+				}
 
-            return TimestampToDateTime(Convert.ToUInt32(val));
-            
-        }
+				return TimestampToDateTime(Convert.ToUInt32(val));
 
-        /// <summary>
-        /// Set Timestamp field
-        /// Units: s</summary>
-        /// <param name="timestamp_">Nullable field value to be set</param>
-        public void SetTimestamp(DateTime timestamp_)
-        {
-            SetFieldValue(253, 0, timestamp_.GetTimeStamp(), Fit.SubfieldIndexMainField);
-        }
-        
-        ///<summary>
-        /// Retrieves the ProcessingInterval field
-        /// Units: s
-        /// Comment: Processing interval length in seconds</summary>
-        /// <returns>Returns nullable ushort representing the ProcessingInterval field</returns>
-        public ushort? GetProcessingInterval()
-        {
-            Object val = GetFieldValue(0, 0, Fit.SubfieldIndexMainField);
-            if(val == null)
-            {
-                return null;
-            }
+			}
+			set
+			{
+				SetFieldValue(253, 0, value.GetTimeStamp(), Fit.SubfieldIndexMainField);
+			}
+		}
 
-            return (Convert.ToUInt16(val));
-            
-        }
+		///<summary>
+		/// Retrieves the ProcessingInterval field
+		/// Units: s
+		/// Comment: Processing interval length in seconds</summary>
+		/// <returns>Returns nullable ushort representing the ProcessingInterval field</returns>
+		public ushort? ProcessingInterval
+		{
+			get
+			{
+				Object val = GetFieldValue(0, 0, Fit.SubfieldIndexMainField);
+				if (val == null)
+				{
+					return null;
+				}
 
-        /// <summary>
-        /// Set ProcessingInterval field
-        /// Units: s
-        /// Comment: Processing interval length in seconds</summary>
-        /// <param name="processingInterval_">Nullable field value to be set</param>
-        public void SetProcessingInterval(ushort? processingInterval_)
-        {
-            SetFieldValue(0, 0, processingInterval_, Fit.SubfieldIndexMainField);
-        }
-        
-        
-        /// <summary>
-        ///
-        /// </summary>
-        /// <returns>returns number of elements in field Value</returns>
-        public int GetNumValue()
-        {
-            return GetNumFieldValues(1, Fit.SubfieldIndexMainField);
-        }
+				return (Convert.ToUInt16(val));
 
-        ///<summary>
-        /// Retrieves the Value field
-        /// Units: degC
-        /// Comment: Wrist temperature reading</summary>
-        /// <param name="index">0 based index of Value element to retrieve</param>
-        /// <returns>Returns nullable float representing the Value field</returns>
-        public float? GetValue(int index)
-        {
-            Object val = GetFieldValue(1, index, Fit.SubfieldIndexMainField);
-            if(val == null)
-            {
-                return null;
-            }
+			}
+			set
+			{
+				SetFieldValue(0, 0, value, Fit.SubfieldIndexMainField);
+			}
+		}
 
-            return (Convert.ToSingle(val));
-            
-        }
 
-        /// <summary>
-        /// Set Value field
-        /// Units: degC
-        /// Comment: Wrist temperature reading</summary>
-        /// <param name="index">0 based index of value</param>
-        /// <param name="value_">Nullable field value to be set</param>
-        public void SetValue(int index, float? value_)
-        {
-            SetFieldValue(1, index, value_, Fit.SubfieldIndexMainField);
-        }
-        
-        #endregion // Methods
-    } // Class
+		/// <summary>
+		///
+		/// </summary>
+		/// <returns>returns number of elements in field Value</returns>
+		public int GetNumValue()
+		{
+			return GetNumFieldValues(1, Fit.SubfieldIndexMainField);
+		}
+
+		///<summary>
+		/// Retrieves the Value field
+		/// Units: degC
+		/// Comment: Wrist temperature reading</summary>
+		/// <param name="index">0 based index of Value element to retrieve</param>
+		/// <returns>Returns nullable float representing the Value field</returns>
+		public float? GetValue(int index)
+		{
+			Object val = GetFieldValue(1, index, Fit.SubfieldIndexMainField);
+			if (val == null)
+			{
+				return null;
+			}
+
+			return (Convert.ToSingle(val));
+
+		}
+
+		/// <summary>
+		/// Set Value field
+		/// Units: degC
+		/// Comment: Wrist temperature reading</summary>
+		/// <param name="index">0 based index of value</param>
+		/// <param name="value_">Nullable field value to be set</param>
+		public void SetValue(int index, float? value_)
+		{
+			SetFieldValue(1, index, value_, Fit.SubfieldIndexMainField);
+		}
+
+		#endregion // Methods
+	} // Class
 } // namespace

--- a/Dynastream/Fit/Profile/Mesgs/JumpMesg.cs
+++ b/Dynastream/Fit/Profile/Mesgs/JumpMesg.cs
@@ -21,291 +21,272 @@ using System.Linq;
 
 namespace Dynastream.Fit
 {
-    /// <summary>
-    /// Implements the Jump profile message.
-    /// </summary>
-    public class JumpMesg : Mesg
-    {
-        #region Fields
-        #endregion
+	/// <summary>
+	/// Implements the Jump profile message.
+	/// </summary>
+	public class JumpMesg : Mesg
+	{
+		#region Fields
+		#endregion
 
-        /// <summary>
-        /// Field Numbers for <see cref="JumpMesg"/>
-        /// </summary>
-        public sealed class FieldDefNum
-        {
-            public const byte Timestamp = 253;
-            public const byte Distance = 0;
-            public const byte Height = 1;
-            public const byte Rotations = 2;
-            public const byte HangTime = 3;
-            public const byte Score = 4;
-            public const byte PositionLat = 5;
-            public const byte PositionLong = 6;
-            public const byte Speed = 7;
-            public const byte EnhancedSpeed = 8;
-            public const byte Invalid = Fit.FieldNumInvalid;
-        }
+		/// <summary>
+		/// Field Numbers for <see cref="JumpMesg"/>
+		/// </summary>
+		public sealed class FieldDefNum
+		{
+			public const byte Timestamp = 253;
+			public const byte Distance = 0;
+			public const byte Height = 1;
+			public const byte Rotations = 2;
+			public const byte HangTime = 3;
+			public const byte Score = 4;
+			public const byte PositionLat = 5;
+			public const byte PositionLong = 6;
+			public const byte Speed = 7;
+			public const byte EnhancedSpeed = 8;
+			public const byte Invalid = Fit.FieldNumInvalid;
+		}
 
-        #region Constructors
-        public JumpMesg() : base(Profile.GetMesg(MesgNum.Jump))
-        {
-        }
+		#region Constructors
+		public JumpMesg() : base(Profile.GetMesg(MesgNum.Jump))
+		{
+		}
 
-        public JumpMesg(Mesg mesg) : base(mesg)
-        {
-        }
-        #endregion // Constructors
+		public JumpMesg(Mesg mesg) : base(mesg)
+		{
+		}
+		#endregion // Constructors
 
-        #region Methods
-        ///<summary>
-        /// Retrieves the Timestamp field
-        /// Units: s</summary>
-        /// <returns>Returns DateTime representing the Timestamp field</returns>
-        public DateTime GetTimestamp()
-        {
-            Object val = GetFieldValue(253, 0, Fit.SubfieldIndexMainField);
-            if(val == null)
-            {
-                return null;
-            }
+		#region Methods
+		///<summary>
+		/// Retrieves the Timestamp field
+		/// Units: s</summary>
+		/// <returns>Returns DateTime representing the Timestamp field</returns>
+		public DateTime Timestamp
+		{
+			get
+			{
+				Object val = GetFieldValue(253, 0, Fit.SubfieldIndexMainField);
+				if (val == null)
+				{
+					return null;
+				}
 
-            return TimestampToDateTime(Convert.ToUInt32(val));
-            
-        }
+				return TimestampToDateTime(Convert.ToUInt32(val));
 
-        /// <summary>
-        /// Set Timestamp field
-        /// Units: s</summary>
-        /// <param name="timestamp_">Nullable field value to be set</param>
-        public void SetTimestamp(DateTime timestamp_)
-        {
-            SetFieldValue(253, 0, timestamp_.GetTimeStamp(), Fit.SubfieldIndexMainField);
-        }
-        
-        ///<summary>
-        /// Retrieves the Distance field
-        /// Units: m</summary>
-        /// <returns>Returns nullable float representing the Distance field</returns>
-        public float? GetDistance()
-        {
-            Object val = GetFieldValue(0, 0, Fit.SubfieldIndexMainField);
-            if(val == null)
-            {
-                return null;
-            }
+			}
+			set
+			{
+				SetFieldValue(253, 0, value.GetTimeStamp(), Fit.SubfieldIndexMainField);
+			}
+		}
 
-            return (Convert.ToSingle(val));
-            
-        }
+		///<summary>
+		/// Retrieves the Distance field
+		/// Units: m</summary>
+		/// <returns>Returns nullable float representing the Distance field</returns>
+		public float? Distance
+		{
+			get
+			{
+				Object val = GetFieldValue(0, 0, Fit.SubfieldIndexMainField);
+				if (val == null)
+				{
+					return null;
+				}
 
-        /// <summary>
-        /// Set Distance field
-        /// Units: m</summary>
-        /// <param name="distance_">Nullable field value to be set</param>
-        public void SetDistance(float? distance_)
-        {
-            SetFieldValue(0, 0, distance_, Fit.SubfieldIndexMainField);
-        }
-        
-        ///<summary>
-        /// Retrieves the Height field
-        /// Units: m</summary>
-        /// <returns>Returns nullable float representing the Height field</returns>
-        public float? GetHeight()
-        {
-            Object val = GetFieldValue(1, 0, Fit.SubfieldIndexMainField);
-            if(val == null)
-            {
-                return null;
-            }
+				return (Convert.ToSingle(val));
 
-            return (Convert.ToSingle(val));
-            
-        }
+			}
+			set
+			{
+				SetFieldValue(0, 0, value, Fit.SubfieldIndexMainField);
+			}
+		}
 
-        /// <summary>
-        /// Set Height field
-        /// Units: m</summary>
-        /// <param name="height_">Nullable field value to be set</param>
-        public void SetHeight(float? height_)
-        {
-            SetFieldValue(1, 0, height_, Fit.SubfieldIndexMainField);
-        }
-        
-        ///<summary>
-        /// Retrieves the Rotations field</summary>
-        /// <returns>Returns nullable byte representing the Rotations field</returns>
-        public byte? GetRotations()
-        {
-            Object val = GetFieldValue(2, 0, Fit.SubfieldIndexMainField);
-            if(val == null)
-            {
-                return null;
-            }
+		///<summary>
+		/// Retrieves the Height field
+		/// Units: m</summary>
+		/// <returns>Returns nullable float representing the Height field</returns>
+		public float? Height
+		{
+			get
+			{
+				Object val = GetFieldValue(1, 0, Fit.SubfieldIndexMainField);
+				if (val == null)
+				{
+					return null;
+				}
 
-            return (Convert.ToByte(val));
-            
-        }
+				return (Convert.ToSingle(val));
 
-        /// <summary>
-        /// Set Rotations field</summary>
-        /// <param name="rotations_">Nullable field value to be set</param>
-        public void SetRotations(byte? rotations_)
-        {
-            SetFieldValue(2, 0, rotations_, Fit.SubfieldIndexMainField);
-        }
-        
-        ///<summary>
-        /// Retrieves the HangTime field
-        /// Units: s</summary>
-        /// <returns>Returns nullable float representing the HangTime field</returns>
-        public float? GetHangTime()
-        {
-            Object val = GetFieldValue(3, 0, Fit.SubfieldIndexMainField);
-            if(val == null)
-            {
-                return null;
-            }
+			}
+			set
+			{
+				SetFieldValue(1, 0, value, Fit.SubfieldIndexMainField);
+			}
+		}
 
-            return (Convert.ToSingle(val));
-            
-        }
+		///<summary>
+		/// Retrieves the Rotations field</summary>
+		/// <returns>Returns nullable byte representing the Rotations field</returns>
+		public byte? Rotations
+		{
+			get
+			{
+				Object val = GetFieldValue(2, 0, Fit.SubfieldIndexMainField);
+				if (val == null)
+				{
+					return null;
+				}
 
-        /// <summary>
-        /// Set HangTime field
-        /// Units: s</summary>
-        /// <param name="hangTime_">Nullable field value to be set</param>
-        public void SetHangTime(float? hangTime_)
-        {
-            SetFieldValue(3, 0, hangTime_, Fit.SubfieldIndexMainField);
-        }
-        
-        ///<summary>
-        /// Retrieves the Score field
-        /// Comment: A score for a jump calculated based on hang time, rotations, and distance.</summary>
-        /// <returns>Returns nullable float representing the Score field</returns>
-        public float? GetScore()
-        {
-            Object val = GetFieldValue(4, 0, Fit.SubfieldIndexMainField);
-            if(val == null)
-            {
-                return null;
-            }
+				return (Convert.ToByte(val));
 
-            return (Convert.ToSingle(val));
-            
-        }
+			}
+			set
+			{
+				SetFieldValue(2, 0, value, Fit.SubfieldIndexMainField);
+			}
+		}
 
-        /// <summary>
-        /// Set Score field
-        /// Comment: A score for a jump calculated based on hang time, rotations, and distance.</summary>
-        /// <param name="score_">Nullable field value to be set</param>
-        public void SetScore(float? score_)
-        {
-            SetFieldValue(4, 0, score_, Fit.SubfieldIndexMainField);
-        }
-        
-        ///<summary>
-        /// Retrieves the PositionLat field
-        /// Units: semicircles</summary>
-        /// <returns>Returns nullable int representing the PositionLat field</returns>
-        public int? GetPositionLat()
-        {
-            Object val = GetFieldValue(5, 0, Fit.SubfieldIndexMainField);
-            if(val == null)
-            {
-                return null;
-            }
+		///<summary>
+		/// Retrieves the HangTime field
+		/// Units: s</summary>
+		/// <returns>Returns nullable float representing the HangTime field</returns>
+		public float? HangTime
+		{
+			get
+			{
+				Object val = GetFieldValue(3, 0, Fit.SubfieldIndexMainField);
+				if (val == null)
+				{
+					return null;
+				}
 
-            return (Convert.ToInt32(val));
-            
-        }
+				return (Convert.ToSingle(val));
 
-        /// <summary>
-        /// Set PositionLat field
-        /// Units: semicircles</summary>
-        /// <param name="positionLat_">Nullable field value to be set</param>
-        public void SetPositionLat(int? positionLat_)
-        {
-            SetFieldValue(5, 0, positionLat_, Fit.SubfieldIndexMainField);
-        }
-        
-        ///<summary>
-        /// Retrieves the PositionLong field
-        /// Units: semicircles</summary>
-        /// <returns>Returns nullable int representing the PositionLong field</returns>
-        public int? GetPositionLong()
-        {
-            Object val = GetFieldValue(6, 0, Fit.SubfieldIndexMainField);
-            if(val == null)
-            {
-                return null;
-            }
+			}
+			set
+			{
+				SetFieldValue(3, 0, value, Fit.SubfieldIndexMainField);
+			}
+		}
 
-            return (Convert.ToInt32(val));
-            
-        }
+		///<summary>
+		/// Retrieves the Score field
+		/// Comment: A score for a jump calculated based on hang time, rotations, and distance.</summary>
+		/// <returns>Returns nullable float representing the Score field</returns>
+		public float? Score
+		{
+			get
+			{
+				Object val = GetFieldValue(4, 0, Fit.SubfieldIndexMainField);
+				if (val == null)
+				{
+					return null;
+				}
 
-        /// <summary>
-        /// Set PositionLong field
-        /// Units: semicircles</summary>
-        /// <param name="positionLong_">Nullable field value to be set</param>
-        public void SetPositionLong(int? positionLong_)
-        {
-            SetFieldValue(6, 0, positionLong_, Fit.SubfieldIndexMainField);
-        }
-        
-        ///<summary>
-        /// Retrieves the Speed field
-        /// Units: m/s</summary>
-        /// <returns>Returns nullable float representing the Speed field</returns>
-        public float? GetSpeed()
-        {
-            Object val = GetFieldValue(7, 0, Fit.SubfieldIndexMainField);
-            if(val == null)
-            {
-                return null;
-            }
+				return (Convert.ToSingle(val));
 
-            return (Convert.ToSingle(val));
-            
-        }
+			}
+			set
+			{
+				SetFieldValue(4, 0, value, Fit.SubfieldIndexMainField);
+			}
+		}
 
-        /// <summary>
-        /// Set Speed field
-        /// Units: m/s</summary>
-        /// <param name="speed_">Nullable field value to be set</param>
-        public void SetSpeed(float? speed_)
-        {
-            SetFieldValue(7, 0, speed_, Fit.SubfieldIndexMainField);
-        }
-        
-        ///<summary>
-        /// Retrieves the EnhancedSpeed field
-        /// Units: m/s</summary>
-        /// <returns>Returns nullable float representing the EnhancedSpeed field</returns>
-        public float? GetEnhancedSpeed()
-        {
-            Object val = GetFieldValue(8, 0, Fit.SubfieldIndexMainField);
-            if(val == null)
-            {
-                return null;
-            }
+		///<summary>
+		/// Retrieves the PositionLat field
+		/// Units: semicircles</summary>
+		/// <returns>Returns nullable int representing the PositionLat field</returns>
+		public int? PositionLat
+		{
+			get
+			{
+				Object val = GetFieldValue(5, 0, Fit.SubfieldIndexMainField);
+				if (val == null)
+				{
+					return null;
+				}
 
-            return (Convert.ToSingle(val));
-            
-        }
+				return (Convert.ToInt32(val));
 
-        /// <summary>
-        /// Set EnhancedSpeed field
-        /// Units: m/s</summary>
-        /// <param name="enhancedSpeed_">Nullable field value to be set</param>
-        public void SetEnhancedSpeed(float? enhancedSpeed_)
-        {
-            SetFieldValue(8, 0, enhancedSpeed_, Fit.SubfieldIndexMainField);
-        }
-        
-        #endregion // Methods
-    } // Class
+			}
+			set
+			{
+				SetFieldValue(5, 0, value, Fit.SubfieldIndexMainField);
+			}
+		}
+
+		///<summary>
+		/// Retrieves the PositionLong field
+		/// Units: semicircles</summary>
+		/// <returns>Returns nullable int representing the PositionLong field</returns>
+		public int? PositionLong
+		{
+			get
+			{
+				Object val = GetFieldValue(6, 0, Fit.SubfieldIndexMainField);
+				if (val == null)
+				{
+					return null;
+				}
+
+				return (Convert.ToInt32(val));
+
+			}
+			set
+			{
+				SetFieldValue(6, 0, value, Fit.SubfieldIndexMainField);
+			}
+		}
+
+		///<summary>
+		/// Retrieves the Speed field
+		/// Units: m/s</summary>
+		/// <returns>Returns nullable float representing the Speed field</returns>
+		public float? Speed
+		{
+			get
+			{
+				Object val = GetFieldValue(7, 0, Fit.SubfieldIndexMainField);
+				if (val == null)
+				{
+					return null;
+				}
+
+				return (Convert.ToSingle(val));
+
+			}
+			set
+			{
+				SetFieldValue(7, 0, value, Fit.SubfieldIndexMainField);
+			}
+		}
+
+		///<summary>
+		/// Retrieves the EnhancedSpeed field
+		/// Units: m/s</summary>
+		/// <returns>Returns nullable float representing the EnhancedSpeed field</returns>
+		public float? EnhancedSpeed
+		{
+			get
+			{
+				Object val = GetFieldValue(8, 0, Fit.SubfieldIndexMainField);
+				if (val == null)
+				{
+					return null;
+				}
+
+				return (Convert.ToSingle(val));
+
+			}
+			set
+			{
+				SetFieldValue(8, 0, value, Fit.SubfieldIndexMainField);
+			}
+		}
+
+		#endregion // Methods
+	} // Class
 } // namespace

--- a/Dynastream/Fit/Profile/Mesgs/LapMesg.cs
+++ b/Dynastream/Fit/Profile/Mesgs/LapMesg.cs
@@ -21,3606 +21,3382 @@ using System.Linq;
 
 namespace Dynastream.Fit
 {
-    /// <summary>
-    /// Implements the Lap profile message.
-    /// </summary>
-    public class LapMesg : Mesg
-    {
-        #region Fields
-        static class TotalCyclesSubfield
-        {
-            public static ushort TotalStrides = 0;
-            public static ushort TotalStrokes = 1;
-            public static ushort Subfields = 2;
-            public static ushort Active = Fit.SubfieldIndexActiveSubfield;
-            public static ushort MainField = Fit.SubfieldIndexMainField;
-        }
-        static class AvgCadenceSubfield
-        {
-            public static ushort AvgRunningCadence = 0;
-            public static ushort Subfields = 1;
-            public static ushort Active = Fit.SubfieldIndexActiveSubfield;
-            public static ushort MainField = Fit.SubfieldIndexMainField;
-        }
-        static class MaxCadenceSubfield
-        {
-            public static ushort MaxRunningCadence = 0;
-            public static ushort Subfields = 1;
-            public static ushort Active = Fit.SubfieldIndexActiveSubfield;
-            public static ushort MainField = Fit.SubfieldIndexMainField;
-        }
-        #endregion
-
-        /// <summary>
-        /// Field Numbers for <see cref="LapMesg"/>
-        /// </summary>
-        public sealed class FieldDefNum
-        {
-            public const byte MessageIndex = 254;
-            public const byte Timestamp = 253;
-            public const byte Event = 0;
-            public const byte EventType = 1;
-            public const byte StartTime = 2;
-            public const byte StartPositionLat = 3;
-            public const byte StartPositionLong = 4;
-            public const byte EndPositionLat = 5;
-            public const byte EndPositionLong = 6;
-            public const byte TotalElapsedTime = 7;
-            public const byte TotalTimerTime = 8;
-            public const byte TotalDistance = 9;
-            public const byte TotalCycles = 10;
-            public const byte TotalCalories = 11;
-            public const byte TotalFatCalories = 12;
-            public const byte AvgSpeed = 13;
-            public const byte MaxSpeed = 14;
-            public const byte AvgHeartRate = 15;
-            public const byte MaxHeartRate = 16;
-            public const byte AvgCadence = 17;
-            public const byte MaxCadence = 18;
-            public const byte AvgPower = 19;
-            public const byte MaxPower = 20;
-            public const byte TotalAscent = 21;
-            public const byte TotalDescent = 22;
-            public const byte Intensity = 23;
-            public const byte LapTrigger = 24;
-            public const byte Sport = 25;
-            public const byte EventGroup = 26;
-            public const byte NumLengths = 32;
-            public const byte NormalizedPower = 33;
-            public const byte LeftRightBalance = 34;
-            public const byte FirstLengthIndex = 35;
-            public const byte AvgStrokeDistance = 37;
-            public const byte SwimStroke = 38;
-            public const byte SubSport = 39;
-            public const byte NumActiveLengths = 40;
-            public const byte TotalWork = 41;
-            public const byte AvgAltitude = 42;
-            public const byte MaxAltitude = 43;
-            public const byte GpsAccuracy = 44;
-            public const byte AvgGrade = 45;
-            public const byte AvgPosGrade = 46;
-            public const byte AvgNegGrade = 47;
-            public const byte MaxPosGrade = 48;
-            public const byte MaxNegGrade = 49;
-            public const byte AvgTemperature = 50;
-            public const byte MaxTemperature = 51;
-            public const byte TotalMovingTime = 52;
-            public const byte AvgPosVerticalSpeed = 53;
-            public const byte AvgNegVerticalSpeed = 54;
-            public const byte MaxPosVerticalSpeed = 55;
-            public const byte MaxNegVerticalSpeed = 56;
-            public const byte TimeInHrZone = 57;
-            public const byte TimeInSpeedZone = 58;
-            public const byte TimeInCadenceZone = 59;
-            public const byte TimeInPowerZone = 60;
-            public const byte RepetitionNum = 61;
-            public const byte MinAltitude = 62;
-            public const byte MinHeartRate = 63;
-            public const byte WktStepIndex = 71;
-            public const byte OpponentScore = 74;
-            public const byte StrokeCount = 75;
-            public const byte ZoneCount = 76;
-            public const byte AvgVerticalOscillation = 77;
-            public const byte AvgStanceTimePercent = 78;
-            public const byte AvgStanceTime = 79;
-            public const byte AvgFractionalCadence = 80;
-            public const byte MaxFractionalCadence = 81;
-            public const byte TotalFractionalCycles = 82;
-            public const byte PlayerScore = 83;
-            public const byte AvgTotalHemoglobinConc = 84;
-            public const byte MinTotalHemoglobinConc = 85;
-            public const byte MaxTotalHemoglobinConc = 86;
-            public const byte AvgSaturatedHemoglobinPercent = 87;
-            public const byte MinSaturatedHemoglobinPercent = 88;
-            public const byte MaxSaturatedHemoglobinPercent = 89;
-            public const byte AvgLeftTorqueEffectiveness = 91;
-            public const byte AvgRightTorqueEffectiveness = 92;
-            public const byte AvgLeftPedalSmoothness = 93;
-            public const byte AvgRightPedalSmoothness = 94;
-            public const byte AvgCombinedPedalSmoothness = 95;
-            public const byte TimeStanding = 98;
-            public const byte StandCount = 99;
-            public const byte AvgLeftPco = 100;
-            public const byte AvgRightPco = 101;
-            public const byte AvgLeftPowerPhase = 102;
-            public const byte AvgLeftPowerPhasePeak = 103;
-            public const byte AvgRightPowerPhase = 104;
-            public const byte AvgRightPowerPhasePeak = 105;
-            public const byte AvgPowerPosition = 106;
-            public const byte MaxPowerPosition = 107;
-            public const byte AvgCadencePosition = 108;
-            public const byte MaxCadencePosition = 109;
-            public const byte EnhancedAvgSpeed = 110;
-            public const byte EnhancedMaxSpeed = 111;
-            public const byte EnhancedAvgAltitude = 112;
-            public const byte EnhancedMinAltitude = 113;
-            public const byte EnhancedMaxAltitude = 114;
-            public const byte AvgLevMotorPower = 115;
-            public const byte MaxLevMotorPower = 116;
-            public const byte LevBatteryConsumption = 117;
-            public const byte AvgVerticalRatio = 118;
-            public const byte AvgStanceTimeBalance = 119;
-            public const byte AvgStepLength = 120;
-            public const byte AvgVam = 121;
-            public const byte AvgDepth = 122;
-            public const byte MaxDepth = 123;
-            public const byte MinTemperature = 124;
-            public const byte EnhancedAvgRespirationRate = 136;
-            public const byte EnhancedMaxRespirationRate = 137;
-            public const byte AvgRespirationRate = 147;
-            public const byte MaxRespirationRate = 148;
-            public const byte TotalGrit = 149;
-            public const byte TotalFlow = 150;
-            public const byte JumpCount = 151;
-            public const byte AvgGrit = 153;
-            public const byte AvgFlow = 154;
-            public const byte TotalFractionalAscent = 156;
-            public const byte TotalFractionalDescent = 157;
-            public const byte AvgCoreTemperature = 158;
-            public const byte MinCoreTemperature = 159;
-            public const byte MaxCoreTemperature = 160;
-            public const byte Invalid = Fit.FieldNumInvalid;
-        }
-
-        #region Constructors
-        public LapMesg() : base(Profile.GetMesg(MesgNum.Lap))
-        {
-        }
-
-        public LapMesg(Mesg mesg) : base(mesg)
-        {
-        }
-        #endregion // Constructors
-
-        #region Methods
-        ///<summary>
-        /// Retrieves the MessageIndex field</summary>
-        /// <returns>Returns nullable ushort representing the MessageIndex field</returns>
-        public ushort? GetMessageIndex()
-        {
-            Object val = GetFieldValue(254, 0, Fit.SubfieldIndexMainField);
-            if(val == null)
-            {
-                return null;
-            }
-
-            return (Convert.ToUInt16(val));
-            
-        }
-
-        /// <summary>
-        /// Set MessageIndex field</summary>
-        /// <param name="messageIndex_">Nullable field value to be set</param>
-        public void SetMessageIndex(ushort? messageIndex_)
-        {
-            SetFieldValue(254, 0, messageIndex_, Fit.SubfieldIndexMainField);
-        }
-        
-        ///<summary>
-        /// Retrieves the Timestamp field
-        /// Units: s
-        /// Comment: Lap end time.</summary>
-        /// <returns>Returns DateTime representing the Timestamp field</returns>
-        public DateTime GetTimestamp()
-        {
-            Object val = GetFieldValue(253, 0, Fit.SubfieldIndexMainField);
-            if(val == null)
-            {
-                return null;
-            }
-
-            return TimestampToDateTime(Convert.ToUInt32(val));
-            
-        }
-
-        /// <summary>
-        /// Set Timestamp field
-        /// Units: s
-        /// Comment: Lap end time.</summary>
-        /// <param name="timestamp_">Nullable field value to be set</param>
-        public void SetTimestamp(DateTime timestamp_)
-        {
-            SetFieldValue(253, 0, timestamp_.GetTimeStamp(), Fit.SubfieldIndexMainField);
-        }
-        
-        ///<summary>
-        /// Retrieves the Event field</summary>
-        /// <returns>Returns nullable Event enum representing the Event field</returns>
-        public Event? GetEvent()
-        {
-            object obj = GetFieldValue(0, 0, Fit.SubfieldIndexMainField);
-            Event? value = obj == null ? (Event?)null : (Event)obj;
-            return value;
-        }
-
-        /// <summary>
-        /// Set Event field</summary>
-        /// <param name="event_">Nullable field value to be set</param>
-        public void SetEvent(Event? event_)
-        {
-            SetFieldValue(0, 0, event_, Fit.SubfieldIndexMainField);
-        }
-        
-        ///<summary>
-        /// Retrieves the EventType field</summary>
-        /// <returns>Returns nullable EventType enum representing the EventType field</returns>
-        public EventType? GetEventType()
-        {
-            object obj = GetFieldValue(1, 0, Fit.SubfieldIndexMainField);
-            EventType? value = obj == null ? (EventType?)null : (EventType)obj;
-            return value;
-        }
-
-        /// <summary>
-        /// Set EventType field</summary>
-        /// <param name="eventType_">Nullable field value to be set</param>
-        public void SetEventType(EventType? eventType_)
-        {
-            SetFieldValue(1, 0, eventType_, Fit.SubfieldIndexMainField);
-        }
-        
-        ///<summary>
-        /// Retrieves the StartTime field</summary>
-        /// <returns>Returns DateTime representing the StartTime field</returns>
-        public DateTime GetStartTime()
-        {
-            Object val = GetFieldValue(2, 0, Fit.SubfieldIndexMainField);
-            if(val == null)
-            {
-                return null;
-            }
-
-            return TimestampToDateTime(Convert.ToUInt32(val));
-            
-        }
-
-        /// <summary>
-        /// Set StartTime field</summary>
-        /// <param name="startTime_">Nullable field value to be set</param>
-        public void SetStartTime(DateTime startTime_)
-        {
-            SetFieldValue(2, 0, startTime_.GetTimeStamp(), Fit.SubfieldIndexMainField);
-        }
-        
-        ///<summary>
-        /// Retrieves the StartPositionLat field
-        /// Units: semicircles</summary>
-        /// <returns>Returns nullable int representing the StartPositionLat field</returns>
-        public int? GetStartPositionLat()
-        {
-            Object val = GetFieldValue(3, 0, Fit.SubfieldIndexMainField);
-            if(val == null)
-            {
-                return null;
-            }
-
-            return (Convert.ToInt32(val));
-            
-        }
-
-        /// <summary>
-        /// Set StartPositionLat field
-        /// Units: semicircles</summary>
-        /// <param name="startPositionLat_">Nullable field value to be set</param>
-        public void SetStartPositionLat(int? startPositionLat_)
-        {
-            SetFieldValue(3, 0, startPositionLat_, Fit.SubfieldIndexMainField);
-        }
-        
-        ///<summary>
-        /// Retrieves the StartPositionLong field
-        /// Units: semicircles</summary>
-        /// <returns>Returns nullable int representing the StartPositionLong field</returns>
-        public int? GetStartPositionLong()
-        {
-            Object val = GetFieldValue(4, 0, Fit.SubfieldIndexMainField);
-            if(val == null)
-            {
-                return null;
-            }
-
-            return (Convert.ToInt32(val));
-            
-        }
-
-        /// <summary>
-        /// Set StartPositionLong field
-        /// Units: semicircles</summary>
-        /// <param name="startPositionLong_">Nullable field value to be set</param>
-        public void SetStartPositionLong(int? startPositionLong_)
-        {
-            SetFieldValue(4, 0, startPositionLong_, Fit.SubfieldIndexMainField);
-        }
-        
-        ///<summary>
-        /// Retrieves the EndPositionLat field
-        /// Units: semicircles</summary>
-        /// <returns>Returns nullable int representing the EndPositionLat field</returns>
-        public int? GetEndPositionLat()
-        {
-            Object val = GetFieldValue(5, 0, Fit.SubfieldIndexMainField);
-            if(val == null)
-            {
-                return null;
-            }
-
-            return (Convert.ToInt32(val));
-            
-        }
-
-        /// <summary>
-        /// Set EndPositionLat field
-        /// Units: semicircles</summary>
-        /// <param name="endPositionLat_">Nullable field value to be set</param>
-        public void SetEndPositionLat(int? endPositionLat_)
-        {
-            SetFieldValue(5, 0, endPositionLat_, Fit.SubfieldIndexMainField);
-        }
-        
-        ///<summary>
-        /// Retrieves the EndPositionLong field
-        /// Units: semicircles</summary>
-        /// <returns>Returns nullable int representing the EndPositionLong field</returns>
-        public int? GetEndPositionLong()
-        {
-            Object val = GetFieldValue(6, 0, Fit.SubfieldIndexMainField);
-            if(val == null)
-            {
-                return null;
-            }
-
-            return (Convert.ToInt32(val));
-            
-        }
-
-        /// <summary>
-        /// Set EndPositionLong field
-        /// Units: semicircles</summary>
-        /// <param name="endPositionLong_">Nullable field value to be set</param>
-        public void SetEndPositionLong(int? endPositionLong_)
-        {
-            SetFieldValue(6, 0, endPositionLong_, Fit.SubfieldIndexMainField);
-        }
-        
-        ///<summary>
-        /// Retrieves the TotalElapsedTime field
-        /// Units: s
-        /// Comment: Time (includes pauses)</summary>
-        /// <returns>Returns nullable float representing the TotalElapsedTime field</returns>
-        public float? GetTotalElapsedTime()
-        {
-            Object val = GetFieldValue(7, 0, Fit.SubfieldIndexMainField);
-            if(val == null)
-            {
-                return null;
-            }
-
-            return (Convert.ToSingle(val));
-            
-        }
-
-        /// <summary>
-        /// Set TotalElapsedTime field
-        /// Units: s
-        /// Comment: Time (includes pauses)</summary>
-        /// <param name="totalElapsedTime_">Nullable field value to be set</param>
-        public void SetTotalElapsedTime(float? totalElapsedTime_)
-        {
-            SetFieldValue(7, 0, totalElapsedTime_, Fit.SubfieldIndexMainField);
-        }
-        
-        ///<summary>
-        /// Retrieves the TotalTimerTime field
-        /// Units: s
-        /// Comment: Timer Time (excludes pauses)</summary>
-        /// <returns>Returns nullable float representing the TotalTimerTime field</returns>
-        public float? GetTotalTimerTime()
-        {
-            Object val = GetFieldValue(8, 0, Fit.SubfieldIndexMainField);
-            if(val == null)
-            {
-                return null;
-            }
-
-            return (Convert.ToSingle(val));
-            
-        }
-
-        /// <summary>
-        /// Set TotalTimerTime field
-        /// Units: s
-        /// Comment: Timer Time (excludes pauses)</summary>
-        /// <param name="totalTimerTime_">Nullable field value to be set</param>
-        public void SetTotalTimerTime(float? totalTimerTime_)
-        {
-            SetFieldValue(8, 0, totalTimerTime_, Fit.SubfieldIndexMainField);
-        }
-        
-        ///<summary>
-        /// Retrieves the TotalDistance field
-        /// Units: m</summary>
-        /// <returns>Returns nullable float representing the TotalDistance field</returns>
-        public float? GetTotalDistance()
-        {
-            Object val = GetFieldValue(9, 0, Fit.SubfieldIndexMainField);
-            if(val == null)
-            {
-                return null;
-            }
-
-            return (Convert.ToSingle(val));
-            
-        }
-
-        /// <summary>
-        /// Set TotalDistance field
-        /// Units: m</summary>
-        /// <param name="totalDistance_">Nullable field value to be set</param>
-        public void SetTotalDistance(float? totalDistance_)
-        {
-            SetFieldValue(9, 0, totalDistance_, Fit.SubfieldIndexMainField);
-        }
-        
-        ///<summary>
-        /// Retrieves the TotalCycles field
-        /// Units: cycles</summary>
-        /// <returns>Returns nullable uint representing the TotalCycles field</returns>
-        public uint? GetTotalCycles()
-        {
-            Object val = GetFieldValue(10, 0, Fit.SubfieldIndexMainField);
-            if(val == null)
-            {
-                return null;
-            }
-
-            return (Convert.ToUInt32(val));
-            
-        }
-
-        /// <summary>
-        /// Set TotalCycles field
-        /// Units: cycles</summary>
-        /// <param name="totalCycles_">Nullable field value to be set</param>
-        public void SetTotalCycles(uint? totalCycles_)
-        {
-            SetFieldValue(10, 0, totalCycles_, Fit.SubfieldIndexMainField);
-        }
-        
-
-        /// <summary>
-        /// Retrieves the TotalStrides subfield
-        /// Units: strides</summary>
-        /// <returns>Nullable uint representing the TotalStrides subfield</returns>
-        public uint? GetTotalStrides()
-        {
-            Object val = GetFieldValue(10, 0, TotalCyclesSubfield.TotalStrides);
-            if(val == null)
-            {
-                return null;
-            }
-
-            return (Convert.ToUInt32(val));
-            
-        }
-
-        /// <summary>
-        ///
-        /// Set TotalStrides subfield
-        /// Units: strides</summary>
-        /// <param name="totalStrides">Subfield value to be set</param>
-        public void SetTotalStrides(uint? totalStrides)
-        {
-            SetFieldValue(10, 0, totalStrides, TotalCyclesSubfield.TotalStrides);
-        }
-
-        /// <summary>
-        /// Retrieves the TotalStrokes subfield
-        /// Units: strokes</summary>
-        /// <returns>Nullable uint representing the TotalStrokes subfield</returns>
-        public uint? GetTotalStrokes()
-        {
-            Object val = GetFieldValue(10, 0, TotalCyclesSubfield.TotalStrokes);
-            if(val == null)
-            {
-                return null;
-            }
-
-            return (Convert.ToUInt32(val));
-            
-        }
-
-        /// <summary>
-        ///
-        /// Set TotalStrokes subfield
-        /// Units: strokes</summary>
-        /// <param name="totalStrokes">Subfield value to be set</param>
-        public void SetTotalStrokes(uint? totalStrokes)
-        {
-            SetFieldValue(10, 0, totalStrokes, TotalCyclesSubfield.TotalStrokes);
-        }
-        ///<summary>
-        /// Retrieves the TotalCalories field
-        /// Units: kcal</summary>
-        /// <returns>Returns nullable ushort representing the TotalCalories field</returns>
-        public ushort? GetTotalCalories()
-        {
-            Object val = GetFieldValue(11, 0, Fit.SubfieldIndexMainField);
-            if(val == null)
-            {
-                return null;
-            }
-
-            return (Convert.ToUInt16(val));
-            
-        }
-
-        /// <summary>
-        /// Set TotalCalories field
-        /// Units: kcal</summary>
-        /// <param name="totalCalories_">Nullable field value to be set</param>
-        public void SetTotalCalories(ushort? totalCalories_)
-        {
-            SetFieldValue(11, 0, totalCalories_, Fit.SubfieldIndexMainField);
-        }
-        
-        ///<summary>
-        /// Retrieves the TotalFatCalories field
-        /// Units: kcal
-        /// Comment: If New Leaf</summary>
-        /// <returns>Returns nullable ushort representing the TotalFatCalories field</returns>
-        public ushort? GetTotalFatCalories()
-        {
-            Object val = GetFieldValue(12, 0, Fit.SubfieldIndexMainField);
-            if(val == null)
-            {
-                return null;
-            }
-
-            return (Convert.ToUInt16(val));
-            
-        }
-
-        /// <summary>
-        /// Set TotalFatCalories field
-        /// Units: kcal
-        /// Comment: If New Leaf</summary>
-        /// <param name="totalFatCalories_">Nullable field value to be set</param>
-        public void SetTotalFatCalories(ushort? totalFatCalories_)
-        {
-            SetFieldValue(12, 0, totalFatCalories_, Fit.SubfieldIndexMainField);
-        }
-        
-        ///<summary>
-        /// Retrieves the AvgSpeed field
-        /// Units: m/s</summary>
-        /// <returns>Returns nullable float representing the AvgSpeed field</returns>
-        public float? GetAvgSpeed()
-        {
-            Object val = GetFieldValue(13, 0, Fit.SubfieldIndexMainField);
-            if(val == null)
-            {
-                return null;
-            }
-
-            return (Convert.ToSingle(val));
-            
-        }
-
-        /// <summary>
-        /// Set AvgSpeed field
-        /// Units: m/s</summary>
-        /// <param name="avgSpeed_">Nullable field value to be set</param>
-        public void SetAvgSpeed(float? avgSpeed_)
-        {
-            SetFieldValue(13, 0, avgSpeed_, Fit.SubfieldIndexMainField);
-        }
-        
-        ///<summary>
-        /// Retrieves the MaxSpeed field
-        /// Units: m/s</summary>
-        /// <returns>Returns nullable float representing the MaxSpeed field</returns>
-        public float? GetMaxSpeed()
-        {
-            Object val = GetFieldValue(14, 0, Fit.SubfieldIndexMainField);
-            if(val == null)
-            {
-                return null;
-            }
-
-            return (Convert.ToSingle(val));
-            
-        }
-
-        /// <summary>
-        /// Set MaxSpeed field
-        /// Units: m/s</summary>
-        /// <param name="maxSpeed_">Nullable field value to be set</param>
-        public void SetMaxSpeed(float? maxSpeed_)
-        {
-            SetFieldValue(14, 0, maxSpeed_, Fit.SubfieldIndexMainField);
-        }
-        
-        ///<summary>
-        /// Retrieves the AvgHeartRate field
-        /// Units: bpm</summary>
-        /// <returns>Returns nullable byte representing the AvgHeartRate field</returns>
-        public byte? GetAvgHeartRate()
-        {
-            Object val = GetFieldValue(15, 0, Fit.SubfieldIndexMainField);
-            if(val == null)
-            {
-                return null;
-            }
-
-            return (Convert.ToByte(val));
-            
-        }
-
-        /// <summary>
-        /// Set AvgHeartRate field
-        /// Units: bpm</summary>
-        /// <param name="avgHeartRate_">Nullable field value to be set</param>
-        public void SetAvgHeartRate(byte? avgHeartRate_)
-        {
-            SetFieldValue(15, 0, avgHeartRate_, Fit.SubfieldIndexMainField);
-        }
-        
-        ///<summary>
-        /// Retrieves the MaxHeartRate field
-        /// Units: bpm</summary>
-        /// <returns>Returns nullable byte representing the MaxHeartRate field</returns>
-        public byte? GetMaxHeartRate()
-        {
-            Object val = GetFieldValue(16, 0, Fit.SubfieldIndexMainField);
-            if(val == null)
-            {
-                return null;
-            }
-
-            return (Convert.ToByte(val));
-            
-        }
-
-        /// <summary>
-        /// Set MaxHeartRate field
-        /// Units: bpm</summary>
-        /// <param name="maxHeartRate_">Nullable field value to be set</param>
-        public void SetMaxHeartRate(byte? maxHeartRate_)
-        {
-            SetFieldValue(16, 0, maxHeartRate_, Fit.SubfieldIndexMainField);
-        }
-        
-        ///<summary>
-        /// Retrieves the AvgCadence field
-        /// Units: rpm
-        /// Comment: total_cycles / total_timer_time if non_zero_avg_cadence otherwise total_cycles / total_elapsed_time</summary>
-        /// <returns>Returns nullable byte representing the AvgCadence field</returns>
-        public byte? GetAvgCadence()
-        {
-            Object val = GetFieldValue(17, 0, Fit.SubfieldIndexMainField);
-            if(val == null)
-            {
-                return null;
-            }
-
-            return (Convert.ToByte(val));
-            
-        }
-
-        /// <summary>
-        /// Set AvgCadence field
-        /// Units: rpm
-        /// Comment: total_cycles / total_timer_time if non_zero_avg_cadence otherwise total_cycles / total_elapsed_time</summary>
-        /// <param name="avgCadence_">Nullable field value to be set</param>
-        public void SetAvgCadence(byte? avgCadence_)
-        {
-            SetFieldValue(17, 0, avgCadence_, Fit.SubfieldIndexMainField);
-        }
-        
-
-        /// <summary>
-        /// Retrieves the AvgRunningCadence subfield
-        /// Units: strides/min</summary>
-        /// <returns>Nullable byte representing the AvgRunningCadence subfield</returns>
-        public byte? GetAvgRunningCadence()
-        {
-            Object val = GetFieldValue(17, 0, AvgCadenceSubfield.AvgRunningCadence);
-            if(val == null)
-            {
-                return null;
-            }
-
-            return (Convert.ToByte(val));
-            
-        }
-
-        /// <summary>
-        ///
-        /// Set AvgRunningCadence subfield
-        /// Units: strides/min</summary>
-        /// <param name="avgRunningCadence">Subfield value to be set</param>
-        public void SetAvgRunningCadence(byte? avgRunningCadence)
-        {
-            SetFieldValue(17, 0, avgRunningCadence, AvgCadenceSubfield.AvgRunningCadence);
-        }
-        ///<summary>
-        /// Retrieves the MaxCadence field
-        /// Units: rpm</summary>
-        /// <returns>Returns nullable byte representing the MaxCadence field</returns>
-        public byte? GetMaxCadence()
-        {
-            Object val = GetFieldValue(18, 0, Fit.SubfieldIndexMainField);
-            if(val == null)
-            {
-                return null;
-            }
-
-            return (Convert.ToByte(val));
-            
-        }
-
-        /// <summary>
-        /// Set MaxCadence field
-        /// Units: rpm</summary>
-        /// <param name="maxCadence_">Nullable field value to be set</param>
-        public void SetMaxCadence(byte? maxCadence_)
-        {
-            SetFieldValue(18, 0, maxCadence_, Fit.SubfieldIndexMainField);
-        }
-        
-
-        /// <summary>
-        /// Retrieves the MaxRunningCadence subfield
-        /// Units: strides/min</summary>
-        /// <returns>Nullable byte representing the MaxRunningCadence subfield</returns>
-        public byte? GetMaxRunningCadence()
-        {
-            Object val = GetFieldValue(18, 0, MaxCadenceSubfield.MaxRunningCadence);
-            if(val == null)
-            {
-                return null;
-            }
-
-            return (Convert.ToByte(val));
-            
-        }
-
-        /// <summary>
-        ///
-        /// Set MaxRunningCadence subfield
-        /// Units: strides/min</summary>
-        /// <param name="maxRunningCadence">Subfield value to be set</param>
-        public void SetMaxRunningCadence(byte? maxRunningCadence)
-        {
-            SetFieldValue(18, 0, maxRunningCadence, MaxCadenceSubfield.MaxRunningCadence);
-        }
-        ///<summary>
-        /// Retrieves the AvgPower field
-        /// Units: watts
-        /// Comment: total_power / total_timer_time if non_zero_avg_power otherwise total_power / total_elapsed_time</summary>
-        /// <returns>Returns nullable ushort representing the AvgPower field</returns>
-        public ushort? GetAvgPower()
-        {
-            Object val = GetFieldValue(19, 0, Fit.SubfieldIndexMainField);
-            if(val == null)
-            {
-                return null;
-            }
-
-            return (Convert.ToUInt16(val));
-            
-        }
-
-        /// <summary>
-        /// Set AvgPower field
-        /// Units: watts
-        /// Comment: total_power / total_timer_time if non_zero_avg_power otherwise total_power / total_elapsed_time</summary>
-        /// <param name="avgPower_">Nullable field value to be set</param>
-        public void SetAvgPower(ushort? avgPower_)
-        {
-            SetFieldValue(19, 0, avgPower_, Fit.SubfieldIndexMainField);
-        }
-        
-        ///<summary>
-        /// Retrieves the MaxPower field
-        /// Units: watts</summary>
-        /// <returns>Returns nullable ushort representing the MaxPower field</returns>
-        public ushort? GetMaxPower()
-        {
-            Object val = GetFieldValue(20, 0, Fit.SubfieldIndexMainField);
-            if(val == null)
-            {
-                return null;
-            }
-
-            return (Convert.ToUInt16(val));
-            
-        }
-
-        /// <summary>
-        /// Set MaxPower field
-        /// Units: watts</summary>
-        /// <param name="maxPower_">Nullable field value to be set</param>
-        public void SetMaxPower(ushort? maxPower_)
-        {
-            SetFieldValue(20, 0, maxPower_, Fit.SubfieldIndexMainField);
-        }
-        
-        ///<summary>
-        /// Retrieves the TotalAscent field
-        /// Units: m</summary>
-        /// <returns>Returns nullable ushort representing the TotalAscent field</returns>
-        public ushort? GetTotalAscent()
-        {
-            Object val = GetFieldValue(21, 0, Fit.SubfieldIndexMainField);
-            if(val == null)
-            {
-                return null;
-            }
-
-            return (Convert.ToUInt16(val));
-            
-        }
-
-        /// <summary>
-        /// Set TotalAscent field
-        /// Units: m</summary>
-        /// <param name="totalAscent_">Nullable field value to be set</param>
-        public void SetTotalAscent(ushort? totalAscent_)
-        {
-            SetFieldValue(21, 0, totalAscent_, Fit.SubfieldIndexMainField);
-        }
-        
-        ///<summary>
-        /// Retrieves the TotalDescent field
-        /// Units: m</summary>
-        /// <returns>Returns nullable ushort representing the TotalDescent field</returns>
-        public ushort? GetTotalDescent()
-        {
-            Object val = GetFieldValue(22, 0, Fit.SubfieldIndexMainField);
-            if(val == null)
-            {
-                return null;
-            }
-
-            return (Convert.ToUInt16(val));
-            
-        }
-
-        /// <summary>
-        /// Set TotalDescent field
-        /// Units: m</summary>
-        /// <param name="totalDescent_">Nullable field value to be set</param>
-        public void SetTotalDescent(ushort? totalDescent_)
-        {
-            SetFieldValue(22, 0, totalDescent_, Fit.SubfieldIndexMainField);
-        }
-        
-        ///<summary>
-        /// Retrieves the Intensity field</summary>
-        /// <returns>Returns nullable Intensity enum representing the Intensity field</returns>
-        public Intensity? GetIntensity()
-        {
-            object obj = GetFieldValue(23, 0, Fit.SubfieldIndexMainField);
-            Intensity? value = obj == null ? (Intensity?)null : (Intensity)obj;
-            return value;
-        }
-
-        /// <summary>
-        /// Set Intensity field</summary>
-        /// <param name="intensity_">Nullable field value to be set</param>
-        public void SetIntensity(Intensity? intensity_)
-        {
-            SetFieldValue(23, 0, intensity_, Fit.SubfieldIndexMainField);
-        }
-        
-        ///<summary>
-        /// Retrieves the LapTrigger field</summary>
-        /// <returns>Returns nullable LapTrigger enum representing the LapTrigger field</returns>
-        public LapTrigger? GetLapTrigger()
-        {
-            object obj = GetFieldValue(24, 0, Fit.SubfieldIndexMainField);
-            LapTrigger? value = obj == null ? (LapTrigger?)null : (LapTrigger)obj;
-            return value;
-        }
-
-        /// <summary>
-        /// Set LapTrigger field</summary>
-        /// <param name="lapTrigger_">Nullable field value to be set</param>
-        public void SetLapTrigger(LapTrigger? lapTrigger_)
-        {
-            SetFieldValue(24, 0, lapTrigger_, Fit.SubfieldIndexMainField);
-        }
-        
-        ///<summary>
-        /// Retrieves the Sport field</summary>
-        /// <returns>Returns nullable Sport enum representing the Sport field</returns>
-        public Sport? GetSport()
-        {
-            object obj = GetFieldValue(25, 0, Fit.SubfieldIndexMainField);
-            Sport? value = obj == null ? (Sport?)null : (Sport)obj;
-            return value;
-        }
-
-        /// <summary>
-        /// Set Sport field</summary>
-        /// <param name="sport_">Nullable field value to be set</param>
-        public void SetSport(Sport? sport_)
-        {
-            SetFieldValue(25, 0, sport_, Fit.SubfieldIndexMainField);
-        }
-        
-        ///<summary>
-        /// Retrieves the EventGroup field</summary>
-        /// <returns>Returns nullable byte representing the EventGroup field</returns>
-        public byte? GetEventGroup()
-        {
-            Object val = GetFieldValue(26, 0, Fit.SubfieldIndexMainField);
-            if(val == null)
-            {
-                return null;
-            }
-
-            return (Convert.ToByte(val));
-            
-        }
-
-        /// <summary>
-        /// Set EventGroup field</summary>
-        /// <param name="eventGroup_">Nullable field value to be set</param>
-        public void SetEventGroup(byte? eventGroup_)
-        {
-            SetFieldValue(26, 0, eventGroup_, Fit.SubfieldIndexMainField);
-        }
-        
-        ///<summary>
-        /// Retrieves the NumLengths field
-        /// Units: lengths
-        /// Comment: # of lengths of swim pool</summary>
-        /// <returns>Returns nullable ushort representing the NumLengths field</returns>
-        public ushort? GetNumLengths()
-        {
-            Object val = GetFieldValue(32, 0, Fit.SubfieldIndexMainField);
-            if(val == null)
-            {
-                return null;
-            }
-
-            return (Convert.ToUInt16(val));
-            
-        }
-
-        /// <summary>
-        /// Set NumLengths field
-        /// Units: lengths
-        /// Comment: # of lengths of swim pool</summary>
-        /// <param name="numLengths_">Nullable field value to be set</param>
-        public void SetNumLengths(ushort? numLengths_)
-        {
-            SetFieldValue(32, 0, numLengths_, Fit.SubfieldIndexMainField);
-        }
-        
-        ///<summary>
-        /// Retrieves the NormalizedPower field
-        /// Units: watts</summary>
-        /// <returns>Returns nullable ushort representing the NormalizedPower field</returns>
-        public ushort? GetNormalizedPower()
-        {
-            Object val = GetFieldValue(33, 0, Fit.SubfieldIndexMainField);
-            if(val == null)
-            {
-                return null;
-            }
-
-            return (Convert.ToUInt16(val));
-            
-        }
-
-        /// <summary>
-        /// Set NormalizedPower field
-        /// Units: watts</summary>
-        /// <param name="normalizedPower_">Nullable field value to be set</param>
-        public void SetNormalizedPower(ushort? normalizedPower_)
-        {
-            SetFieldValue(33, 0, normalizedPower_, Fit.SubfieldIndexMainField);
-        }
-        
-        ///<summary>
-        /// Retrieves the LeftRightBalance field</summary>
-        /// <returns>Returns nullable ushort representing the LeftRightBalance field</returns>
-        public ushort? GetLeftRightBalance()
-        {
-            Object val = GetFieldValue(34, 0, Fit.SubfieldIndexMainField);
-            if(val == null)
-            {
-                return null;
-            }
-
-            return (Convert.ToUInt16(val));
-            
-        }
-
-        /// <summary>
-        /// Set LeftRightBalance field</summary>
-        /// <param name="leftRightBalance_">Nullable field value to be set</param>
-        public void SetLeftRightBalance(ushort? leftRightBalance_)
-        {
-            SetFieldValue(34, 0, leftRightBalance_, Fit.SubfieldIndexMainField);
-        }
-        
-        ///<summary>
-        /// Retrieves the FirstLengthIndex field</summary>
-        /// <returns>Returns nullable ushort representing the FirstLengthIndex field</returns>
-        public ushort? GetFirstLengthIndex()
-        {
-            Object val = GetFieldValue(35, 0, Fit.SubfieldIndexMainField);
-            if(val == null)
-            {
-                return null;
-            }
-
-            return (Convert.ToUInt16(val));
-            
-        }
-
-        /// <summary>
-        /// Set FirstLengthIndex field</summary>
-        /// <param name="firstLengthIndex_">Nullable field value to be set</param>
-        public void SetFirstLengthIndex(ushort? firstLengthIndex_)
-        {
-            SetFieldValue(35, 0, firstLengthIndex_, Fit.SubfieldIndexMainField);
-        }
-        
-        ///<summary>
-        /// Retrieves the AvgStrokeDistance field
-        /// Units: m</summary>
-        /// <returns>Returns nullable float representing the AvgStrokeDistance field</returns>
-        public float? GetAvgStrokeDistance()
-        {
-            Object val = GetFieldValue(37, 0, Fit.SubfieldIndexMainField);
-            if(val == null)
-            {
-                return null;
-            }
-
-            return (Convert.ToSingle(val));
-            
-        }
-
-        /// <summary>
-        /// Set AvgStrokeDistance field
-        /// Units: m</summary>
-        /// <param name="avgStrokeDistance_">Nullable field value to be set</param>
-        public void SetAvgStrokeDistance(float? avgStrokeDistance_)
-        {
-            SetFieldValue(37, 0, avgStrokeDistance_, Fit.SubfieldIndexMainField);
-        }
-        
-        ///<summary>
-        /// Retrieves the SwimStroke field</summary>
-        /// <returns>Returns nullable SwimStroke enum representing the SwimStroke field</returns>
-        public SwimStroke? GetSwimStroke()
-        {
-            object obj = GetFieldValue(38, 0, Fit.SubfieldIndexMainField);
-            SwimStroke? value = obj == null ? (SwimStroke?)null : (SwimStroke)obj;
-            return value;
-        }
-
-        /// <summary>
-        /// Set SwimStroke field</summary>
-        /// <param name="swimStroke_">Nullable field value to be set</param>
-        public void SetSwimStroke(SwimStroke? swimStroke_)
-        {
-            SetFieldValue(38, 0, swimStroke_, Fit.SubfieldIndexMainField);
-        }
-        
-        ///<summary>
-        /// Retrieves the SubSport field</summary>
-        /// <returns>Returns nullable SubSport enum representing the SubSport field</returns>
-        public SubSport? GetSubSport()
-        {
-            object obj = GetFieldValue(39, 0, Fit.SubfieldIndexMainField);
-            SubSport? value = obj == null ? (SubSport?)null : (SubSport)obj;
-            return value;
-        }
-
-        /// <summary>
-        /// Set SubSport field</summary>
-        /// <param name="subSport_">Nullable field value to be set</param>
-        public void SetSubSport(SubSport? subSport_)
-        {
-            SetFieldValue(39, 0, subSport_, Fit.SubfieldIndexMainField);
-        }
-        
-        ///<summary>
-        /// Retrieves the NumActiveLengths field
-        /// Units: lengths
-        /// Comment: # of active lengths of swim pool</summary>
-        /// <returns>Returns nullable ushort representing the NumActiveLengths field</returns>
-        public ushort? GetNumActiveLengths()
-        {
-            Object val = GetFieldValue(40, 0, Fit.SubfieldIndexMainField);
-            if(val == null)
-            {
-                return null;
-            }
-
-            return (Convert.ToUInt16(val));
-            
-        }
-
-        /// <summary>
-        /// Set NumActiveLengths field
-        /// Units: lengths
-        /// Comment: # of active lengths of swim pool</summary>
-        /// <param name="numActiveLengths_">Nullable field value to be set</param>
-        public void SetNumActiveLengths(ushort? numActiveLengths_)
-        {
-            SetFieldValue(40, 0, numActiveLengths_, Fit.SubfieldIndexMainField);
-        }
-        
-        ///<summary>
-        /// Retrieves the TotalWork field
-        /// Units: J</summary>
-        /// <returns>Returns nullable uint representing the TotalWork field</returns>
-        public uint? GetTotalWork()
-        {
-            Object val = GetFieldValue(41, 0, Fit.SubfieldIndexMainField);
-            if(val == null)
-            {
-                return null;
-            }
-
-            return (Convert.ToUInt32(val));
-            
-        }
-
-        /// <summary>
-        /// Set TotalWork field
-        /// Units: J</summary>
-        /// <param name="totalWork_">Nullable field value to be set</param>
-        public void SetTotalWork(uint? totalWork_)
-        {
-            SetFieldValue(41, 0, totalWork_, Fit.SubfieldIndexMainField);
-        }
-        
-        ///<summary>
-        /// Retrieves the AvgAltitude field
-        /// Units: m</summary>
-        /// <returns>Returns nullable float representing the AvgAltitude field</returns>
-        public float? GetAvgAltitude()
-        {
-            Object val = GetFieldValue(42, 0, Fit.SubfieldIndexMainField);
-            if(val == null)
-            {
-                return null;
-            }
-
-            return (Convert.ToSingle(val));
-            
-        }
-
-        /// <summary>
-        /// Set AvgAltitude field
-        /// Units: m</summary>
-        /// <param name="avgAltitude_">Nullable field value to be set</param>
-        public void SetAvgAltitude(float? avgAltitude_)
-        {
-            SetFieldValue(42, 0, avgAltitude_, Fit.SubfieldIndexMainField);
-        }
-        
-        ///<summary>
-        /// Retrieves the MaxAltitude field
-        /// Units: m</summary>
-        /// <returns>Returns nullable float representing the MaxAltitude field</returns>
-        public float? GetMaxAltitude()
-        {
-            Object val = GetFieldValue(43, 0, Fit.SubfieldIndexMainField);
-            if(val == null)
-            {
-                return null;
-            }
-
-            return (Convert.ToSingle(val));
-            
-        }
-
-        /// <summary>
-        /// Set MaxAltitude field
-        /// Units: m</summary>
-        /// <param name="maxAltitude_">Nullable field value to be set</param>
-        public void SetMaxAltitude(float? maxAltitude_)
-        {
-            SetFieldValue(43, 0, maxAltitude_, Fit.SubfieldIndexMainField);
-        }
-        
-        ///<summary>
-        /// Retrieves the GpsAccuracy field
-        /// Units: m</summary>
-        /// <returns>Returns nullable byte representing the GpsAccuracy field</returns>
-        public byte? GetGpsAccuracy()
-        {
-            Object val = GetFieldValue(44, 0, Fit.SubfieldIndexMainField);
-            if(val == null)
-            {
-                return null;
-            }
-
-            return (Convert.ToByte(val));
-            
-        }
-
-        /// <summary>
-        /// Set GpsAccuracy field
-        /// Units: m</summary>
-        /// <param name="gpsAccuracy_">Nullable field value to be set</param>
-        public void SetGpsAccuracy(byte? gpsAccuracy_)
-        {
-            SetFieldValue(44, 0, gpsAccuracy_, Fit.SubfieldIndexMainField);
-        }
-        
-        ///<summary>
-        /// Retrieves the AvgGrade field
-        /// Units: %</summary>
-        /// <returns>Returns nullable float representing the AvgGrade field</returns>
-        public float? GetAvgGrade()
-        {
-            Object val = GetFieldValue(45, 0, Fit.SubfieldIndexMainField);
-            if(val == null)
-            {
-                return null;
-            }
-
-            return (Convert.ToSingle(val));
-            
-        }
-
-        /// <summary>
-        /// Set AvgGrade field
-        /// Units: %</summary>
-        /// <param name="avgGrade_">Nullable field value to be set</param>
-        public void SetAvgGrade(float? avgGrade_)
-        {
-            SetFieldValue(45, 0, avgGrade_, Fit.SubfieldIndexMainField);
-        }
-        
-        ///<summary>
-        /// Retrieves the AvgPosGrade field
-        /// Units: %</summary>
-        /// <returns>Returns nullable float representing the AvgPosGrade field</returns>
-        public float? GetAvgPosGrade()
-        {
-            Object val = GetFieldValue(46, 0, Fit.SubfieldIndexMainField);
-            if(val == null)
-            {
-                return null;
-            }
-
-            return (Convert.ToSingle(val));
-            
-        }
-
-        /// <summary>
-        /// Set AvgPosGrade field
-        /// Units: %</summary>
-        /// <param name="avgPosGrade_">Nullable field value to be set</param>
-        public void SetAvgPosGrade(float? avgPosGrade_)
-        {
-            SetFieldValue(46, 0, avgPosGrade_, Fit.SubfieldIndexMainField);
-        }
-        
-        ///<summary>
-        /// Retrieves the AvgNegGrade field
-        /// Units: %</summary>
-        /// <returns>Returns nullable float representing the AvgNegGrade field</returns>
-        public float? GetAvgNegGrade()
-        {
-            Object val = GetFieldValue(47, 0, Fit.SubfieldIndexMainField);
-            if(val == null)
-            {
-                return null;
-            }
-
-            return (Convert.ToSingle(val));
-            
-        }
-
-        /// <summary>
-        /// Set AvgNegGrade field
-        /// Units: %</summary>
-        /// <param name="avgNegGrade_">Nullable field value to be set</param>
-        public void SetAvgNegGrade(float? avgNegGrade_)
-        {
-            SetFieldValue(47, 0, avgNegGrade_, Fit.SubfieldIndexMainField);
-        }
-        
-        ///<summary>
-        /// Retrieves the MaxPosGrade field
-        /// Units: %</summary>
-        /// <returns>Returns nullable float representing the MaxPosGrade field</returns>
-        public float? GetMaxPosGrade()
-        {
-            Object val = GetFieldValue(48, 0, Fit.SubfieldIndexMainField);
-            if(val == null)
-            {
-                return null;
-            }
-
-            return (Convert.ToSingle(val));
-            
-        }
-
-        /// <summary>
-        /// Set MaxPosGrade field
-        /// Units: %</summary>
-        /// <param name="maxPosGrade_">Nullable field value to be set</param>
-        public void SetMaxPosGrade(float? maxPosGrade_)
-        {
-            SetFieldValue(48, 0, maxPosGrade_, Fit.SubfieldIndexMainField);
-        }
-        
-        ///<summary>
-        /// Retrieves the MaxNegGrade field
-        /// Units: %</summary>
-        /// <returns>Returns nullable float representing the MaxNegGrade field</returns>
-        public float? GetMaxNegGrade()
-        {
-            Object val = GetFieldValue(49, 0, Fit.SubfieldIndexMainField);
-            if(val == null)
-            {
-                return null;
-            }
-
-            return (Convert.ToSingle(val));
-            
-        }
-
-        /// <summary>
-        /// Set MaxNegGrade field
-        /// Units: %</summary>
-        /// <param name="maxNegGrade_">Nullable field value to be set</param>
-        public void SetMaxNegGrade(float? maxNegGrade_)
-        {
-            SetFieldValue(49, 0, maxNegGrade_, Fit.SubfieldIndexMainField);
-        }
-        
-        ///<summary>
-        /// Retrieves the AvgTemperature field
-        /// Units: C</summary>
-        /// <returns>Returns nullable sbyte representing the AvgTemperature field</returns>
-        public sbyte? GetAvgTemperature()
-        {
-            Object val = GetFieldValue(50, 0, Fit.SubfieldIndexMainField);
-            if(val == null)
-            {
-                return null;
-            }
-
-            return (Convert.ToSByte(val));
-            
-        }
-
-        /// <summary>
-        /// Set AvgTemperature field
-        /// Units: C</summary>
-        /// <param name="avgTemperature_">Nullable field value to be set</param>
-        public void SetAvgTemperature(sbyte? avgTemperature_)
-        {
-            SetFieldValue(50, 0, avgTemperature_, Fit.SubfieldIndexMainField);
-        }
-        
-        ///<summary>
-        /// Retrieves the MaxTemperature field
-        /// Units: C</summary>
-        /// <returns>Returns nullable sbyte representing the MaxTemperature field</returns>
-        public sbyte? GetMaxTemperature()
-        {
-            Object val = GetFieldValue(51, 0, Fit.SubfieldIndexMainField);
-            if(val == null)
-            {
-                return null;
-            }
-
-            return (Convert.ToSByte(val));
-            
-        }
-
-        /// <summary>
-        /// Set MaxTemperature field
-        /// Units: C</summary>
-        /// <param name="maxTemperature_">Nullable field value to be set</param>
-        public void SetMaxTemperature(sbyte? maxTemperature_)
-        {
-            SetFieldValue(51, 0, maxTemperature_, Fit.SubfieldIndexMainField);
-        }
-        
-        ///<summary>
-        /// Retrieves the TotalMovingTime field
-        /// Units: s</summary>
-        /// <returns>Returns nullable float representing the TotalMovingTime field</returns>
-        public float? GetTotalMovingTime()
-        {
-            Object val = GetFieldValue(52, 0, Fit.SubfieldIndexMainField);
-            if(val == null)
-            {
-                return null;
-            }
-
-            return (Convert.ToSingle(val));
-            
-        }
-
-        /// <summary>
-        /// Set TotalMovingTime field
-        /// Units: s</summary>
-        /// <param name="totalMovingTime_">Nullable field value to be set</param>
-        public void SetTotalMovingTime(float? totalMovingTime_)
-        {
-            SetFieldValue(52, 0, totalMovingTime_, Fit.SubfieldIndexMainField);
-        }
-        
-        ///<summary>
-        /// Retrieves the AvgPosVerticalSpeed field
-        /// Units: m/s</summary>
-        /// <returns>Returns nullable float representing the AvgPosVerticalSpeed field</returns>
-        public float? GetAvgPosVerticalSpeed()
-        {
-            Object val = GetFieldValue(53, 0, Fit.SubfieldIndexMainField);
-            if(val == null)
-            {
-                return null;
-            }
-
-            return (Convert.ToSingle(val));
-            
-        }
-
-        /// <summary>
-        /// Set AvgPosVerticalSpeed field
-        /// Units: m/s</summary>
-        /// <param name="avgPosVerticalSpeed_">Nullable field value to be set</param>
-        public void SetAvgPosVerticalSpeed(float? avgPosVerticalSpeed_)
-        {
-            SetFieldValue(53, 0, avgPosVerticalSpeed_, Fit.SubfieldIndexMainField);
-        }
-        
-        ///<summary>
-        /// Retrieves the AvgNegVerticalSpeed field
-        /// Units: m/s</summary>
-        /// <returns>Returns nullable float representing the AvgNegVerticalSpeed field</returns>
-        public float? GetAvgNegVerticalSpeed()
-        {
-            Object val = GetFieldValue(54, 0, Fit.SubfieldIndexMainField);
-            if(val == null)
-            {
-                return null;
-            }
-
-            return (Convert.ToSingle(val));
-            
-        }
-
-        /// <summary>
-        /// Set AvgNegVerticalSpeed field
-        /// Units: m/s</summary>
-        /// <param name="avgNegVerticalSpeed_">Nullable field value to be set</param>
-        public void SetAvgNegVerticalSpeed(float? avgNegVerticalSpeed_)
-        {
-            SetFieldValue(54, 0, avgNegVerticalSpeed_, Fit.SubfieldIndexMainField);
-        }
-        
-        ///<summary>
-        /// Retrieves the MaxPosVerticalSpeed field
-        /// Units: m/s</summary>
-        /// <returns>Returns nullable float representing the MaxPosVerticalSpeed field</returns>
-        public float? GetMaxPosVerticalSpeed()
-        {
-            Object val = GetFieldValue(55, 0, Fit.SubfieldIndexMainField);
-            if(val == null)
-            {
-                return null;
-            }
-
-            return (Convert.ToSingle(val));
-            
-        }
-
-        /// <summary>
-        /// Set MaxPosVerticalSpeed field
-        /// Units: m/s</summary>
-        /// <param name="maxPosVerticalSpeed_">Nullable field value to be set</param>
-        public void SetMaxPosVerticalSpeed(float? maxPosVerticalSpeed_)
-        {
-            SetFieldValue(55, 0, maxPosVerticalSpeed_, Fit.SubfieldIndexMainField);
-        }
-        
-        ///<summary>
-        /// Retrieves the MaxNegVerticalSpeed field
-        /// Units: m/s</summary>
-        /// <returns>Returns nullable float representing the MaxNegVerticalSpeed field</returns>
-        public float? GetMaxNegVerticalSpeed()
-        {
-            Object val = GetFieldValue(56, 0, Fit.SubfieldIndexMainField);
-            if(val == null)
-            {
-                return null;
-            }
-
-            return (Convert.ToSingle(val));
-            
-        }
-
-        /// <summary>
-        /// Set MaxNegVerticalSpeed field
-        /// Units: m/s</summary>
-        /// <param name="maxNegVerticalSpeed_">Nullable field value to be set</param>
-        public void SetMaxNegVerticalSpeed(float? maxNegVerticalSpeed_)
-        {
-            SetFieldValue(56, 0, maxNegVerticalSpeed_, Fit.SubfieldIndexMainField);
-        }
-        
-        
-        /// <summary>
-        ///
-        /// </summary>
-        /// <returns>returns number of elements in field TimeInHrZone</returns>
-        public int GetNumTimeInHrZone()
-        {
-            return GetNumFieldValues(57, Fit.SubfieldIndexMainField);
-        }
-
-        ///<summary>
-        /// Retrieves the TimeInHrZone field
-        /// Units: s</summary>
-        /// <param name="index">0 based index of TimeInHrZone element to retrieve</param>
-        /// <returns>Returns nullable float representing the TimeInHrZone field</returns>
-        public float? GetTimeInHrZone(int index)
-        {
-            Object val = GetFieldValue(57, index, Fit.SubfieldIndexMainField);
-            if(val == null)
-            {
-                return null;
-            }
-
-            return (Convert.ToSingle(val));
-            
-        }
-
-        /// <summary>
-        /// Set TimeInHrZone field
-        /// Units: s</summary>
-        /// <param name="index">0 based index of time_in_hr_zone</param>
-        /// <param name="timeInHrZone_">Nullable field value to be set</param>
-        public void SetTimeInHrZone(int index, float? timeInHrZone_)
-        {
-            SetFieldValue(57, index, timeInHrZone_, Fit.SubfieldIndexMainField);
-        }
-        
-        
-        /// <summary>
-        ///
-        /// </summary>
-        /// <returns>returns number of elements in field TimeInSpeedZone</returns>
-        public int GetNumTimeInSpeedZone()
-        {
-            return GetNumFieldValues(58, Fit.SubfieldIndexMainField);
-        }
-
-        ///<summary>
-        /// Retrieves the TimeInSpeedZone field
-        /// Units: s</summary>
-        /// <param name="index">0 based index of TimeInSpeedZone element to retrieve</param>
-        /// <returns>Returns nullable float representing the TimeInSpeedZone field</returns>
-        public float? GetTimeInSpeedZone(int index)
-        {
-            Object val = GetFieldValue(58, index, Fit.SubfieldIndexMainField);
-            if(val == null)
-            {
-                return null;
-            }
-
-            return (Convert.ToSingle(val));
-            
-        }
-
-        /// <summary>
-        /// Set TimeInSpeedZone field
-        /// Units: s</summary>
-        /// <param name="index">0 based index of time_in_speed_zone</param>
-        /// <param name="timeInSpeedZone_">Nullable field value to be set</param>
-        public void SetTimeInSpeedZone(int index, float? timeInSpeedZone_)
-        {
-            SetFieldValue(58, index, timeInSpeedZone_, Fit.SubfieldIndexMainField);
-        }
-        
-        
-        /// <summary>
-        ///
-        /// </summary>
-        /// <returns>returns number of elements in field TimeInCadenceZone</returns>
-        public int GetNumTimeInCadenceZone()
-        {
-            return GetNumFieldValues(59, Fit.SubfieldIndexMainField);
-        }
-
-        ///<summary>
-        /// Retrieves the TimeInCadenceZone field
-        /// Units: s</summary>
-        /// <param name="index">0 based index of TimeInCadenceZone element to retrieve</param>
-        /// <returns>Returns nullable float representing the TimeInCadenceZone field</returns>
-        public float? GetTimeInCadenceZone(int index)
-        {
-            Object val = GetFieldValue(59, index, Fit.SubfieldIndexMainField);
-            if(val == null)
-            {
-                return null;
-            }
-
-            return (Convert.ToSingle(val));
-            
-        }
-
-        /// <summary>
-        /// Set TimeInCadenceZone field
-        /// Units: s</summary>
-        /// <param name="index">0 based index of time_in_cadence_zone</param>
-        /// <param name="timeInCadenceZone_">Nullable field value to be set</param>
-        public void SetTimeInCadenceZone(int index, float? timeInCadenceZone_)
-        {
-            SetFieldValue(59, index, timeInCadenceZone_, Fit.SubfieldIndexMainField);
-        }
-        
-        
-        /// <summary>
-        ///
-        /// </summary>
-        /// <returns>returns number of elements in field TimeInPowerZone</returns>
-        public int GetNumTimeInPowerZone()
-        {
-            return GetNumFieldValues(60, Fit.SubfieldIndexMainField);
-        }
-
-        ///<summary>
-        /// Retrieves the TimeInPowerZone field
-        /// Units: s</summary>
-        /// <param name="index">0 based index of TimeInPowerZone element to retrieve</param>
-        /// <returns>Returns nullable float representing the TimeInPowerZone field</returns>
-        public float? GetTimeInPowerZone(int index)
-        {
-            Object val = GetFieldValue(60, index, Fit.SubfieldIndexMainField);
-            if(val == null)
-            {
-                return null;
-            }
-
-            return (Convert.ToSingle(val));
-            
-        }
-
-        /// <summary>
-        /// Set TimeInPowerZone field
-        /// Units: s</summary>
-        /// <param name="index">0 based index of time_in_power_zone</param>
-        /// <param name="timeInPowerZone_">Nullable field value to be set</param>
-        public void SetTimeInPowerZone(int index, float? timeInPowerZone_)
-        {
-            SetFieldValue(60, index, timeInPowerZone_, Fit.SubfieldIndexMainField);
-        }
-        
-        ///<summary>
-        /// Retrieves the RepetitionNum field</summary>
-        /// <returns>Returns nullable ushort representing the RepetitionNum field</returns>
-        public ushort? GetRepetitionNum()
-        {
-            Object val = GetFieldValue(61, 0, Fit.SubfieldIndexMainField);
-            if(val == null)
-            {
-                return null;
-            }
-
-            return (Convert.ToUInt16(val));
-            
-        }
-
-        /// <summary>
-        /// Set RepetitionNum field</summary>
-        /// <param name="repetitionNum_">Nullable field value to be set</param>
-        public void SetRepetitionNum(ushort? repetitionNum_)
-        {
-            SetFieldValue(61, 0, repetitionNum_, Fit.SubfieldIndexMainField);
-        }
-        
-        ///<summary>
-        /// Retrieves the MinAltitude field
-        /// Units: m</summary>
-        /// <returns>Returns nullable float representing the MinAltitude field</returns>
-        public float? GetMinAltitude()
-        {
-            Object val = GetFieldValue(62, 0, Fit.SubfieldIndexMainField);
-            if(val == null)
-            {
-                return null;
-            }
-
-            return (Convert.ToSingle(val));
-            
-        }
-
-        /// <summary>
-        /// Set MinAltitude field
-        /// Units: m</summary>
-        /// <param name="minAltitude_">Nullable field value to be set</param>
-        public void SetMinAltitude(float? minAltitude_)
-        {
-            SetFieldValue(62, 0, minAltitude_, Fit.SubfieldIndexMainField);
-        }
-        
-        ///<summary>
-        /// Retrieves the MinHeartRate field
-        /// Units: bpm</summary>
-        /// <returns>Returns nullable byte representing the MinHeartRate field</returns>
-        public byte? GetMinHeartRate()
-        {
-            Object val = GetFieldValue(63, 0, Fit.SubfieldIndexMainField);
-            if(val == null)
-            {
-                return null;
-            }
-
-            return (Convert.ToByte(val));
-            
-        }
-
-        /// <summary>
-        /// Set MinHeartRate field
-        /// Units: bpm</summary>
-        /// <param name="minHeartRate_">Nullable field value to be set</param>
-        public void SetMinHeartRate(byte? minHeartRate_)
-        {
-            SetFieldValue(63, 0, minHeartRate_, Fit.SubfieldIndexMainField);
-        }
-        
-        ///<summary>
-        /// Retrieves the WktStepIndex field</summary>
-        /// <returns>Returns nullable ushort representing the WktStepIndex field</returns>
-        public ushort? GetWktStepIndex()
-        {
-            Object val = GetFieldValue(71, 0, Fit.SubfieldIndexMainField);
-            if(val == null)
-            {
-                return null;
-            }
-
-            return (Convert.ToUInt16(val));
-            
-        }
-
-        /// <summary>
-        /// Set WktStepIndex field</summary>
-        /// <param name="wktStepIndex_">Nullable field value to be set</param>
-        public void SetWktStepIndex(ushort? wktStepIndex_)
-        {
-            SetFieldValue(71, 0, wktStepIndex_, Fit.SubfieldIndexMainField);
-        }
-        
-        ///<summary>
-        /// Retrieves the OpponentScore field</summary>
-        /// <returns>Returns nullable ushort representing the OpponentScore field</returns>
-        public ushort? GetOpponentScore()
-        {
-            Object val = GetFieldValue(74, 0, Fit.SubfieldIndexMainField);
-            if(val == null)
-            {
-                return null;
-            }
-
-            return (Convert.ToUInt16(val));
-            
-        }
-
-        /// <summary>
-        /// Set OpponentScore field</summary>
-        /// <param name="opponentScore_">Nullable field value to be set</param>
-        public void SetOpponentScore(ushort? opponentScore_)
-        {
-            SetFieldValue(74, 0, opponentScore_, Fit.SubfieldIndexMainField);
-        }
-        
-        
-        /// <summary>
-        ///
-        /// </summary>
-        /// <returns>returns number of elements in field StrokeCount</returns>
-        public int GetNumStrokeCount()
-        {
-            return GetNumFieldValues(75, Fit.SubfieldIndexMainField);
-        }
-
-        ///<summary>
-        /// Retrieves the StrokeCount field
-        /// Units: counts
-        /// Comment: stroke_type enum used as the index</summary>
-        /// <param name="index">0 based index of StrokeCount element to retrieve</param>
-        /// <returns>Returns nullable ushort representing the StrokeCount field</returns>
-        public ushort? GetStrokeCount(int index)
-        {
-            Object val = GetFieldValue(75, index, Fit.SubfieldIndexMainField);
-            if(val == null)
-            {
-                return null;
-            }
-
-            return (Convert.ToUInt16(val));
-            
-        }
-
-        /// <summary>
-        /// Set StrokeCount field
-        /// Units: counts
-        /// Comment: stroke_type enum used as the index</summary>
-        /// <param name="index">0 based index of stroke_count</param>
-        /// <param name="strokeCount_">Nullable field value to be set</param>
-        public void SetStrokeCount(int index, ushort? strokeCount_)
-        {
-            SetFieldValue(75, index, strokeCount_, Fit.SubfieldIndexMainField);
-        }
-        
-        
-        /// <summary>
-        ///
-        /// </summary>
-        /// <returns>returns number of elements in field ZoneCount</returns>
-        public int GetNumZoneCount()
-        {
-            return GetNumFieldValues(76, Fit.SubfieldIndexMainField);
-        }
-
-        ///<summary>
-        /// Retrieves the ZoneCount field
-        /// Units: counts
-        /// Comment: zone number used as the index</summary>
-        /// <param name="index">0 based index of ZoneCount element to retrieve</param>
-        /// <returns>Returns nullable ushort representing the ZoneCount field</returns>
-        public ushort? GetZoneCount(int index)
-        {
-            Object val = GetFieldValue(76, index, Fit.SubfieldIndexMainField);
-            if(val == null)
-            {
-                return null;
-            }
-
-            return (Convert.ToUInt16(val));
-            
-        }
-
-        /// <summary>
-        /// Set ZoneCount field
-        /// Units: counts
-        /// Comment: zone number used as the index</summary>
-        /// <param name="index">0 based index of zone_count</param>
-        /// <param name="zoneCount_">Nullable field value to be set</param>
-        public void SetZoneCount(int index, ushort? zoneCount_)
-        {
-            SetFieldValue(76, index, zoneCount_, Fit.SubfieldIndexMainField);
-        }
-        
-        ///<summary>
-        /// Retrieves the AvgVerticalOscillation field
-        /// Units: mm</summary>
-        /// <returns>Returns nullable float representing the AvgVerticalOscillation field</returns>
-        public float? GetAvgVerticalOscillation()
-        {
-            Object val = GetFieldValue(77, 0, Fit.SubfieldIndexMainField);
-            if(val == null)
-            {
-                return null;
-            }
-
-            return (Convert.ToSingle(val));
-            
-        }
-
-        /// <summary>
-        /// Set AvgVerticalOscillation field
-        /// Units: mm</summary>
-        /// <param name="avgVerticalOscillation_">Nullable field value to be set</param>
-        public void SetAvgVerticalOscillation(float? avgVerticalOscillation_)
-        {
-            SetFieldValue(77, 0, avgVerticalOscillation_, Fit.SubfieldIndexMainField);
-        }
-        
-        ///<summary>
-        /// Retrieves the AvgStanceTimePercent field
-        /// Units: percent</summary>
-        /// <returns>Returns nullable float representing the AvgStanceTimePercent field</returns>
-        public float? GetAvgStanceTimePercent()
-        {
-            Object val = GetFieldValue(78, 0, Fit.SubfieldIndexMainField);
-            if(val == null)
-            {
-                return null;
-            }
-
-            return (Convert.ToSingle(val));
-            
-        }
-
-        /// <summary>
-        /// Set AvgStanceTimePercent field
-        /// Units: percent</summary>
-        /// <param name="avgStanceTimePercent_">Nullable field value to be set</param>
-        public void SetAvgStanceTimePercent(float? avgStanceTimePercent_)
-        {
-            SetFieldValue(78, 0, avgStanceTimePercent_, Fit.SubfieldIndexMainField);
-        }
-        
-        ///<summary>
-        /// Retrieves the AvgStanceTime field
-        /// Units: ms</summary>
-        /// <returns>Returns nullable float representing the AvgStanceTime field</returns>
-        public float? GetAvgStanceTime()
-        {
-            Object val = GetFieldValue(79, 0, Fit.SubfieldIndexMainField);
-            if(val == null)
-            {
-                return null;
-            }
-
-            return (Convert.ToSingle(val));
-            
-        }
-
-        /// <summary>
-        /// Set AvgStanceTime field
-        /// Units: ms</summary>
-        /// <param name="avgStanceTime_">Nullable field value to be set</param>
-        public void SetAvgStanceTime(float? avgStanceTime_)
-        {
-            SetFieldValue(79, 0, avgStanceTime_, Fit.SubfieldIndexMainField);
-        }
-        
-        ///<summary>
-        /// Retrieves the AvgFractionalCadence field
-        /// Units: rpm
-        /// Comment: fractional part of the avg_cadence</summary>
-        /// <returns>Returns nullable float representing the AvgFractionalCadence field</returns>
-        public float? GetAvgFractionalCadence()
-        {
-            Object val = GetFieldValue(80, 0, Fit.SubfieldIndexMainField);
-            if(val == null)
-            {
-                return null;
-            }
-
-            return (Convert.ToSingle(val));
-            
-        }
-
-        /// <summary>
-        /// Set AvgFractionalCadence field
-        /// Units: rpm
-        /// Comment: fractional part of the avg_cadence</summary>
-        /// <param name="avgFractionalCadence_">Nullable field value to be set</param>
-        public void SetAvgFractionalCadence(float? avgFractionalCadence_)
-        {
-            SetFieldValue(80, 0, avgFractionalCadence_, Fit.SubfieldIndexMainField);
-        }
-        
-        ///<summary>
-        /// Retrieves the MaxFractionalCadence field
-        /// Units: rpm
-        /// Comment: fractional part of the max_cadence</summary>
-        /// <returns>Returns nullable float representing the MaxFractionalCadence field</returns>
-        public float? GetMaxFractionalCadence()
-        {
-            Object val = GetFieldValue(81, 0, Fit.SubfieldIndexMainField);
-            if(val == null)
-            {
-                return null;
-            }
-
-            return (Convert.ToSingle(val));
-            
-        }
-
-        /// <summary>
-        /// Set MaxFractionalCadence field
-        /// Units: rpm
-        /// Comment: fractional part of the max_cadence</summary>
-        /// <param name="maxFractionalCadence_">Nullable field value to be set</param>
-        public void SetMaxFractionalCadence(float? maxFractionalCadence_)
-        {
-            SetFieldValue(81, 0, maxFractionalCadence_, Fit.SubfieldIndexMainField);
-        }
-        
-        ///<summary>
-        /// Retrieves the TotalFractionalCycles field
-        /// Units: cycles
-        /// Comment: fractional part of the total_cycles</summary>
-        /// <returns>Returns nullable float representing the TotalFractionalCycles field</returns>
-        public float? GetTotalFractionalCycles()
-        {
-            Object val = GetFieldValue(82, 0, Fit.SubfieldIndexMainField);
-            if(val == null)
-            {
-                return null;
-            }
-
-            return (Convert.ToSingle(val));
-            
-        }
-
-        /// <summary>
-        /// Set TotalFractionalCycles field
-        /// Units: cycles
-        /// Comment: fractional part of the total_cycles</summary>
-        /// <param name="totalFractionalCycles_">Nullable field value to be set</param>
-        public void SetTotalFractionalCycles(float? totalFractionalCycles_)
-        {
-            SetFieldValue(82, 0, totalFractionalCycles_, Fit.SubfieldIndexMainField);
-        }
-        
-        ///<summary>
-        /// Retrieves the PlayerScore field</summary>
-        /// <returns>Returns nullable ushort representing the PlayerScore field</returns>
-        public ushort? GetPlayerScore()
-        {
-            Object val = GetFieldValue(83, 0, Fit.SubfieldIndexMainField);
-            if(val == null)
-            {
-                return null;
-            }
-
-            return (Convert.ToUInt16(val));
-            
-        }
-
-        /// <summary>
-        /// Set PlayerScore field</summary>
-        /// <param name="playerScore_">Nullable field value to be set</param>
-        public void SetPlayerScore(ushort? playerScore_)
-        {
-            SetFieldValue(83, 0, playerScore_, Fit.SubfieldIndexMainField);
-        }
-        
-        
-        /// <summary>
-        ///
-        /// </summary>
-        /// <returns>returns number of elements in field AvgTotalHemoglobinConc</returns>
-        public int GetNumAvgTotalHemoglobinConc()
-        {
-            return GetNumFieldValues(84, Fit.SubfieldIndexMainField);
-        }
-
-        ///<summary>
-        /// Retrieves the AvgTotalHemoglobinConc field
-        /// Units: g/dL
-        /// Comment: Avg saturated and unsaturated hemoglobin</summary>
-        /// <param name="index">0 based index of AvgTotalHemoglobinConc element to retrieve</param>
-        /// <returns>Returns nullable float representing the AvgTotalHemoglobinConc field</returns>
-        public float? GetAvgTotalHemoglobinConc(int index)
-        {
-            Object val = GetFieldValue(84, index, Fit.SubfieldIndexMainField);
-            if(val == null)
-            {
-                return null;
-            }
-
-            return (Convert.ToSingle(val));
-            
-        }
-
-        /// <summary>
-        /// Set AvgTotalHemoglobinConc field
-        /// Units: g/dL
-        /// Comment: Avg saturated and unsaturated hemoglobin</summary>
-        /// <param name="index">0 based index of avg_total_hemoglobin_conc</param>
-        /// <param name="avgTotalHemoglobinConc_">Nullable field value to be set</param>
-        public void SetAvgTotalHemoglobinConc(int index, float? avgTotalHemoglobinConc_)
-        {
-            SetFieldValue(84, index, avgTotalHemoglobinConc_, Fit.SubfieldIndexMainField);
-        }
-        
-        
-        /// <summary>
-        ///
-        /// </summary>
-        /// <returns>returns number of elements in field MinTotalHemoglobinConc</returns>
-        public int GetNumMinTotalHemoglobinConc()
-        {
-            return GetNumFieldValues(85, Fit.SubfieldIndexMainField);
-        }
-
-        ///<summary>
-        /// Retrieves the MinTotalHemoglobinConc field
-        /// Units: g/dL
-        /// Comment: Min saturated and unsaturated hemoglobin</summary>
-        /// <param name="index">0 based index of MinTotalHemoglobinConc element to retrieve</param>
-        /// <returns>Returns nullable float representing the MinTotalHemoglobinConc field</returns>
-        public float? GetMinTotalHemoglobinConc(int index)
-        {
-            Object val = GetFieldValue(85, index, Fit.SubfieldIndexMainField);
-            if(val == null)
-            {
-                return null;
-            }
-
-            return (Convert.ToSingle(val));
-            
-        }
-
-        /// <summary>
-        /// Set MinTotalHemoglobinConc field
-        /// Units: g/dL
-        /// Comment: Min saturated and unsaturated hemoglobin</summary>
-        /// <param name="index">0 based index of min_total_hemoglobin_conc</param>
-        /// <param name="minTotalHemoglobinConc_">Nullable field value to be set</param>
-        public void SetMinTotalHemoglobinConc(int index, float? minTotalHemoglobinConc_)
-        {
-            SetFieldValue(85, index, minTotalHemoglobinConc_, Fit.SubfieldIndexMainField);
-        }
-        
-        
-        /// <summary>
-        ///
-        /// </summary>
-        /// <returns>returns number of elements in field MaxTotalHemoglobinConc</returns>
-        public int GetNumMaxTotalHemoglobinConc()
-        {
-            return GetNumFieldValues(86, Fit.SubfieldIndexMainField);
-        }
-
-        ///<summary>
-        /// Retrieves the MaxTotalHemoglobinConc field
-        /// Units: g/dL
-        /// Comment: Max saturated and unsaturated hemoglobin</summary>
-        /// <param name="index">0 based index of MaxTotalHemoglobinConc element to retrieve</param>
-        /// <returns>Returns nullable float representing the MaxTotalHemoglobinConc field</returns>
-        public float? GetMaxTotalHemoglobinConc(int index)
-        {
-            Object val = GetFieldValue(86, index, Fit.SubfieldIndexMainField);
-            if(val == null)
-            {
-                return null;
-            }
-
-            return (Convert.ToSingle(val));
-            
-        }
-
-        /// <summary>
-        /// Set MaxTotalHemoglobinConc field
-        /// Units: g/dL
-        /// Comment: Max saturated and unsaturated hemoglobin</summary>
-        /// <param name="index">0 based index of max_total_hemoglobin_conc</param>
-        /// <param name="maxTotalHemoglobinConc_">Nullable field value to be set</param>
-        public void SetMaxTotalHemoglobinConc(int index, float? maxTotalHemoglobinConc_)
-        {
-            SetFieldValue(86, index, maxTotalHemoglobinConc_, Fit.SubfieldIndexMainField);
-        }
-        
-        
-        /// <summary>
-        ///
-        /// </summary>
-        /// <returns>returns number of elements in field AvgSaturatedHemoglobinPercent</returns>
-        public int GetNumAvgSaturatedHemoglobinPercent()
-        {
-            return GetNumFieldValues(87, Fit.SubfieldIndexMainField);
-        }
-
-        ///<summary>
-        /// Retrieves the AvgSaturatedHemoglobinPercent field
-        /// Units: %
-        /// Comment: Avg percentage of hemoglobin saturated with oxygen</summary>
-        /// <param name="index">0 based index of AvgSaturatedHemoglobinPercent element to retrieve</param>
-        /// <returns>Returns nullable float representing the AvgSaturatedHemoglobinPercent field</returns>
-        public float? GetAvgSaturatedHemoglobinPercent(int index)
-        {
-            Object val = GetFieldValue(87, index, Fit.SubfieldIndexMainField);
-            if(val == null)
-            {
-                return null;
-            }
-
-            return (Convert.ToSingle(val));
-            
-        }
-
-        /// <summary>
-        /// Set AvgSaturatedHemoglobinPercent field
-        /// Units: %
-        /// Comment: Avg percentage of hemoglobin saturated with oxygen</summary>
-        /// <param name="index">0 based index of avg_saturated_hemoglobin_percent</param>
-        /// <param name="avgSaturatedHemoglobinPercent_">Nullable field value to be set</param>
-        public void SetAvgSaturatedHemoglobinPercent(int index, float? avgSaturatedHemoglobinPercent_)
-        {
-            SetFieldValue(87, index, avgSaturatedHemoglobinPercent_, Fit.SubfieldIndexMainField);
-        }
-        
-        
-        /// <summary>
-        ///
-        /// </summary>
-        /// <returns>returns number of elements in field MinSaturatedHemoglobinPercent</returns>
-        public int GetNumMinSaturatedHemoglobinPercent()
-        {
-            return GetNumFieldValues(88, Fit.SubfieldIndexMainField);
-        }
-
-        ///<summary>
-        /// Retrieves the MinSaturatedHemoglobinPercent field
-        /// Units: %
-        /// Comment: Min percentage of hemoglobin saturated with oxygen</summary>
-        /// <param name="index">0 based index of MinSaturatedHemoglobinPercent element to retrieve</param>
-        /// <returns>Returns nullable float representing the MinSaturatedHemoglobinPercent field</returns>
-        public float? GetMinSaturatedHemoglobinPercent(int index)
-        {
-            Object val = GetFieldValue(88, index, Fit.SubfieldIndexMainField);
-            if(val == null)
-            {
-                return null;
-            }
-
-            return (Convert.ToSingle(val));
-            
-        }
-
-        /// <summary>
-        /// Set MinSaturatedHemoglobinPercent field
-        /// Units: %
-        /// Comment: Min percentage of hemoglobin saturated with oxygen</summary>
-        /// <param name="index">0 based index of min_saturated_hemoglobin_percent</param>
-        /// <param name="minSaturatedHemoglobinPercent_">Nullable field value to be set</param>
-        public void SetMinSaturatedHemoglobinPercent(int index, float? minSaturatedHemoglobinPercent_)
-        {
-            SetFieldValue(88, index, minSaturatedHemoglobinPercent_, Fit.SubfieldIndexMainField);
-        }
-        
-        
-        /// <summary>
-        ///
-        /// </summary>
-        /// <returns>returns number of elements in field MaxSaturatedHemoglobinPercent</returns>
-        public int GetNumMaxSaturatedHemoglobinPercent()
-        {
-            return GetNumFieldValues(89, Fit.SubfieldIndexMainField);
-        }
-
-        ///<summary>
-        /// Retrieves the MaxSaturatedHemoglobinPercent field
-        /// Units: %
-        /// Comment: Max percentage of hemoglobin saturated with oxygen</summary>
-        /// <param name="index">0 based index of MaxSaturatedHemoglobinPercent element to retrieve</param>
-        /// <returns>Returns nullable float representing the MaxSaturatedHemoglobinPercent field</returns>
-        public float? GetMaxSaturatedHemoglobinPercent(int index)
-        {
-            Object val = GetFieldValue(89, index, Fit.SubfieldIndexMainField);
-            if(val == null)
-            {
-                return null;
-            }
-
-            return (Convert.ToSingle(val));
-            
-        }
-
-        /// <summary>
-        /// Set MaxSaturatedHemoglobinPercent field
-        /// Units: %
-        /// Comment: Max percentage of hemoglobin saturated with oxygen</summary>
-        /// <param name="index">0 based index of max_saturated_hemoglobin_percent</param>
-        /// <param name="maxSaturatedHemoglobinPercent_">Nullable field value to be set</param>
-        public void SetMaxSaturatedHemoglobinPercent(int index, float? maxSaturatedHemoglobinPercent_)
-        {
-            SetFieldValue(89, index, maxSaturatedHemoglobinPercent_, Fit.SubfieldIndexMainField);
-        }
-        
-        ///<summary>
-        /// Retrieves the AvgLeftTorqueEffectiveness field
-        /// Units: percent</summary>
-        /// <returns>Returns nullable float representing the AvgLeftTorqueEffectiveness field</returns>
-        public float? GetAvgLeftTorqueEffectiveness()
-        {
-            Object val = GetFieldValue(91, 0, Fit.SubfieldIndexMainField);
-            if(val == null)
-            {
-                return null;
-            }
-
-            return (Convert.ToSingle(val));
-            
-        }
-
-        /// <summary>
-        /// Set AvgLeftTorqueEffectiveness field
-        /// Units: percent</summary>
-        /// <param name="avgLeftTorqueEffectiveness_">Nullable field value to be set</param>
-        public void SetAvgLeftTorqueEffectiveness(float? avgLeftTorqueEffectiveness_)
-        {
-            SetFieldValue(91, 0, avgLeftTorqueEffectiveness_, Fit.SubfieldIndexMainField);
-        }
-        
-        ///<summary>
-        /// Retrieves the AvgRightTorqueEffectiveness field
-        /// Units: percent</summary>
-        /// <returns>Returns nullable float representing the AvgRightTorqueEffectiveness field</returns>
-        public float? GetAvgRightTorqueEffectiveness()
-        {
-            Object val = GetFieldValue(92, 0, Fit.SubfieldIndexMainField);
-            if(val == null)
-            {
-                return null;
-            }
-
-            return (Convert.ToSingle(val));
-            
-        }
-
-        /// <summary>
-        /// Set AvgRightTorqueEffectiveness field
-        /// Units: percent</summary>
-        /// <param name="avgRightTorqueEffectiveness_">Nullable field value to be set</param>
-        public void SetAvgRightTorqueEffectiveness(float? avgRightTorqueEffectiveness_)
-        {
-            SetFieldValue(92, 0, avgRightTorqueEffectiveness_, Fit.SubfieldIndexMainField);
-        }
-        
-        ///<summary>
-        /// Retrieves the AvgLeftPedalSmoothness field
-        /// Units: percent</summary>
-        /// <returns>Returns nullable float representing the AvgLeftPedalSmoothness field</returns>
-        public float? GetAvgLeftPedalSmoothness()
-        {
-            Object val = GetFieldValue(93, 0, Fit.SubfieldIndexMainField);
-            if(val == null)
-            {
-                return null;
-            }
-
-            return (Convert.ToSingle(val));
-            
-        }
-
-        /// <summary>
-        /// Set AvgLeftPedalSmoothness field
-        /// Units: percent</summary>
-        /// <param name="avgLeftPedalSmoothness_">Nullable field value to be set</param>
-        public void SetAvgLeftPedalSmoothness(float? avgLeftPedalSmoothness_)
-        {
-            SetFieldValue(93, 0, avgLeftPedalSmoothness_, Fit.SubfieldIndexMainField);
-        }
-        
-        ///<summary>
-        /// Retrieves the AvgRightPedalSmoothness field
-        /// Units: percent</summary>
-        /// <returns>Returns nullable float representing the AvgRightPedalSmoothness field</returns>
-        public float? GetAvgRightPedalSmoothness()
-        {
-            Object val = GetFieldValue(94, 0, Fit.SubfieldIndexMainField);
-            if(val == null)
-            {
-                return null;
-            }
-
-            return (Convert.ToSingle(val));
-            
-        }
-
-        /// <summary>
-        /// Set AvgRightPedalSmoothness field
-        /// Units: percent</summary>
-        /// <param name="avgRightPedalSmoothness_">Nullable field value to be set</param>
-        public void SetAvgRightPedalSmoothness(float? avgRightPedalSmoothness_)
-        {
-            SetFieldValue(94, 0, avgRightPedalSmoothness_, Fit.SubfieldIndexMainField);
-        }
-        
-        ///<summary>
-        /// Retrieves the AvgCombinedPedalSmoothness field
-        /// Units: percent</summary>
-        /// <returns>Returns nullable float representing the AvgCombinedPedalSmoothness field</returns>
-        public float? GetAvgCombinedPedalSmoothness()
-        {
-            Object val = GetFieldValue(95, 0, Fit.SubfieldIndexMainField);
-            if(val == null)
-            {
-                return null;
-            }
-
-            return (Convert.ToSingle(val));
-            
-        }
-
-        /// <summary>
-        /// Set AvgCombinedPedalSmoothness field
-        /// Units: percent</summary>
-        /// <param name="avgCombinedPedalSmoothness_">Nullable field value to be set</param>
-        public void SetAvgCombinedPedalSmoothness(float? avgCombinedPedalSmoothness_)
-        {
-            SetFieldValue(95, 0, avgCombinedPedalSmoothness_, Fit.SubfieldIndexMainField);
-        }
-        
-        ///<summary>
-        /// Retrieves the TimeStanding field
-        /// Units: s
-        /// Comment: Total time spent in the standing position</summary>
-        /// <returns>Returns nullable float representing the TimeStanding field</returns>
-        public float? GetTimeStanding()
-        {
-            Object val = GetFieldValue(98, 0, Fit.SubfieldIndexMainField);
-            if(val == null)
-            {
-                return null;
-            }
-
-            return (Convert.ToSingle(val));
-            
-        }
-
-        /// <summary>
-        /// Set TimeStanding field
-        /// Units: s
-        /// Comment: Total time spent in the standing position</summary>
-        /// <param name="timeStanding_">Nullable field value to be set</param>
-        public void SetTimeStanding(float? timeStanding_)
-        {
-            SetFieldValue(98, 0, timeStanding_, Fit.SubfieldIndexMainField);
-        }
-        
-        ///<summary>
-        /// Retrieves the StandCount field
-        /// Comment: Number of transitions to the standing state</summary>
-        /// <returns>Returns nullable ushort representing the StandCount field</returns>
-        public ushort? GetStandCount()
-        {
-            Object val = GetFieldValue(99, 0, Fit.SubfieldIndexMainField);
-            if(val == null)
-            {
-                return null;
-            }
-
-            return (Convert.ToUInt16(val));
-            
-        }
-
-        /// <summary>
-        /// Set StandCount field
-        /// Comment: Number of transitions to the standing state</summary>
-        /// <param name="standCount_">Nullable field value to be set</param>
-        public void SetStandCount(ushort? standCount_)
-        {
-            SetFieldValue(99, 0, standCount_, Fit.SubfieldIndexMainField);
-        }
-        
-        ///<summary>
-        /// Retrieves the AvgLeftPco field
-        /// Units: mm
-        /// Comment: Average left platform center offset</summary>
-        /// <returns>Returns nullable sbyte representing the AvgLeftPco field</returns>
-        public sbyte? GetAvgLeftPco()
-        {
-            Object val = GetFieldValue(100, 0, Fit.SubfieldIndexMainField);
-            if(val == null)
-            {
-                return null;
-            }
-
-            return (Convert.ToSByte(val));
-            
-        }
-
-        /// <summary>
-        /// Set AvgLeftPco field
-        /// Units: mm
-        /// Comment: Average left platform center offset</summary>
-        /// <param name="avgLeftPco_">Nullable field value to be set</param>
-        public void SetAvgLeftPco(sbyte? avgLeftPco_)
-        {
-            SetFieldValue(100, 0, avgLeftPco_, Fit.SubfieldIndexMainField);
-        }
-        
-        ///<summary>
-        /// Retrieves the AvgRightPco field
-        /// Units: mm
-        /// Comment: Average right platform center offset</summary>
-        /// <returns>Returns nullable sbyte representing the AvgRightPco field</returns>
-        public sbyte? GetAvgRightPco()
-        {
-            Object val = GetFieldValue(101, 0, Fit.SubfieldIndexMainField);
-            if(val == null)
-            {
-                return null;
-            }
-
-            return (Convert.ToSByte(val));
-            
-        }
-
-        /// <summary>
-        /// Set AvgRightPco field
-        /// Units: mm
-        /// Comment: Average right platform center offset</summary>
-        /// <param name="avgRightPco_">Nullable field value to be set</param>
-        public void SetAvgRightPco(sbyte? avgRightPco_)
-        {
-            SetFieldValue(101, 0, avgRightPco_, Fit.SubfieldIndexMainField);
-        }
-        
-        
-        /// <summary>
-        ///
-        /// </summary>
-        /// <returns>returns number of elements in field AvgLeftPowerPhase</returns>
-        public int GetNumAvgLeftPowerPhase()
-        {
-            return GetNumFieldValues(102, Fit.SubfieldIndexMainField);
-        }
-
-        ///<summary>
-        /// Retrieves the AvgLeftPowerPhase field
-        /// Units: degrees
-        /// Comment: Average left power phase angles. Data value indexes defined by power_phase_type.</summary>
-        /// <param name="index">0 based index of AvgLeftPowerPhase element to retrieve</param>
-        /// <returns>Returns nullable float representing the AvgLeftPowerPhase field</returns>
-        public float? GetAvgLeftPowerPhase(int index)
-        {
-            Object val = GetFieldValue(102, index, Fit.SubfieldIndexMainField);
-            if(val == null)
-            {
-                return null;
-            }
-
-            return (Convert.ToSingle(val));
-            
-        }
-
-        /// <summary>
-        /// Set AvgLeftPowerPhase field
-        /// Units: degrees
-        /// Comment: Average left power phase angles. Data value indexes defined by power_phase_type.</summary>
-        /// <param name="index">0 based index of avg_left_power_phase</param>
-        /// <param name="avgLeftPowerPhase_">Nullable field value to be set</param>
-        public void SetAvgLeftPowerPhase(int index, float? avgLeftPowerPhase_)
-        {
-            SetFieldValue(102, index, avgLeftPowerPhase_, Fit.SubfieldIndexMainField);
-        }
-        
-        
-        /// <summary>
-        ///
-        /// </summary>
-        /// <returns>returns number of elements in field AvgLeftPowerPhasePeak</returns>
-        public int GetNumAvgLeftPowerPhasePeak()
-        {
-            return GetNumFieldValues(103, Fit.SubfieldIndexMainField);
-        }
-
-        ///<summary>
-        /// Retrieves the AvgLeftPowerPhasePeak field
-        /// Units: degrees
-        /// Comment: Average left power phase peak angles. Data value indexes defined by power_phase_type.</summary>
-        /// <param name="index">0 based index of AvgLeftPowerPhasePeak element to retrieve</param>
-        /// <returns>Returns nullable float representing the AvgLeftPowerPhasePeak field</returns>
-        public float? GetAvgLeftPowerPhasePeak(int index)
-        {
-            Object val = GetFieldValue(103, index, Fit.SubfieldIndexMainField);
-            if(val == null)
-            {
-                return null;
-            }
-
-            return (Convert.ToSingle(val));
-            
-        }
-
-        /// <summary>
-        /// Set AvgLeftPowerPhasePeak field
-        /// Units: degrees
-        /// Comment: Average left power phase peak angles. Data value indexes defined by power_phase_type.</summary>
-        /// <param name="index">0 based index of avg_left_power_phase_peak</param>
-        /// <param name="avgLeftPowerPhasePeak_">Nullable field value to be set</param>
-        public void SetAvgLeftPowerPhasePeak(int index, float? avgLeftPowerPhasePeak_)
-        {
-            SetFieldValue(103, index, avgLeftPowerPhasePeak_, Fit.SubfieldIndexMainField);
-        }
-        
-        
-        /// <summary>
-        ///
-        /// </summary>
-        /// <returns>returns number of elements in field AvgRightPowerPhase</returns>
-        public int GetNumAvgRightPowerPhase()
-        {
-            return GetNumFieldValues(104, Fit.SubfieldIndexMainField);
-        }
-
-        ///<summary>
-        /// Retrieves the AvgRightPowerPhase field
-        /// Units: degrees
-        /// Comment: Average right power phase angles. Data value indexes defined by power_phase_type.</summary>
-        /// <param name="index">0 based index of AvgRightPowerPhase element to retrieve</param>
-        /// <returns>Returns nullable float representing the AvgRightPowerPhase field</returns>
-        public float? GetAvgRightPowerPhase(int index)
-        {
-            Object val = GetFieldValue(104, index, Fit.SubfieldIndexMainField);
-            if(val == null)
-            {
-                return null;
-            }
-
-            return (Convert.ToSingle(val));
-            
-        }
-
-        /// <summary>
-        /// Set AvgRightPowerPhase field
-        /// Units: degrees
-        /// Comment: Average right power phase angles. Data value indexes defined by power_phase_type.</summary>
-        /// <param name="index">0 based index of avg_right_power_phase</param>
-        /// <param name="avgRightPowerPhase_">Nullable field value to be set</param>
-        public void SetAvgRightPowerPhase(int index, float? avgRightPowerPhase_)
-        {
-            SetFieldValue(104, index, avgRightPowerPhase_, Fit.SubfieldIndexMainField);
-        }
-        
-        
-        /// <summary>
-        ///
-        /// </summary>
-        /// <returns>returns number of elements in field AvgRightPowerPhasePeak</returns>
-        public int GetNumAvgRightPowerPhasePeak()
-        {
-            return GetNumFieldValues(105, Fit.SubfieldIndexMainField);
-        }
-
-        ///<summary>
-        /// Retrieves the AvgRightPowerPhasePeak field
-        /// Units: degrees
-        /// Comment: Average right power phase peak angles. Data value indexes defined by power_phase_type.</summary>
-        /// <param name="index">0 based index of AvgRightPowerPhasePeak element to retrieve</param>
-        /// <returns>Returns nullable float representing the AvgRightPowerPhasePeak field</returns>
-        public float? GetAvgRightPowerPhasePeak(int index)
-        {
-            Object val = GetFieldValue(105, index, Fit.SubfieldIndexMainField);
-            if(val == null)
-            {
-                return null;
-            }
-
-            return (Convert.ToSingle(val));
-            
-        }
-
-        /// <summary>
-        /// Set AvgRightPowerPhasePeak field
-        /// Units: degrees
-        /// Comment: Average right power phase peak angles. Data value indexes defined by power_phase_type.</summary>
-        /// <param name="index">0 based index of avg_right_power_phase_peak</param>
-        /// <param name="avgRightPowerPhasePeak_">Nullable field value to be set</param>
-        public void SetAvgRightPowerPhasePeak(int index, float? avgRightPowerPhasePeak_)
-        {
-            SetFieldValue(105, index, avgRightPowerPhasePeak_, Fit.SubfieldIndexMainField);
-        }
-        
-        
-        /// <summary>
-        ///
-        /// </summary>
-        /// <returns>returns number of elements in field AvgPowerPosition</returns>
-        public int GetNumAvgPowerPosition()
-        {
-            return GetNumFieldValues(106, Fit.SubfieldIndexMainField);
-        }
-
-        ///<summary>
-        /// Retrieves the AvgPowerPosition field
-        /// Units: watts
-        /// Comment: Average power by position. Data value indexes defined by rider_position_type.</summary>
-        /// <param name="index">0 based index of AvgPowerPosition element to retrieve</param>
-        /// <returns>Returns nullable ushort representing the AvgPowerPosition field</returns>
-        public ushort? GetAvgPowerPosition(int index)
-        {
-            Object val = GetFieldValue(106, index, Fit.SubfieldIndexMainField);
-            if(val == null)
-            {
-                return null;
-            }
-
-            return (Convert.ToUInt16(val));
-            
-        }
-
-        /// <summary>
-        /// Set AvgPowerPosition field
-        /// Units: watts
-        /// Comment: Average power by position. Data value indexes defined by rider_position_type.</summary>
-        /// <param name="index">0 based index of avg_power_position</param>
-        /// <param name="avgPowerPosition_">Nullable field value to be set</param>
-        public void SetAvgPowerPosition(int index, ushort? avgPowerPosition_)
-        {
-            SetFieldValue(106, index, avgPowerPosition_, Fit.SubfieldIndexMainField);
-        }
-        
-        
-        /// <summary>
-        ///
-        /// </summary>
-        /// <returns>returns number of elements in field MaxPowerPosition</returns>
-        public int GetNumMaxPowerPosition()
-        {
-            return GetNumFieldValues(107, Fit.SubfieldIndexMainField);
-        }
-
-        ///<summary>
-        /// Retrieves the MaxPowerPosition field
-        /// Units: watts
-        /// Comment: Maximum power by position. Data value indexes defined by rider_position_type.</summary>
-        /// <param name="index">0 based index of MaxPowerPosition element to retrieve</param>
-        /// <returns>Returns nullable ushort representing the MaxPowerPosition field</returns>
-        public ushort? GetMaxPowerPosition(int index)
-        {
-            Object val = GetFieldValue(107, index, Fit.SubfieldIndexMainField);
-            if(val == null)
-            {
-                return null;
-            }
-
-            return (Convert.ToUInt16(val));
-            
-        }
-
-        /// <summary>
-        /// Set MaxPowerPosition field
-        /// Units: watts
-        /// Comment: Maximum power by position. Data value indexes defined by rider_position_type.</summary>
-        /// <param name="index">0 based index of max_power_position</param>
-        /// <param name="maxPowerPosition_">Nullable field value to be set</param>
-        public void SetMaxPowerPosition(int index, ushort? maxPowerPosition_)
-        {
-            SetFieldValue(107, index, maxPowerPosition_, Fit.SubfieldIndexMainField);
-        }
-        
-        
-        /// <summary>
-        ///
-        /// </summary>
-        /// <returns>returns number of elements in field AvgCadencePosition</returns>
-        public int GetNumAvgCadencePosition()
-        {
-            return GetNumFieldValues(108, Fit.SubfieldIndexMainField);
-        }
-
-        ///<summary>
-        /// Retrieves the AvgCadencePosition field
-        /// Units: rpm
-        /// Comment: Average cadence by position. Data value indexes defined by rider_position_type.</summary>
-        /// <param name="index">0 based index of AvgCadencePosition element to retrieve</param>
-        /// <returns>Returns nullable byte representing the AvgCadencePosition field</returns>
-        public byte? GetAvgCadencePosition(int index)
-        {
-            Object val = GetFieldValue(108, index, Fit.SubfieldIndexMainField);
-            if(val == null)
-            {
-                return null;
-            }
-
-            return (Convert.ToByte(val));
-            
-        }
-
-        /// <summary>
-        /// Set AvgCadencePosition field
-        /// Units: rpm
-        /// Comment: Average cadence by position. Data value indexes defined by rider_position_type.</summary>
-        /// <param name="index">0 based index of avg_cadence_position</param>
-        /// <param name="avgCadencePosition_">Nullable field value to be set</param>
-        public void SetAvgCadencePosition(int index, byte? avgCadencePosition_)
-        {
-            SetFieldValue(108, index, avgCadencePosition_, Fit.SubfieldIndexMainField);
-        }
-        
-        
-        /// <summary>
-        ///
-        /// </summary>
-        /// <returns>returns number of elements in field MaxCadencePosition</returns>
-        public int GetNumMaxCadencePosition()
-        {
-            return GetNumFieldValues(109, Fit.SubfieldIndexMainField);
-        }
-
-        ///<summary>
-        /// Retrieves the MaxCadencePosition field
-        /// Units: rpm
-        /// Comment: Maximum cadence by position. Data value indexes defined by rider_position_type.</summary>
-        /// <param name="index">0 based index of MaxCadencePosition element to retrieve</param>
-        /// <returns>Returns nullable byte representing the MaxCadencePosition field</returns>
-        public byte? GetMaxCadencePosition(int index)
-        {
-            Object val = GetFieldValue(109, index, Fit.SubfieldIndexMainField);
-            if(val == null)
-            {
-                return null;
-            }
-
-            return (Convert.ToByte(val));
-            
-        }
-
-        /// <summary>
-        /// Set MaxCadencePosition field
-        /// Units: rpm
-        /// Comment: Maximum cadence by position. Data value indexes defined by rider_position_type.</summary>
-        /// <param name="index">0 based index of max_cadence_position</param>
-        /// <param name="maxCadencePosition_">Nullable field value to be set</param>
-        public void SetMaxCadencePosition(int index, byte? maxCadencePosition_)
-        {
-            SetFieldValue(109, index, maxCadencePosition_, Fit.SubfieldIndexMainField);
-        }
-        
-        ///<summary>
-        /// Retrieves the EnhancedAvgSpeed field
-        /// Units: m/s</summary>
-        /// <returns>Returns nullable float representing the EnhancedAvgSpeed field</returns>
-        public float? GetEnhancedAvgSpeed()
-        {
-            Object val = GetFieldValue(110, 0, Fit.SubfieldIndexMainField);
-            if(val == null)
-            {
-                return null;
-            }
-
-            return (Convert.ToSingle(val));
-            
-        }
-
-        /// <summary>
-        /// Set EnhancedAvgSpeed field
-        /// Units: m/s</summary>
-        /// <param name="enhancedAvgSpeed_">Nullable field value to be set</param>
-        public void SetEnhancedAvgSpeed(float? enhancedAvgSpeed_)
-        {
-            SetFieldValue(110, 0, enhancedAvgSpeed_, Fit.SubfieldIndexMainField);
-        }
-        
-        ///<summary>
-        /// Retrieves the EnhancedMaxSpeed field
-        /// Units: m/s</summary>
-        /// <returns>Returns nullable float representing the EnhancedMaxSpeed field</returns>
-        public float? GetEnhancedMaxSpeed()
-        {
-            Object val = GetFieldValue(111, 0, Fit.SubfieldIndexMainField);
-            if(val == null)
-            {
-                return null;
-            }
-
-            return (Convert.ToSingle(val));
-            
-        }
-
-        /// <summary>
-        /// Set EnhancedMaxSpeed field
-        /// Units: m/s</summary>
-        /// <param name="enhancedMaxSpeed_">Nullable field value to be set</param>
-        public void SetEnhancedMaxSpeed(float? enhancedMaxSpeed_)
-        {
-            SetFieldValue(111, 0, enhancedMaxSpeed_, Fit.SubfieldIndexMainField);
-        }
-        
-        ///<summary>
-        /// Retrieves the EnhancedAvgAltitude field
-        /// Units: m</summary>
-        /// <returns>Returns nullable float representing the EnhancedAvgAltitude field</returns>
-        public float? GetEnhancedAvgAltitude()
-        {
-            Object val = GetFieldValue(112, 0, Fit.SubfieldIndexMainField);
-            if(val == null)
-            {
-                return null;
-            }
-
-            return (Convert.ToSingle(val));
-            
-        }
-
-        /// <summary>
-        /// Set EnhancedAvgAltitude field
-        /// Units: m</summary>
-        /// <param name="enhancedAvgAltitude_">Nullable field value to be set</param>
-        public void SetEnhancedAvgAltitude(float? enhancedAvgAltitude_)
-        {
-            SetFieldValue(112, 0, enhancedAvgAltitude_, Fit.SubfieldIndexMainField);
-        }
-        
-        ///<summary>
-        /// Retrieves the EnhancedMinAltitude field
-        /// Units: m</summary>
-        /// <returns>Returns nullable float representing the EnhancedMinAltitude field</returns>
-        public float? GetEnhancedMinAltitude()
-        {
-            Object val = GetFieldValue(113, 0, Fit.SubfieldIndexMainField);
-            if(val == null)
-            {
-                return null;
-            }
-
-            return (Convert.ToSingle(val));
-            
-        }
-
-        /// <summary>
-        /// Set EnhancedMinAltitude field
-        /// Units: m</summary>
-        /// <param name="enhancedMinAltitude_">Nullable field value to be set</param>
-        public void SetEnhancedMinAltitude(float? enhancedMinAltitude_)
-        {
-            SetFieldValue(113, 0, enhancedMinAltitude_, Fit.SubfieldIndexMainField);
-        }
-        
-        ///<summary>
-        /// Retrieves the EnhancedMaxAltitude field
-        /// Units: m</summary>
-        /// <returns>Returns nullable float representing the EnhancedMaxAltitude field</returns>
-        public float? GetEnhancedMaxAltitude()
-        {
-            Object val = GetFieldValue(114, 0, Fit.SubfieldIndexMainField);
-            if(val == null)
-            {
-                return null;
-            }
-
-            return (Convert.ToSingle(val));
-            
-        }
-
-        /// <summary>
-        /// Set EnhancedMaxAltitude field
-        /// Units: m</summary>
-        /// <param name="enhancedMaxAltitude_">Nullable field value to be set</param>
-        public void SetEnhancedMaxAltitude(float? enhancedMaxAltitude_)
-        {
-            SetFieldValue(114, 0, enhancedMaxAltitude_, Fit.SubfieldIndexMainField);
-        }
-        
-        ///<summary>
-        /// Retrieves the AvgLevMotorPower field
-        /// Units: watts
-        /// Comment: lev average motor power during lap</summary>
-        /// <returns>Returns nullable ushort representing the AvgLevMotorPower field</returns>
-        public ushort? GetAvgLevMotorPower()
-        {
-            Object val = GetFieldValue(115, 0, Fit.SubfieldIndexMainField);
-            if(val == null)
-            {
-                return null;
-            }
-
-            return (Convert.ToUInt16(val));
-            
-        }
-
-        /// <summary>
-        /// Set AvgLevMotorPower field
-        /// Units: watts
-        /// Comment: lev average motor power during lap</summary>
-        /// <param name="avgLevMotorPower_">Nullable field value to be set</param>
-        public void SetAvgLevMotorPower(ushort? avgLevMotorPower_)
-        {
-            SetFieldValue(115, 0, avgLevMotorPower_, Fit.SubfieldIndexMainField);
-        }
-        
-        ///<summary>
-        /// Retrieves the MaxLevMotorPower field
-        /// Units: watts
-        /// Comment: lev maximum motor power during lap</summary>
-        /// <returns>Returns nullable ushort representing the MaxLevMotorPower field</returns>
-        public ushort? GetMaxLevMotorPower()
-        {
-            Object val = GetFieldValue(116, 0, Fit.SubfieldIndexMainField);
-            if(val == null)
-            {
-                return null;
-            }
-
-            return (Convert.ToUInt16(val));
-            
-        }
-
-        /// <summary>
-        /// Set MaxLevMotorPower field
-        /// Units: watts
-        /// Comment: lev maximum motor power during lap</summary>
-        /// <param name="maxLevMotorPower_">Nullable field value to be set</param>
-        public void SetMaxLevMotorPower(ushort? maxLevMotorPower_)
-        {
-            SetFieldValue(116, 0, maxLevMotorPower_, Fit.SubfieldIndexMainField);
-        }
-        
-        ///<summary>
-        /// Retrieves the LevBatteryConsumption field
-        /// Units: percent
-        /// Comment: lev battery consumption during lap</summary>
-        /// <returns>Returns nullable float representing the LevBatteryConsumption field</returns>
-        public float? GetLevBatteryConsumption()
-        {
-            Object val = GetFieldValue(117, 0, Fit.SubfieldIndexMainField);
-            if(val == null)
-            {
-                return null;
-            }
-
-            return (Convert.ToSingle(val));
-            
-        }
-
-        /// <summary>
-        /// Set LevBatteryConsumption field
-        /// Units: percent
-        /// Comment: lev battery consumption during lap</summary>
-        /// <param name="levBatteryConsumption_">Nullable field value to be set</param>
-        public void SetLevBatteryConsumption(float? levBatteryConsumption_)
-        {
-            SetFieldValue(117, 0, levBatteryConsumption_, Fit.SubfieldIndexMainField);
-        }
-        
-        ///<summary>
-        /// Retrieves the AvgVerticalRatio field
-        /// Units: percent</summary>
-        /// <returns>Returns nullable float representing the AvgVerticalRatio field</returns>
-        public float? GetAvgVerticalRatio()
-        {
-            Object val = GetFieldValue(118, 0, Fit.SubfieldIndexMainField);
-            if(val == null)
-            {
-                return null;
-            }
-
-            return (Convert.ToSingle(val));
-            
-        }
-
-        /// <summary>
-        /// Set AvgVerticalRatio field
-        /// Units: percent</summary>
-        /// <param name="avgVerticalRatio_">Nullable field value to be set</param>
-        public void SetAvgVerticalRatio(float? avgVerticalRatio_)
-        {
-            SetFieldValue(118, 0, avgVerticalRatio_, Fit.SubfieldIndexMainField);
-        }
-        
-        ///<summary>
-        /// Retrieves the AvgStanceTimeBalance field
-        /// Units: percent</summary>
-        /// <returns>Returns nullable float representing the AvgStanceTimeBalance field</returns>
-        public float? GetAvgStanceTimeBalance()
-        {
-            Object val = GetFieldValue(119, 0, Fit.SubfieldIndexMainField);
-            if(val == null)
-            {
-                return null;
-            }
-
-            return (Convert.ToSingle(val));
-            
-        }
-
-        /// <summary>
-        /// Set AvgStanceTimeBalance field
-        /// Units: percent</summary>
-        /// <param name="avgStanceTimeBalance_">Nullable field value to be set</param>
-        public void SetAvgStanceTimeBalance(float? avgStanceTimeBalance_)
-        {
-            SetFieldValue(119, 0, avgStanceTimeBalance_, Fit.SubfieldIndexMainField);
-        }
-        
-        ///<summary>
-        /// Retrieves the AvgStepLength field
-        /// Units: mm</summary>
-        /// <returns>Returns nullable float representing the AvgStepLength field</returns>
-        public float? GetAvgStepLength()
-        {
-            Object val = GetFieldValue(120, 0, Fit.SubfieldIndexMainField);
-            if(val == null)
-            {
-                return null;
-            }
-
-            return (Convert.ToSingle(val));
-            
-        }
-
-        /// <summary>
-        /// Set AvgStepLength field
-        /// Units: mm</summary>
-        /// <param name="avgStepLength_">Nullable field value to be set</param>
-        public void SetAvgStepLength(float? avgStepLength_)
-        {
-            SetFieldValue(120, 0, avgStepLength_, Fit.SubfieldIndexMainField);
-        }
-        
-        ///<summary>
-        /// Retrieves the AvgVam field
-        /// Units: m/s</summary>
-        /// <returns>Returns nullable float representing the AvgVam field</returns>
-        public float? GetAvgVam()
-        {
-            Object val = GetFieldValue(121, 0, Fit.SubfieldIndexMainField);
-            if(val == null)
-            {
-                return null;
-            }
-
-            return (Convert.ToSingle(val));
-            
-        }
-
-        /// <summary>
-        /// Set AvgVam field
-        /// Units: m/s</summary>
-        /// <param name="avgVam_">Nullable field value to be set</param>
-        public void SetAvgVam(float? avgVam_)
-        {
-            SetFieldValue(121, 0, avgVam_, Fit.SubfieldIndexMainField);
-        }
-        
-        ///<summary>
-        /// Retrieves the AvgDepth field
-        /// Units: m
-        /// Comment: 0 if above water</summary>
-        /// <returns>Returns nullable float representing the AvgDepth field</returns>
-        public float? GetAvgDepth()
-        {
-            Object val = GetFieldValue(122, 0, Fit.SubfieldIndexMainField);
-            if(val == null)
-            {
-                return null;
-            }
-
-            return (Convert.ToSingle(val));
-            
-        }
-
-        /// <summary>
-        /// Set AvgDepth field
-        /// Units: m
-        /// Comment: 0 if above water</summary>
-        /// <param name="avgDepth_">Nullable field value to be set</param>
-        public void SetAvgDepth(float? avgDepth_)
-        {
-            SetFieldValue(122, 0, avgDepth_, Fit.SubfieldIndexMainField);
-        }
-        
-        ///<summary>
-        /// Retrieves the MaxDepth field
-        /// Units: m
-        /// Comment: 0 if above water</summary>
-        /// <returns>Returns nullable float representing the MaxDepth field</returns>
-        public float? GetMaxDepth()
-        {
-            Object val = GetFieldValue(123, 0, Fit.SubfieldIndexMainField);
-            if(val == null)
-            {
-                return null;
-            }
-
-            return (Convert.ToSingle(val));
-            
-        }
-
-        /// <summary>
-        /// Set MaxDepth field
-        /// Units: m
-        /// Comment: 0 if above water</summary>
-        /// <param name="maxDepth_">Nullable field value to be set</param>
-        public void SetMaxDepth(float? maxDepth_)
-        {
-            SetFieldValue(123, 0, maxDepth_, Fit.SubfieldIndexMainField);
-        }
-        
-        ///<summary>
-        /// Retrieves the MinTemperature field
-        /// Units: C</summary>
-        /// <returns>Returns nullable sbyte representing the MinTemperature field</returns>
-        public sbyte? GetMinTemperature()
-        {
-            Object val = GetFieldValue(124, 0, Fit.SubfieldIndexMainField);
-            if(val == null)
-            {
-                return null;
-            }
-
-            return (Convert.ToSByte(val));
-            
-        }
-
-        /// <summary>
-        /// Set MinTemperature field
-        /// Units: C</summary>
-        /// <param name="minTemperature_">Nullable field value to be set</param>
-        public void SetMinTemperature(sbyte? minTemperature_)
-        {
-            SetFieldValue(124, 0, minTemperature_, Fit.SubfieldIndexMainField);
-        }
-        
-        ///<summary>
-        /// Retrieves the EnhancedAvgRespirationRate field
-        /// Units: Breaths/min</summary>
-        /// <returns>Returns nullable float representing the EnhancedAvgRespirationRate field</returns>
-        public float? GetEnhancedAvgRespirationRate()
-        {
-            Object val = GetFieldValue(136, 0, Fit.SubfieldIndexMainField);
-            if(val == null)
-            {
-                return null;
-            }
-
-            return (Convert.ToSingle(val));
-            
-        }
-
-        /// <summary>
-        /// Set EnhancedAvgRespirationRate field
-        /// Units: Breaths/min</summary>
-        /// <param name="enhancedAvgRespirationRate_">Nullable field value to be set</param>
-        public void SetEnhancedAvgRespirationRate(float? enhancedAvgRespirationRate_)
-        {
-            SetFieldValue(136, 0, enhancedAvgRespirationRate_, Fit.SubfieldIndexMainField);
-        }
-        
-        ///<summary>
-        /// Retrieves the EnhancedMaxRespirationRate field
-        /// Units: Breaths/min</summary>
-        /// <returns>Returns nullable float representing the EnhancedMaxRespirationRate field</returns>
-        public float? GetEnhancedMaxRespirationRate()
-        {
-            Object val = GetFieldValue(137, 0, Fit.SubfieldIndexMainField);
-            if(val == null)
-            {
-                return null;
-            }
-
-            return (Convert.ToSingle(val));
-            
-        }
-
-        /// <summary>
-        /// Set EnhancedMaxRespirationRate field
-        /// Units: Breaths/min</summary>
-        /// <param name="enhancedMaxRespirationRate_">Nullable field value to be set</param>
-        public void SetEnhancedMaxRespirationRate(float? enhancedMaxRespirationRate_)
-        {
-            SetFieldValue(137, 0, enhancedMaxRespirationRate_, Fit.SubfieldIndexMainField);
-        }
-        
-        ///<summary>
-        /// Retrieves the AvgRespirationRate field</summary>
-        /// <returns>Returns nullable byte representing the AvgRespirationRate field</returns>
-        public byte? GetAvgRespirationRate()
-        {
-            Object val = GetFieldValue(147, 0, Fit.SubfieldIndexMainField);
-            if(val == null)
-            {
-                return null;
-            }
-
-            return (Convert.ToByte(val));
-            
-        }
-
-        /// <summary>
-        /// Set AvgRespirationRate field</summary>
-        /// <param name="avgRespirationRate_">Nullable field value to be set</param>
-        public void SetAvgRespirationRate(byte? avgRespirationRate_)
-        {
-            SetFieldValue(147, 0, avgRespirationRate_, Fit.SubfieldIndexMainField);
-        }
-        
-        ///<summary>
-        /// Retrieves the MaxRespirationRate field</summary>
-        /// <returns>Returns nullable byte representing the MaxRespirationRate field</returns>
-        public byte? GetMaxRespirationRate()
-        {
-            Object val = GetFieldValue(148, 0, Fit.SubfieldIndexMainField);
-            if(val == null)
-            {
-                return null;
-            }
-
-            return (Convert.ToByte(val));
-            
-        }
-
-        /// <summary>
-        /// Set MaxRespirationRate field</summary>
-        /// <param name="maxRespirationRate_">Nullable field value to be set</param>
-        public void SetMaxRespirationRate(byte? maxRespirationRate_)
-        {
-            SetFieldValue(148, 0, maxRespirationRate_, Fit.SubfieldIndexMainField);
-        }
-        
-        ///<summary>
-        /// Retrieves the TotalGrit field
-        /// Units: kGrit
-        /// Comment: The grit score estimates how challenging a route could be for a cyclist in terms of time spent going over sharp turns or large grade slopes.</summary>
-        /// <returns>Returns nullable float representing the TotalGrit field</returns>
-        public float? GetTotalGrit()
-        {
-            Object val = GetFieldValue(149, 0, Fit.SubfieldIndexMainField);
-            if(val == null)
-            {
-                return null;
-            }
-
-            return (Convert.ToSingle(val));
-            
-        }
-
-        /// <summary>
-        /// Set TotalGrit field
-        /// Units: kGrit
-        /// Comment: The grit score estimates how challenging a route could be for a cyclist in terms of time spent going over sharp turns or large grade slopes.</summary>
-        /// <param name="totalGrit_">Nullable field value to be set</param>
-        public void SetTotalGrit(float? totalGrit_)
-        {
-            SetFieldValue(149, 0, totalGrit_, Fit.SubfieldIndexMainField);
-        }
-        
-        ///<summary>
-        /// Retrieves the TotalFlow field
-        /// Units: Flow
-        /// Comment: The flow score estimates how long distance wise a cyclist deaccelerates over intervals where deacceleration is unnecessary such as smooth turns or small grade angle intervals.</summary>
-        /// <returns>Returns nullable float representing the TotalFlow field</returns>
-        public float? GetTotalFlow()
-        {
-            Object val = GetFieldValue(150, 0, Fit.SubfieldIndexMainField);
-            if(val == null)
-            {
-                return null;
-            }
-
-            return (Convert.ToSingle(val));
-            
-        }
-
-        /// <summary>
-        /// Set TotalFlow field
-        /// Units: Flow
-        /// Comment: The flow score estimates how long distance wise a cyclist deaccelerates over intervals where deacceleration is unnecessary such as smooth turns or small grade angle intervals.</summary>
-        /// <param name="totalFlow_">Nullable field value to be set</param>
-        public void SetTotalFlow(float? totalFlow_)
-        {
-            SetFieldValue(150, 0, totalFlow_, Fit.SubfieldIndexMainField);
-        }
-        
-        ///<summary>
-        /// Retrieves the JumpCount field</summary>
-        /// <returns>Returns nullable ushort representing the JumpCount field</returns>
-        public ushort? GetJumpCount()
-        {
-            Object val = GetFieldValue(151, 0, Fit.SubfieldIndexMainField);
-            if(val == null)
-            {
-                return null;
-            }
-
-            return (Convert.ToUInt16(val));
-            
-        }
-
-        /// <summary>
-        /// Set JumpCount field</summary>
-        /// <param name="jumpCount_">Nullable field value to be set</param>
-        public void SetJumpCount(ushort? jumpCount_)
-        {
-            SetFieldValue(151, 0, jumpCount_, Fit.SubfieldIndexMainField);
-        }
-        
-        ///<summary>
-        /// Retrieves the AvgGrit field
-        /// Units: kGrit
-        /// Comment: The grit score estimates how challenging a route could be for a cyclist in terms of time spent going over sharp turns or large grade slopes.</summary>
-        /// <returns>Returns nullable float representing the AvgGrit field</returns>
-        public float? GetAvgGrit()
-        {
-            Object val = GetFieldValue(153, 0, Fit.SubfieldIndexMainField);
-            if(val == null)
-            {
-                return null;
-            }
-
-            return (Convert.ToSingle(val));
-            
-        }
-
-        /// <summary>
-        /// Set AvgGrit field
-        /// Units: kGrit
-        /// Comment: The grit score estimates how challenging a route could be for a cyclist in terms of time spent going over sharp turns or large grade slopes.</summary>
-        /// <param name="avgGrit_">Nullable field value to be set</param>
-        public void SetAvgGrit(float? avgGrit_)
-        {
-            SetFieldValue(153, 0, avgGrit_, Fit.SubfieldIndexMainField);
-        }
-        
-        ///<summary>
-        /// Retrieves the AvgFlow field
-        /// Units: Flow
-        /// Comment: The flow score estimates how long distance wise a cyclist deaccelerates over intervals where deacceleration is unnecessary such as smooth turns or small grade angle intervals.</summary>
-        /// <returns>Returns nullable float representing the AvgFlow field</returns>
-        public float? GetAvgFlow()
-        {
-            Object val = GetFieldValue(154, 0, Fit.SubfieldIndexMainField);
-            if(val == null)
-            {
-                return null;
-            }
-
-            return (Convert.ToSingle(val));
-            
-        }
-
-        /// <summary>
-        /// Set AvgFlow field
-        /// Units: Flow
-        /// Comment: The flow score estimates how long distance wise a cyclist deaccelerates over intervals where deacceleration is unnecessary such as smooth turns or small grade angle intervals.</summary>
-        /// <param name="avgFlow_">Nullable field value to be set</param>
-        public void SetAvgFlow(float? avgFlow_)
-        {
-            SetFieldValue(154, 0, avgFlow_, Fit.SubfieldIndexMainField);
-        }
-        
-        ///<summary>
-        /// Retrieves the TotalFractionalAscent field
-        /// Units: m
-        /// Comment: fractional part of total_ascent</summary>
-        /// <returns>Returns nullable float representing the TotalFractionalAscent field</returns>
-        public float? GetTotalFractionalAscent()
-        {
-            Object val = GetFieldValue(156, 0, Fit.SubfieldIndexMainField);
-            if(val == null)
-            {
-                return null;
-            }
-
-            return (Convert.ToSingle(val));
-            
-        }
-
-        /// <summary>
-        /// Set TotalFractionalAscent field
-        /// Units: m
-        /// Comment: fractional part of total_ascent</summary>
-        /// <param name="totalFractionalAscent_">Nullable field value to be set</param>
-        public void SetTotalFractionalAscent(float? totalFractionalAscent_)
-        {
-            SetFieldValue(156, 0, totalFractionalAscent_, Fit.SubfieldIndexMainField);
-        }
-        
-        ///<summary>
-        /// Retrieves the TotalFractionalDescent field
-        /// Units: m
-        /// Comment: fractional part of total_descent</summary>
-        /// <returns>Returns nullable float representing the TotalFractionalDescent field</returns>
-        public float? GetTotalFractionalDescent()
-        {
-            Object val = GetFieldValue(157, 0, Fit.SubfieldIndexMainField);
-            if(val == null)
-            {
-                return null;
-            }
-
-            return (Convert.ToSingle(val));
-            
-        }
-
-        /// <summary>
-        /// Set TotalFractionalDescent field
-        /// Units: m
-        /// Comment: fractional part of total_descent</summary>
-        /// <param name="totalFractionalDescent_">Nullable field value to be set</param>
-        public void SetTotalFractionalDescent(float? totalFractionalDescent_)
-        {
-            SetFieldValue(157, 0, totalFractionalDescent_, Fit.SubfieldIndexMainField);
-        }
-        
-        ///<summary>
-        /// Retrieves the AvgCoreTemperature field
-        /// Units: C</summary>
-        /// <returns>Returns nullable float representing the AvgCoreTemperature field</returns>
-        public float? GetAvgCoreTemperature()
-        {
-            Object val = GetFieldValue(158, 0, Fit.SubfieldIndexMainField);
-            if(val == null)
-            {
-                return null;
-            }
-
-            return (Convert.ToSingle(val));
-            
-        }
-
-        /// <summary>
-        /// Set AvgCoreTemperature field
-        /// Units: C</summary>
-        /// <param name="avgCoreTemperature_">Nullable field value to be set</param>
-        public void SetAvgCoreTemperature(float? avgCoreTemperature_)
-        {
-            SetFieldValue(158, 0, avgCoreTemperature_, Fit.SubfieldIndexMainField);
-        }
-        
-        ///<summary>
-        /// Retrieves the MinCoreTemperature field
-        /// Units: C</summary>
-        /// <returns>Returns nullable float representing the MinCoreTemperature field</returns>
-        public float? GetMinCoreTemperature()
-        {
-            Object val = GetFieldValue(159, 0, Fit.SubfieldIndexMainField);
-            if(val == null)
-            {
-                return null;
-            }
-
-            return (Convert.ToSingle(val));
-            
-        }
-
-        /// <summary>
-        /// Set MinCoreTemperature field
-        /// Units: C</summary>
-        /// <param name="minCoreTemperature_">Nullable field value to be set</param>
-        public void SetMinCoreTemperature(float? minCoreTemperature_)
-        {
-            SetFieldValue(159, 0, minCoreTemperature_, Fit.SubfieldIndexMainField);
-        }
-        
-        ///<summary>
-        /// Retrieves the MaxCoreTemperature field
-        /// Units: C</summary>
-        /// <returns>Returns nullable float representing the MaxCoreTemperature field</returns>
-        public float? GetMaxCoreTemperature()
-        {
-            Object val = GetFieldValue(160, 0, Fit.SubfieldIndexMainField);
-            if(val == null)
-            {
-                return null;
-            }
-
-            return (Convert.ToSingle(val));
-            
-        }
-
-        /// <summary>
-        /// Set MaxCoreTemperature field
-        /// Units: C</summary>
-        /// <param name="maxCoreTemperature_">Nullable field value to be set</param>
-        public void SetMaxCoreTemperature(float? maxCoreTemperature_)
-        {
-            SetFieldValue(160, 0, maxCoreTemperature_, Fit.SubfieldIndexMainField);
-        }
-        
-        #endregion // Methods
-    } // Class
+	/// <summary>
+	/// Implements the Lap profile message.
+	/// </summary>
+	public class LapMesg : Mesg
+	{
+		#region Fields
+		static class TotalCyclesSubfield
+		{
+			public static ushort TotalStrides = 0;
+			public static ushort TotalStrokes = 1;
+			public static ushort Subfields = 2;
+			public static ushort Active = Fit.SubfieldIndexActiveSubfield;
+			public static ushort MainField = Fit.SubfieldIndexMainField;
+		}
+		static class AvgCadenceSubfield
+		{
+			public static ushort AvgRunningCadence = 0;
+			public static ushort Subfields = 1;
+			public static ushort Active = Fit.SubfieldIndexActiveSubfield;
+			public static ushort MainField = Fit.SubfieldIndexMainField;
+		}
+		static class MaxCadenceSubfield
+		{
+			public static ushort MaxRunningCadence = 0;
+			public static ushort Subfields = 1;
+			public static ushort Active = Fit.SubfieldIndexActiveSubfield;
+			public static ushort MainField = Fit.SubfieldIndexMainField;
+		}
+		#endregion
+
+		/// <summary>
+		/// Field Numbers for <see cref="LapMesg"/>
+		/// </summary>
+		public sealed class FieldDefNum
+		{
+			public const byte MessageIndex = 254;
+			public const byte Timestamp = 253;
+			public const byte Event = 0;
+			public const byte EventType = 1;
+			public const byte StartTime = 2;
+			public const byte StartPositionLat = 3;
+			public const byte StartPositionLong = 4;
+			public const byte EndPositionLat = 5;
+			public const byte EndPositionLong = 6;
+			public const byte TotalElapsedTime = 7;
+			public const byte TotalTimerTime = 8;
+			public const byte TotalDistance = 9;
+			public const byte TotalCycles = 10;
+			public const byte TotalCalories = 11;
+			public const byte TotalFatCalories = 12;
+			public const byte AvgSpeed = 13;
+			public const byte MaxSpeed = 14;
+			public const byte AvgHeartRate = 15;
+			public const byte MaxHeartRate = 16;
+			public const byte AvgCadence = 17;
+			public const byte MaxCadence = 18;
+			public const byte AvgPower = 19;
+			public const byte MaxPower = 20;
+			public const byte TotalAscent = 21;
+			public const byte TotalDescent = 22;
+			public const byte Intensity = 23;
+			public const byte LapTrigger = 24;
+			public const byte Sport = 25;
+			public const byte EventGroup = 26;
+			public const byte NumLengths = 32;
+			public const byte NormalizedPower = 33;
+			public const byte LeftRightBalance = 34;
+			public const byte FirstLengthIndex = 35;
+			public const byte AvgStrokeDistance = 37;
+			public const byte SwimStroke = 38;
+			public const byte SubSport = 39;
+			public const byte NumActiveLengths = 40;
+			public const byte TotalWork = 41;
+			public const byte AvgAltitude = 42;
+			public const byte MaxAltitude = 43;
+			public const byte GpsAccuracy = 44;
+			public const byte AvgGrade = 45;
+			public const byte AvgPosGrade = 46;
+			public const byte AvgNegGrade = 47;
+			public const byte MaxPosGrade = 48;
+			public const byte MaxNegGrade = 49;
+			public const byte AvgTemperature = 50;
+			public const byte MaxTemperature = 51;
+			public const byte TotalMovingTime = 52;
+			public const byte AvgPosVerticalSpeed = 53;
+			public const byte AvgNegVerticalSpeed = 54;
+			public const byte MaxPosVerticalSpeed = 55;
+			public const byte MaxNegVerticalSpeed = 56;
+			public const byte TimeInHrZone = 57;
+			public const byte TimeInSpeedZone = 58;
+			public const byte TimeInCadenceZone = 59;
+			public const byte TimeInPowerZone = 60;
+			public const byte RepetitionNum = 61;
+			public const byte MinAltitude = 62;
+			public const byte MinHeartRate = 63;
+			public const byte WktStepIndex = 71;
+			public const byte OpponentScore = 74;
+			public const byte StrokeCount = 75;
+			public const byte ZoneCount = 76;
+			public const byte AvgVerticalOscillation = 77;
+			public const byte AvgStanceTimePercent = 78;
+			public const byte AvgStanceTime = 79;
+			public const byte AvgFractionalCadence = 80;
+			public const byte MaxFractionalCadence = 81;
+			public const byte TotalFractionalCycles = 82;
+			public const byte PlayerScore = 83;
+			public const byte AvgTotalHemoglobinConc = 84;
+			public const byte MinTotalHemoglobinConc = 85;
+			public const byte MaxTotalHemoglobinConc = 86;
+			public const byte AvgSaturatedHemoglobinPercent = 87;
+			public const byte MinSaturatedHemoglobinPercent = 88;
+			public const byte MaxSaturatedHemoglobinPercent = 89;
+			public const byte AvgLeftTorqueEffectiveness = 91;
+			public const byte AvgRightTorqueEffectiveness = 92;
+			public const byte AvgLeftPedalSmoothness = 93;
+			public const byte AvgRightPedalSmoothness = 94;
+			public const byte AvgCombinedPedalSmoothness = 95;
+			public const byte TimeStanding = 98;
+			public const byte StandCount = 99;
+			public const byte AvgLeftPco = 100;
+			public const byte AvgRightPco = 101;
+			public const byte AvgLeftPowerPhase = 102;
+			public const byte AvgLeftPowerPhasePeak = 103;
+			public const byte AvgRightPowerPhase = 104;
+			public const byte AvgRightPowerPhasePeak = 105;
+			public const byte AvgPowerPosition = 106;
+			public const byte MaxPowerPosition = 107;
+			public const byte AvgCadencePosition = 108;
+			public const byte MaxCadencePosition = 109;
+			public const byte EnhancedAvgSpeed = 110;
+			public const byte EnhancedMaxSpeed = 111;
+			public const byte EnhancedAvgAltitude = 112;
+			public const byte EnhancedMinAltitude = 113;
+			public const byte EnhancedMaxAltitude = 114;
+			public const byte AvgLevMotorPower = 115;
+			public const byte MaxLevMotorPower = 116;
+			public const byte LevBatteryConsumption = 117;
+			public const byte AvgVerticalRatio = 118;
+			public const byte AvgStanceTimeBalance = 119;
+			public const byte AvgStepLength = 120;
+			public const byte AvgVam = 121;
+			public const byte AvgDepth = 122;
+			public const byte MaxDepth = 123;
+			public const byte MinTemperature = 124;
+			public const byte EnhancedAvgRespirationRate = 136;
+			public const byte EnhancedMaxRespirationRate = 137;
+			public const byte AvgRespirationRate = 147;
+			public const byte MaxRespirationRate = 148;
+			public const byte TotalGrit = 149;
+			public const byte TotalFlow = 150;
+			public const byte JumpCount = 151;
+			public const byte AvgGrit = 153;
+			public const byte AvgFlow = 154;
+			public const byte TotalFractionalAscent = 156;
+			public const byte TotalFractionalDescent = 157;
+			public const byte AvgCoreTemperature = 158;
+			public const byte MinCoreTemperature = 159;
+			public const byte MaxCoreTemperature = 160;
+			public const byte Invalid = Fit.FieldNumInvalid;
+		}
+
+		#region Constructors
+		public LapMesg() : base(Profile.GetMesg(MesgNum.Lap))
+		{
+		}
+
+		public LapMesg(Mesg mesg) : base(mesg)
+		{
+		}
+		#endregion // Constructors
+
+		#region Methods
+		///<summary>
+		/// Retrieves the MessageIndex field</summary>
+		/// <returns>Returns nullable ushort representing the MessageIndex field</returns>
+		public ushort? MessageIndex
+		{
+			get
+			{
+				Object val = GetFieldValue(254, 0, Fit.SubfieldIndexMainField);
+				if (val == null)
+				{
+					return null;
+				}
+
+				return (Convert.ToUInt16(val));
+
+			}
+			set
+			{
+				SetFieldValue(254, 0, value, Fit.SubfieldIndexMainField);
+			}
+		}
+
+		///<summary>
+		/// Retrieves the Timestamp field
+		/// Units: s
+		/// Comment: Lap end time.</summary>
+		/// <returns>Returns DateTime representing the Timestamp field</returns>
+		public DateTime Timestamp
+		{
+			get
+			{
+				Object val = GetFieldValue(253, 0, Fit.SubfieldIndexMainField);
+				if (val == null)
+				{
+					return null;
+				}
+
+				return TimestampToDateTime(Convert.ToUInt32(val));
+
+			}
+			set
+			{
+				SetFieldValue(253, 0, value.GetTimeStamp(), Fit.SubfieldIndexMainField);
+			}
+		}
+
+		///<summary>
+		/// Retrieves the Event field</summary>
+		/// <returns>Returns nullable Event enum representing the Event field</returns>
+		public Event? Event
+		{
+			get
+			{
+				object obj = GetFieldValue(0, 0, Fit.SubfieldIndexMainField);
+				Event? value = obj == null ? (Event?)null : (Event)obj;
+				return value;
+			}
+			set
+			{
+				SetFieldValue(0, 0, value, Fit.SubfieldIndexMainField);
+			}
+		}
+
+		///<summary>
+		/// Retrieves the EventType field</summary>
+		/// <returns>Returns nullable EventType enum representing the EventType field</returns>
+		public EventType? EventType
+		{
+			get
+			{
+				object obj = GetFieldValue(1, 0, Fit.SubfieldIndexMainField);
+				EventType? value = obj == null ? (EventType?)null : (EventType)obj;
+				return value;
+			}
+			set
+			{
+				SetFieldValue(1, 0, value, Fit.SubfieldIndexMainField);
+			}
+		}
+
+		///<summary>
+		/// Retrieves the StartTime field</summary>
+		/// <returns>Returns DateTime representing the StartTime field</returns>
+		public DateTime StartTime
+		{
+			get
+			{
+				Object val = GetFieldValue(2, 0, Fit.SubfieldIndexMainField);
+				if (val == null)
+				{
+					return null;
+				}
+
+				return TimestampToDateTime(Convert.ToUInt32(val));
+
+			}
+			set
+			{
+				SetFieldValue(2, 0, value.GetTimeStamp(), Fit.SubfieldIndexMainField);
+			}
+		}
+
+		///<summary>
+		/// Retrieves the StartPositionLat field
+		/// Units: semicircles</summary>
+		/// <returns>Returns nullable int representing the StartPositionLat field</returns>
+		public int? StartPositionLat
+		{
+			get
+			{
+				Object val = GetFieldValue(3, 0, Fit.SubfieldIndexMainField);
+				if (val == null)
+				{
+					return null;
+				}
+
+				return (Convert.ToInt32(val));
+
+			}
+			set
+			{
+				SetFieldValue(3, 0, value, Fit.SubfieldIndexMainField);
+			}
+		}
+
+		///<summary>
+		/// Retrieves the StartPositionLong field
+		/// Units: semicircles</summary>
+		/// <returns>Returns nullable int representing the StartPositionLong field</returns>
+		public int? StartPositionLong
+		{
+			get
+			{
+				Object val = GetFieldValue(4, 0, Fit.SubfieldIndexMainField);
+				if (val == null)
+				{
+					return null;
+				}
+
+				return (Convert.ToInt32(val));
+
+			}
+			set
+			{
+				SetFieldValue(4, 0, value, Fit.SubfieldIndexMainField);
+			}
+		}
+
+		///<summary>
+		/// Retrieves the EndPositionLat field
+		/// Units: semicircles</summary>
+		/// <returns>Returns nullable int representing the EndPositionLat field</returns>
+		public int? EndPositionLat
+		{
+			get
+			{
+				Object val = GetFieldValue(5, 0, Fit.SubfieldIndexMainField);
+				if (val == null)
+				{
+					return null;
+				}
+
+				return (Convert.ToInt32(val));
+
+			}
+			set
+			{
+				SetFieldValue(5, 0, value, Fit.SubfieldIndexMainField);
+			}
+		}
+
+		///<summary>
+		/// Retrieves the EndPositionLong field
+		/// Units: semicircles</summary>
+		/// <returns>Returns nullable int representing the EndPositionLong field</returns>
+		public int? EndPositionLong
+		{
+			get
+			{
+				Object val = GetFieldValue(6, 0, Fit.SubfieldIndexMainField);
+				if (val == null)
+				{
+					return null;
+				}
+
+				return (Convert.ToInt32(val));
+
+			}
+			set
+			{
+				SetFieldValue(6, 0, value, Fit.SubfieldIndexMainField);
+			}
+		}
+
+		///<summary>
+		/// Retrieves the TotalElapsedTime field
+		/// Units: s
+		/// Comment: Time (includes pauses)</summary>
+		/// <returns>Returns nullable float representing the TotalElapsedTime field</returns>
+		public float? TotalElapsedTime
+		{
+			get
+			{
+				Object val = GetFieldValue(7, 0, Fit.SubfieldIndexMainField);
+				if (val == null)
+				{
+					return null;
+				}
+
+				return (Convert.ToSingle(val));
+
+			}
+			set
+			{
+				SetFieldValue(7, 0, value, Fit.SubfieldIndexMainField);
+			}
+		}
+
+		///<summary>
+		/// Retrieves the TotalTimerTime field
+		/// Units: s
+		/// Comment: Timer Time (excludes pauses)</summary>
+		/// <returns>Returns nullable float representing the TotalTimerTime field</returns>
+		public float? TotalTimerTime
+		{
+			get
+			{
+				Object val = GetFieldValue(8, 0, Fit.SubfieldIndexMainField);
+				if (val == null)
+				{
+					return null;
+				}
+
+				return (Convert.ToSingle(val));
+
+			}
+			set
+			{
+				SetFieldValue(8, 0, value, Fit.SubfieldIndexMainField);
+			}
+		}
+
+		///<summary>
+		/// Retrieves the TotalDistance field
+		/// Units: m</summary>
+		/// <returns>Returns nullable float representing the TotalDistance field</returns>
+		public float? TotalDistance
+		{
+			get
+			{
+				Object val = GetFieldValue(9, 0, Fit.SubfieldIndexMainField);
+				if (val == null)
+				{
+					return null;
+				}
+
+				return (Convert.ToSingle(val));
+
+			}
+			set
+			{
+				SetFieldValue(9, 0, value, Fit.SubfieldIndexMainField);
+			}
+		}
+
+		///<summary>
+		/// Retrieves the TotalCycles field
+		/// Units: cycles</summary>
+		/// <returns>Returns nullable uint representing the TotalCycles field</returns>
+		public uint? TotalCycles
+		{
+			get
+			{
+				Object val = GetFieldValue(10, 0, Fit.SubfieldIndexMainField);
+				if (val == null)
+				{
+					return null;
+				}
+
+				return (Convert.ToUInt32(val));
+
+			}
+			set
+			{
+				SetFieldValue(10, 0, value, Fit.SubfieldIndexMainField);
+			}
+		}
+
+
+		/// <summary>
+		/// Retrieves the TotalStrides subfield
+		/// Units: strides</summary>
+		/// <returns>Nullable uint representing the TotalStrides subfield</returns>
+		public uint? TotalStrides
+		{
+			get
+			{
+				Object val = GetFieldValue(10, 0, TotalCyclesSubfield.TotalStrides);
+				if (val == null)
+				{
+					return null;
+				}
+
+				return (Convert.ToUInt32(val));
+
+			}
+			set
+			{
+				SetFieldValue(10, 0, value, TotalCyclesSubfield.TotalStrides);
+			}
+		}
+
+		/// <summary>
+		/// Retrieves the TotalStrokes subfield
+		/// Units: strokes</summary>
+		/// <returns>Nullable uint representing the TotalStrokes subfield</returns>
+		public uint? TotalStrokes
+		{
+			get
+			{
+				Object val = GetFieldValue(10, 0, TotalCyclesSubfield.TotalStrokes);
+				if (val == null)
+				{
+					return null;
+				}
+
+				return (Convert.ToUInt32(val));
+
+			}
+			set
+			{
+				SetFieldValue(10, 0, value, TotalCyclesSubfield.TotalStrokes);
+			}
+		}
+		///<summary>
+		/// Retrieves the TotalCalories field
+		/// Units: kcal</summary>
+		/// <returns>Returns nullable ushort representing the TotalCalories field</returns>
+		public ushort? TotalCalories
+		{
+			get
+			{
+				Object val = GetFieldValue(11, 0, Fit.SubfieldIndexMainField);
+				if (val == null)
+				{
+					return null;
+				}
+
+				return (Convert.ToUInt16(val));
+
+			}
+			set
+			{
+				SetFieldValue(11, 0, value, Fit.SubfieldIndexMainField);
+			}
+		}
+
+		///<summary>
+		/// Retrieves the TotalFatCalories field
+		/// Units: kcal
+		/// Comment: If New Leaf</summary>
+		/// <returns>Returns nullable ushort representing the TotalFatCalories field</returns>
+		public ushort? TotalFatCalories
+		{
+			get
+			{
+				Object val = GetFieldValue(12, 0, Fit.SubfieldIndexMainField);
+				if (val == null)
+				{
+					return null;
+				}
+
+				return (Convert.ToUInt16(val));
+
+			}
+			set
+			{
+				SetFieldValue(12, 0, value, Fit.SubfieldIndexMainField);
+			}
+		}
+
+		///<summary>
+		/// Retrieves the AvgSpeed field
+		/// Units: m/s</summary>
+		/// <returns>Returns nullable float representing the AvgSpeed field</returns>
+		public float? AvgSpeed
+		{
+			get
+			{
+				Object val = GetFieldValue(13, 0, Fit.SubfieldIndexMainField);
+				if (val == null)
+				{
+					return null;
+				}
+
+				return (Convert.ToSingle(val));
+
+			}
+			set
+			{
+				SetFieldValue(13, 0, value, Fit.SubfieldIndexMainField);
+			}
+		}
+
+		///<summary>
+		/// Retrieves the MaxSpeed field
+		/// Units: m/s</summary>
+		/// <returns>Returns nullable float representing the MaxSpeed field</returns>
+		public float? MaxSpeed
+		{
+			get
+			{
+				Object val = GetFieldValue(14, 0, Fit.SubfieldIndexMainField);
+				if (val == null)
+				{
+					return null;
+				}
+
+				return (Convert.ToSingle(val));
+
+			}
+			set
+			{
+				SetFieldValue(14, 0, value, Fit.SubfieldIndexMainField);
+			}
+		}
+
+		///<summary>
+		/// Retrieves the AvgHeartRate field
+		/// Units: bpm</summary>
+		/// <returns>Returns nullable byte representing the AvgHeartRate field</returns>
+		public byte? AvgHeartRate
+		{
+			get
+			{
+				Object val = GetFieldValue(15, 0, Fit.SubfieldIndexMainField);
+				if (val == null)
+				{
+					return null;
+				}
+
+				return (Convert.ToByte(val));
+
+			}
+			set
+			{
+				SetFieldValue(15, 0, value, Fit.SubfieldIndexMainField);
+			}
+		}
+
+		///<summary>
+		/// Retrieves the MaxHeartRate field
+		/// Units: bpm</summary>
+		/// <returns>Returns nullable byte representing the MaxHeartRate field</returns>
+		public byte? MaxHeartRate
+		{
+			get
+			{
+				Object val = GetFieldValue(16, 0, Fit.SubfieldIndexMainField);
+				if (val == null)
+				{
+					return null;
+				}
+
+				return (Convert.ToByte(val));
+
+			}
+			set
+			{
+				SetFieldValue(16, 0, value, Fit.SubfieldIndexMainField);
+			}
+		}
+
+		///<summary>
+		/// Retrieves the AvgCadence field
+		/// Units: rpm
+		/// Comment: total_cycles / total_timer_time if non_zero_avg_cadence otherwise total_cycles / total_elapsed_time</summary>
+		/// <returns>Returns nullable byte representing the AvgCadence field</returns>
+		public byte? AvgCadence
+		{
+			get
+			{
+				Object val = GetFieldValue(17, 0, Fit.SubfieldIndexMainField);
+				if (val == null)
+				{
+					return null;
+				}
+
+				return (Convert.ToByte(val));
+
+			}
+			set
+			{
+				SetFieldValue(17, 0, value, Fit.SubfieldIndexMainField);
+			}
+		}
+
+
+		/// <summary>
+		/// Retrieves the AvgRunningCadence subfield
+		/// Units: strides/min</summary>
+		/// <returns>Nullable byte representing the AvgRunningCadence subfield</returns>
+		public byte? AvgRunningCadence
+		{
+			get
+			{
+				Object val = GetFieldValue(17, 0, AvgCadenceSubfield.AvgRunningCadence);
+				if (val == null)
+				{
+					return null;
+				}
+
+				return (Convert.ToByte(val));
+
+			}
+			set
+			{
+				SetFieldValue(17, 0, value, AvgCadenceSubfield.AvgRunningCadence);
+			}
+		}
+		///<summary>
+		/// Retrieves the MaxCadence field
+		/// Units: rpm</summary>
+		/// <returns>Returns nullable byte representing the MaxCadence field</returns>
+		public byte? MaxCadence
+		{
+			get
+			{
+				Object val = GetFieldValue(18, 0, Fit.SubfieldIndexMainField);
+				if (val == null)
+				{
+					return null;
+				}
+
+				return (Convert.ToByte(val));
+
+			}
+			set
+			{
+				SetFieldValue(18, 0, value, Fit.SubfieldIndexMainField);
+			}
+		}
+
+
+		/// <summary>
+		/// Retrieves the MaxRunningCadence subfield
+		/// Units: strides/min</summary>
+		/// <returns>Nullable byte representing the MaxRunningCadence subfield</returns>
+		public byte? MaxRunningCadence
+		{
+			get
+			{
+				Object val = GetFieldValue(18, 0, MaxCadenceSubfield.MaxRunningCadence);
+				if (val == null)
+				{
+					return null;
+				}
+
+				return (Convert.ToByte(val));
+
+			}
+			set
+			{
+				SetFieldValue(18, 0, value, MaxCadenceSubfield.MaxRunningCadence);
+			}
+		}
+		///<summary>
+		/// Retrieves the AvgPower field
+		/// Units: watts
+		/// Comment: total_power / total_timer_time if non_zero_avg_power otherwise total_power / total_elapsed_time</summary>
+		/// <returns>Returns nullable ushort representing the AvgPower field</returns>
+		public ushort? AvgPower
+		{
+			get
+			{
+				Object val = GetFieldValue(19, 0, Fit.SubfieldIndexMainField);
+				if (val == null)
+				{
+					return null;
+				}
+
+				return (Convert.ToUInt16(val));
+
+			}
+			set
+			{
+				SetFieldValue(19, 0, value, Fit.SubfieldIndexMainField);
+			}
+		}
+
+		///<summary>
+		/// Retrieves the MaxPower field
+		/// Units: watts</summary>
+		/// <returns>Returns nullable ushort representing the MaxPower field</returns>
+		public ushort? MaxPower
+		{
+			get
+			{
+				Object val = GetFieldValue(20, 0, Fit.SubfieldIndexMainField);
+				if (val == null)
+				{
+					return null;
+				}
+
+				return (Convert.ToUInt16(val));
+
+			}
+			set
+			{
+				SetFieldValue(20, 0, value, Fit.SubfieldIndexMainField);
+			}
+		}
+
+		///<summary>
+		/// Retrieves the TotalAscent field
+		/// Units: m</summary>
+		/// <returns>Returns nullable ushort representing the TotalAscent field</returns>
+		public ushort? TotalAscent
+		{
+			get
+			{
+				Object val = GetFieldValue(21, 0, Fit.SubfieldIndexMainField);
+				if (val == null)
+				{
+					return null;
+				}
+
+				return (Convert.ToUInt16(val));
+
+			}
+			set
+			{
+				SetFieldValue(21, 0, value, Fit.SubfieldIndexMainField);
+			}
+		}
+
+		///<summary>
+		/// Retrieves the TotalDescent field
+		/// Units: m</summary>
+		/// <returns>Returns nullable ushort representing the TotalDescent field</returns>
+		public ushort? TotalDescent
+		{
+			get
+			{
+				Object val = GetFieldValue(22, 0, Fit.SubfieldIndexMainField);
+				if (val == null)
+				{
+					return null;
+				}
+
+				return (Convert.ToUInt16(val));
+
+			}
+			set
+			{
+				SetFieldValue(22, 0, value, Fit.SubfieldIndexMainField);
+			}
+		}
+
+		///<summary>
+		/// Retrieves the Intensity field</summary>
+		/// <returns>Returns nullable Intensity enum representing the Intensity field</returns>
+		public Intensity? Intensity
+		{
+			get
+			{
+				object obj = GetFieldValue(23, 0, Fit.SubfieldIndexMainField);
+				Intensity? value = obj == null ? (Intensity?)null : (Intensity)obj;
+				return value;
+			}
+			set
+			{
+				SetFieldValue(23, 0, value, Fit.SubfieldIndexMainField);
+			}
+		}
+
+		///<summary>
+		/// Retrieves the LapTrigger field</summary>
+		/// <returns>Returns nullable LapTrigger enum representing the LapTrigger field</returns>
+		public LapTrigger? LapTrigger
+		{
+			get
+			{
+				object obj = GetFieldValue(24, 0, Fit.SubfieldIndexMainField);
+				LapTrigger? value = obj == null ? (LapTrigger?)null : (LapTrigger)obj;
+				return value;
+			}
+			set
+			{
+				SetFieldValue(24, 0, value, Fit.SubfieldIndexMainField);
+			}
+		}
+
+		///<summary>
+		/// Retrieves the Sport field</summary>
+		/// <returns>Returns nullable Sport enum representing the Sport field</returns>
+		public Sport? Sport
+		{
+			get
+			{
+				object obj = GetFieldValue(25, 0, Fit.SubfieldIndexMainField);
+				Sport? value = obj == null ? (Sport?)null : (Sport)obj;
+				return value;
+			}
+			set
+			{
+				SetFieldValue(25, 0, value, Fit.SubfieldIndexMainField);
+			}
+		}
+
+		///<summary>
+		/// Retrieves the EventGroup field</summary>
+		/// <returns>Returns nullable byte representing the EventGroup field</returns>
+		public byte? EventGroup
+		{
+			get
+			{
+				Object val = GetFieldValue(26, 0, Fit.SubfieldIndexMainField);
+				if (val == null)
+				{
+					return null;
+				}
+
+				return (Convert.ToByte(val));
+
+			}
+			set
+			{
+				SetFieldValue(26, 0, value, Fit.SubfieldIndexMainField);
+			}
+		}
+
+		///<summary>
+		/// Retrieves the NumLengths field
+		/// Units: lengths
+		/// Comment: # of lengths of swim pool</summary>
+		/// <returns>Returns nullable ushort representing the NumLengths field</returns>
+		public ushort? NumLengths
+		{
+			get
+			{
+				Object val = GetFieldValue(32, 0, Fit.SubfieldIndexMainField);
+				if (val == null)
+				{
+					return null;
+				}
+
+				return (Convert.ToUInt16(val));
+
+			}
+			set
+			{
+				SetFieldValue(32, 0, value, Fit.SubfieldIndexMainField);
+			}
+		}
+
+		///<summary>
+		/// Retrieves the NormalizedPower field
+		/// Units: watts</summary>
+		/// <returns>Returns nullable ushort representing the NormalizedPower field</returns>
+		public ushort? NormalizedPower
+		{
+			get
+			{
+				Object val = GetFieldValue(33, 0, Fit.SubfieldIndexMainField);
+				if (val == null)
+				{
+					return null;
+				}
+
+				return (Convert.ToUInt16(val));
+
+			}
+			set
+			{
+				SetFieldValue(33, 0, value, Fit.SubfieldIndexMainField);
+			}
+		}
+
+		///<summary>
+		/// Retrieves the LeftRightBalance field</summary>
+		/// <returns>Returns nullable ushort representing the LeftRightBalance field</returns>
+		public ushort? LeftRightBalance
+		{
+			get
+			{
+				Object val = GetFieldValue(34, 0, Fit.SubfieldIndexMainField);
+				if (val == null)
+				{
+					return null;
+				}
+
+				return (Convert.ToUInt16(val));
+
+			}
+			set
+			{
+				SetFieldValue(34, 0, value, Fit.SubfieldIndexMainField);
+			}
+		}
+
+		///<summary>
+		/// Retrieves the FirstLengthIndex field</summary>
+		/// <returns>Returns nullable ushort representing the FirstLengthIndex field</returns>
+		public ushort? FirstLengthIndex
+		{
+			get
+			{
+				Object val = GetFieldValue(35, 0, Fit.SubfieldIndexMainField);
+				if (val == null)
+				{
+					return null;
+				}
+
+				return (Convert.ToUInt16(val));
+
+			}
+			set
+			{
+				SetFieldValue(35, 0, value, Fit.SubfieldIndexMainField);
+			}
+		}
+
+		///<summary>
+		/// Retrieves the AvgStrokeDistance field
+		/// Units: m</summary>
+		/// <returns>Returns nullable float representing the AvgStrokeDistance field</returns>
+		public float? AvgStrokeDistance
+		{
+			get
+			{
+				Object val = GetFieldValue(37, 0, Fit.SubfieldIndexMainField);
+				if (val == null)
+				{
+					return null;
+				}
+
+				return (Convert.ToSingle(val));
+
+			}
+			set
+			{
+				SetFieldValue(37, 0, value, Fit.SubfieldIndexMainField);
+			}
+		}
+
+		///<summary>
+		/// Retrieves the SwimStroke field</summary>
+		/// <returns>Returns nullable SwimStroke enum representing the SwimStroke field</returns>
+		public SwimStroke? SwimStroke
+		{
+			get
+			{
+				object obj = GetFieldValue(38, 0, Fit.SubfieldIndexMainField);
+				SwimStroke? value = obj == null ? (SwimStroke?)null : (SwimStroke)obj;
+				return value;
+			}
+			set
+			{
+				SetFieldValue(38, 0, value, Fit.SubfieldIndexMainField);
+			}
+		}
+
+		///<summary>
+		/// Retrieves the SubSport field</summary>
+		/// <returns>Returns nullable SubSport enum representing the SubSport field</returns>
+		public SubSport? SubSport
+		{
+			get
+			{
+				object obj = GetFieldValue(39, 0, Fit.SubfieldIndexMainField);
+				SubSport? value = obj == null ? (SubSport?)null : (SubSport)obj;
+				return value;
+			}
+			set
+			{
+				SetFieldValue(39, 0, value, Fit.SubfieldIndexMainField);
+			}
+		}
+
+		///<summary>
+		/// Retrieves the NumActiveLengths field
+		/// Units: lengths
+		/// Comment: # of active lengths of swim pool</summary>
+		/// <returns>Returns nullable ushort representing the NumActiveLengths field</returns>
+		public ushort? NumActiveLengths
+		{
+			get
+			{
+				Object val = GetFieldValue(40, 0, Fit.SubfieldIndexMainField);
+				if (val == null)
+				{
+					return null;
+				}
+
+				return (Convert.ToUInt16(val));
+
+			}
+			set
+			{
+				SetFieldValue(40, 0, value, Fit.SubfieldIndexMainField);
+			}
+		}
+
+		///<summary>
+		/// Retrieves the TotalWork field
+		/// Units: J</summary>
+		/// <returns>Returns nullable uint representing the TotalWork field</returns>
+		public uint? TotalWork
+		{
+			get
+			{
+				Object val = GetFieldValue(41, 0, Fit.SubfieldIndexMainField);
+				if (val == null)
+				{
+					return null;
+				}
+
+				return (Convert.ToUInt32(val));
+
+			}
+			set
+			{
+				SetFieldValue(41, 0, value, Fit.SubfieldIndexMainField);
+			}
+		}
+
+		///<summary>
+		/// Retrieves the AvgAltitude field
+		/// Units: m</summary>
+		/// <returns>Returns nullable float representing the AvgAltitude field</returns>
+		public float? AvgAltitude
+		{
+			get
+			{
+				Object val = GetFieldValue(42, 0, Fit.SubfieldIndexMainField);
+				if (val == null)
+				{
+					return null;
+				}
+
+				return (Convert.ToSingle(val));
+
+			}
+			set
+			{
+				SetFieldValue(42, 0, value, Fit.SubfieldIndexMainField);
+			}
+		}
+
+		///<summary>
+		/// Retrieves the MaxAltitude field
+		/// Units: m</summary>
+		/// <returns>Returns nullable float representing the MaxAltitude field</returns>
+		public float? MaxAltitude
+		{
+			get
+			{
+				Object val = GetFieldValue(43, 0, Fit.SubfieldIndexMainField);
+				if (val == null)
+				{
+					return null;
+				}
+
+				return (Convert.ToSingle(val));
+
+			}
+			set
+			{
+				SetFieldValue(43, 0, value, Fit.SubfieldIndexMainField);
+			}
+		}
+
+		///<summary>
+		/// Retrieves the GpsAccuracy field
+		/// Units: m</summary>
+		/// <returns>Returns nullable byte representing the GpsAccuracy field</returns>
+		public byte? GpsAccuracy
+		{
+			get
+			{
+				Object val = GetFieldValue(44, 0, Fit.SubfieldIndexMainField);
+				if (val == null)
+				{
+					return null;
+				}
+
+				return (Convert.ToByte(val));
+
+			}
+			set
+			{
+				SetFieldValue(44, 0, value, Fit.SubfieldIndexMainField);
+			}
+		}
+
+		///<summary>
+		/// Retrieves the AvgGrade field
+		/// Units: %</summary>
+		/// <returns>Returns nullable float representing the AvgGrade field</returns>
+		public float? AvgGrade
+		{
+			get
+			{
+				Object val = GetFieldValue(45, 0, Fit.SubfieldIndexMainField);
+				if (val == null)
+				{
+					return null;
+				}
+
+				return (Convert.ToSingle(val));
+
+			}
+			set
+			{
+				SetFieldValue(45, 0, value, Fit.SubfieldIndexMainField);
+			}
+		}
+
+		///<summary>
+		/// Retrieves the AvgPosGrade field
+		/// Units: %</summary>
+		/// <returns>Returns nullable float representing the AvgPosGrade field</returns>
+		public float? AvgPosGrade
+		{
+			get
+			{
+				Object val = GetFieldValue(46, 0, Fit.SubfieldIndexMainField);
+				if (val == null)
+				{
+					return null;
+				}
+
+				return (Convert.ToSingle(val));
+
+			}
+			set
+			{
+				SetFieldValue(46, 0, value, Fit.SubfieldIndexMainField);
+			}
+		}
+
+		///<summary>
+		/// Retrieves the AvgNegGrade field
+		/// Units: %</summary>
+		/// <returns>Returns nullable float representing the AvgNegGrade field</returns>
+		public float? AvgNegGrade
+		{
+			get
+			{
+				Object val = GetFieldValue(47, 0, Fit.SubfieldIndexMainField);
+				if (val == null)
+				{
+					return null;
+				}
+
+				return (Convert.ToSingle(val));
+
+			}
+			set
+			{
+				SetFieldValue(47, 0, value, Fit.SubfieldIndexMainField);
+			}
+		}
+
+		///<summary>
+		/// Retrieves the MaxPosGrade field
+		/// Units: %</summary>
+		/// <returns>Returns nullable float representing the MaxPosGrade field</returns>
+		public float? MaxPosGrade
+		{
+			get
+			{
+				Object val = GetFieldValue(48, 0, Fit.SubfieldIndexMainField);
+				if (val == null)
+				{
+					return null;
+				}
+
+				return (Convert.ToSingle(val));
+
+			}
+			set
+			{
+				SetFieldValue(48, 0, value, Fit.SubfieldIndexMainField);
+			}
+		}
+
+		///<summary>
+		/// Retrieves the MaxNegGrade field
+		/// Units: %</summary>
+		/// <returns>Returns nullable float representing the MaxNegGrade field</returns>
+		public float? MaxNegGrade
+		{
+			get
+			{
+				Object val = GetFieldValue(49, 0, Fit.SubfieldIndexMainField);
+				if (val == null)
+				{
+					return null;
+				}
+
+				return (Convert.ToSingle(val));
+
+			}
+			set
+			{
+				SetFieldValue(49, 0, value, Fit.SubfieldIndexMainField);
+			}
+		}
+
+		///<summary>
+		/// Retrieves the AvgTemperature field
+		/// Units: C</summary>
+		/// <returns>Returns nullable sbyte representing the AvgTemperature field</returns>
+		public sbyte? AvgTemperature
+		{
+			get
+			{
+				Object val = GetFieldValue(50, 0, Fit.SubfieldIndexMainField);
+				if (val == null)
+				{
+					return null;
+				}
+
+				return (Convert.ToSByte(val));
+
+			}
+			set
+			{
+				SetFieldValue(50, 0, value, Fit.SubfieldIndexMainField);
+			}
+		}
+
+		///<summary>
+		/// Retrieves the MaxTemperature field
+		/// Units: C</summary>
+		/// <returns>Returns nullable sbyte representing the MaxTemperature field</returns>
+		public sbyte? MaxTemperature
+		{
+			get
+			{
+				Object val = GetFieldValue(51, 0, Fit.SubfieldIndexMainField);
+				if (val == null)
+				{
+					return null;
+				}
+
+				return (Convert.ToSByte(val));
+
+			}
+			set
+			{
+				SetFieldValue(51, 0, value, Fit.SubfieldIndexMainField);
+			}
+		}
+
+		///<summary>
+		/// Retrieves the TotalMovingTime field
+		/// Units: s</summary>
+		/// <returns>Returns nullable float representing the TotalMovingTime field</returns>
+		public float? TotalMovingTime
+		{
+			get
+			{
+				Object val = GetFieldValue(52, 0, Fit.SubfieldIndexMainField);
+				if (val == null)
+				{
+					return null;
+				}
+
+				return (Convert.ToSingle(val));
+
+			}
+			set
+			{
+				SetFieldValue(52, 0, value, Fit.SubfieldIndexMainField);
+			}
+		}
+
+		///<summary>
+		/// Retrieves the AvgPosVerticalSpeed field
+		/// Units: m/s</summary>
+		/// <returns>Returns nullable float representing the AvgPosVerticalSpeed field</returns>
+		public float? AvgPosVerticalSpeed
+		{
+			get
+			{
+				Object val = GetFieldValue(53, 0, Fit.SubfieldIndexMainField);
+				if (val == null)
+				{
+					return null;
+				}
+
+				return (Convert.ToSingle(val));
+
+			}
+			set
+			{
+				SetFieldValue(53, 0, value, Fit.SubfieldIndexMainField);
+			}
+		}
+
+		///<summary>
+		/// Retrieves the AvgNegVerticalSpeed field
+		/// Units: m/s</summary>
+		/// <returns>Returns nullable float representing the AvgNegVerticalSpeed field</returns>
+		public float? AvgNegVerticalSpeed
+		{
+			get
+			{
+				Object val = GetFieldValue(54, 0, Fit.SubfieldIndexMainField);
+				if (val == null)
+				{
+					return null;
+				}
+
+				return (Convert.ToSingle(val));
+
+			}
+			set
+			{
+				SetFieldValue(54, 0, value, Fit.SubfieldIndexMainField);
+			}
+		}
+
+		///<summary>
+		/// Retrieves the MaxPosVerticalSpeed field
+		/// Units: m/s</summary>
+		/// <returns>Returns nullable float representing the MaxPosVerticalSpeed field</returns>
+		public float? MaxPosVerticalSpeed
+		{
+			get
+			{
+				Object val = GetFieldValue(55, 0, Fit.SubfieldIndexMainField);
+				if (val == null)
+				{
+					return null;
+				}
+
+				return (Convert.ToSingle(val));
+
+			}
+			set
+			{
+				SetFieldValue(55, 0, value, Fit.SubfieldIndexMainField);
+			}
+		}
+
+		///<summary>
+		/// Retrieves the MaxNegVerticalSpeed field
+		/// Units: m/s</summary>
+		/// <returns>Returns nullable float representing the MaxNegVerticalSpeed field</returns>
+		public float? MaxNegVerticalSpeed
+		{
+			get
+			{
+				Object val = GetFieldValue(56, 0, Fit.SubfieldIndexMainField);
+				if (val == null)
+				{
+					return null;
+				}
+
+				return (Convert.ToSingle(val));
+
+			}
+			set
+			{
+				SetFieldValue(56, 0, value, Fit.SubfieldIndexMainField);
+			}
+		}
+
+
+		/// <summary>
+		///
+		/// </summary>
+		/// <returns>returns number of elements in field TimeInHrZone</returns>
+		public int GetNumTimeInHrZone()
+		{
+			return GetNumFieldValues(57, Fit.SubfieldIndexMainField);
+		}
+
+		///<summary>
+		/// Retrieves the TimeInHrZone field
+		/// Units: s</summary>
+		/// <param name="index">0 based index of TimeInHrZone element to retrieve</param>
+		/// <returns>Returns nullable float representing the TimeInHrZone field</returns>
+		public float? GetTimeInHrZone(int index)
+		{
+			Object val = GetFieldValue(57, index, Fit.SubfieldIndexMainField);
+			if (val == null)
+			{
+				return null;
+			}
+
+			return (Convert.ToSingle(val));
+
+		}
+
+		/// <summary>
+		/// Set TimeInHrZone field
+		/// Units: s</summary>
+		/// <param name="index">0 based index of time_in_hr_zone</param>
+		/// <param name="timeInHrZone_">Nullable field value to be set</param>
+		public void SetTimeInHrZone(int index, float? timeInHrZone_)
+		{
+			SetFieldValue(57, index, timeInHrZone_, Fit.SubfieldIndexMainField);
+		}
+
+
+		/// <summary>
+		///
+		/// </summary>
+		/// <returns>returns number of elements in field TimeInSpeedZone</returns>
+		public int GetNumTimeInSpeedZone()
+		{
+			return GetNumFieldValues(58, Fit.SubfieldIndexMainField);
+		}
+
+		///<summary>
+		/// Retrieves the TimeInSpeedZone field
+		/// Units: s</summary>
+		/// <param name="index">0 based index of TimeInSpeedZone element to retrieve</param>
+		/// <returns>Returns nullable float representing the TimeInSpeedZone field</returns>
+		public float? GetTimeInSpeedZone(int index)
+		{
+			Object val = GetFieldValue(58, index, Fit.SubfieldIndexMainField);
+			if (val == null)
+			{
+				return null;
+			}
+
+			return (Convert.ToSingle(val));
+
+		}
+
+		/// <summary>
+		/// Set TimeInSpeedZone field
+		/// Units: s</summary>
+		/// <param name="index">0 based index of time_in_speed_zone</param>
+		/// <param name="timeInSpeedZone_">Nullable field value to be set</param>
+		public void SetTimeInSpeedZone(int index, float? timeInSpeedZone_)
+		{
+			SetFieldValue(58, index, timeInSpeedZone_, Fit.SubfieldIndexMainField);
+		}
+
+
+		/// <summary>
+		///
+		/// </summary>
+		/// <returns>returns number of elements in field TimeInCadenceZone</returns>
+		public int GetNumTimeInCadenceZone()
+		{
+			return GetNumFieldValues(59, Fit.SubfieldIndexMainField);
+		}
+
+		///<summary>
+		/// Retrieves the TimeInCadenceZone field
+		/// Units: s</summary>
+		/// <param name="index">0 based index of TimeInCadenceZone element to retrieve</param>
+		/// <returns>Returns nullable float representing the TimeInCadenceZone field</returns>
+		public float? GetTimeInCadenceZone(int index)
+		{
+			Object val = GetFieldValue(59, index, Fit.SubfieldIndexMainField);
+			if (val == null)
+			{
+				return null;
+			}
+
+			return (Convert.ToSingle(val));
+
+		}
+
+		/// <summary>
+		/// Set TimeInCadenceZone field
+		/// Units: s</summary>
+		/// <param name="index">0 based index of time_in_cadence_zone</param>
+		/// <param name="timeInCadenceZone_">Nullable field value to be set</param>
+		public void SetTimeInCadenceZone(int index, float? timeInCadenceZone_)
+		{
+			SetFieldValue(59, index, timeInCadenceZone_, Fit.SubfieldIndexMainField);
+		}
+
+
+		/// <summary>
+		///
+		/// </summary>
+		/// <returns>returns number of elements in field TimeInPowerZone</returns>
+		public int GetNumTimeInPowerZone()
+		{
+			return GetNumFieldValues(60, Fit.SubfieldIndexMainField);
+		}
+
+		///<summary>
+		/// Retrieves the TimeInPowerZone field
+		/// Units: s</summary>
+		/// <param name="index">0 based index of TimeInPowerZone element to retrieve</param>
+		/// <returns>Returns nullable float representing the TimeInPowerZone field</returns>
+		public float? GetTimeInPowerZone(int index)
+		{
+			Object val = GetFieldValue(60, index, Fit.SubfieldIndexMainField);
+			if (val == null)
+			{
+				return null;
+			}
+
+			return (Convert.ToSingle(val));
+
+		}
+
+		/// <summary>
+		/// Set TimeInPowerZone field
+		/// Units: s</summary>
+		/// <param name="index">0 based index of time_in_power_zone</param>
+		/// <param name="timeInPowerZone_">Nullable field value to be set</param>
+		public void SetTimeInPowerZone(int index, float? timeInPowerZone_)
+		{
+			SetFieldValue(60, index, timeInPowerZone_, Fit.SubfieldIndexMainField);
+		}
+
+		///<summary>
+		/// Retrieves the RepetitionNum field</summary>
+		/// <returns>Returns nullable ushort representing the RepetitionNum field</returns>
+		public ushort? RepetitionNum
+		{
+			get
+			{
+				Object val = GetFieldValue(61, 0, Fit.SubfieldIndexMainField);
+				if (val == null)
+				{
+					return null;
+				}
+
+				return (Convert.ToUInt16(val));
+
+			}
+			set
+			{
+				SetFieldValue(61, 0, value, Fit.SubfieldIndexMainField);
+			}
+		}
+
+		///<summary>
+		/// Retrieves the MinAltitude field
+		/// Units: m</summary>
+		/// <returns>Returns nullable float representing the MinAltitude field</returns>
+		public float? MinAltitude
+		{
+			get
+			{
+				Object val = GetFieldValue(62, 0, Fit.SubfieldIndexMainField);
+				if (val == null)
+				{
+					return null;
+				}
+
+				return (Convert.ToSingle(val));
+
+			}
+			set
+			{
+				SetFieldValue(62, 0, value, Fit.SubfieldIndexMainField);
+			}
+		}
+
+		///<summary>
+		/// Retrieves the MinHeartRate field
+		/// Units: bpm</summary>
+		/// <returns>Returns nullable byte representing the MinHeartRate field</returns>
+		public byte? MinHeartRate
+		{
+			get
+			{
+				Object val = GetFieldValue(63, 0, Fit.SubfieldIndexMainField);
+				if (val == null)
+				{
+					return null;
+				}
+
+				return (Convert.ToByte(val));
+
+			}
+			set
+			{
+				SetFieldValue(63, 0, value, Fit.SubfieldIndexMainField);
+			}
+		}
+
+		///<summary>
+		/// Retrieves the WktStepIndex field</summary>
+		/// <returns>Returns nullable ushort representing the WktStepIndex field</returns>
+		public ushort? WktStepIndex
+		{
+			get
+			{
+				Object val = GetFieldValue(71, 0, Fit.SubfieldIndexMainField);
+				if (val == null)
+				{
+					return null;
+				}
+
+				return (Convert.ToUInt16(val));
+
+			}
+			set
+			{
+				SetFieldValue(71, 0, value, Fit.SubfieldIndexMainField);
+			}
+		}
+
+		///<summary>
+		/// Retrieves the OpponentScore field</summary>
+		/// <returns>Returns nullable ushort representing the OpponentScore field</returns>
+		public ushort? OpponentScore
+		{
+			get
+			{
+				Object val = GetFieldValue(74, 0, Fit.SubfieldIndexMainField);
+				if (val == null)
+				{
+					return null;
+				}
+
+				return (Convert.ToUInt16(val));
+
+			}
+			set
+			{
+				SetFieldValue(74, 0, value, Fit.SubfieldIndexMainField);
+			}
+		}
+
+
+		/// <summary>
+		///
+		/// </summary>
+		/// <returns>returns number of elements in field StrokeCount</returns>
+		public int GetNumStrokeCount()
+		{
+			return GetNumFieldValues(75, Fit.SubfieldIndexMainField);
+		}
+
+		///<summary>
+		/// Retrieves the StrokeCount field
+		/// Units: counts
+		/// Comment: stroke_type enum used as the index</summary>
+		/// <param name="index">0 based index of StrokeCount element to retrieve</param>
+		/// <returns>Returns nullable ushort representing the StrokeCount field</returns>
+		public ushort? GetStrokeCount(int index)
+		{
+			Object val = GetFieldValue(75, index, Fit.SubfieldIndexMainField);
+			if (val == null)
+			{
+				return null;
+			}
+
+			return (Convert.ToUInt16(val));
+
+		}
+
+		/// <summary>
+		/// Set StrokeCount field
+		/// Units: counts
+		/// Comment: stroke_type enum used as the index</summary>
+		/// <param name="index">0 based index of stroke_count</param>
+		/// <param name="strokeCount_">Nullable field value to be set</param>
+		public void SetStrokeCount(int index, ushort? strokeCount_)
+		{
+			SetFieldValue(75, index, strokeCount_, Fit.SubfieldIndexMainField);
+		}
+
+
+		/// <summary>
+		///
+		/// </summary>
+		/// <returns>returns number of elements in field ZoneCount</returns>
+		public int GetNumZoneCount()
+		{
+			return GetNumFieldValues(76, Fit.SubfieldIndexMainField);
+		}
+
+		///<summary>
+		/// Retrieves the ZoneCount field
+		/// Units: counts
+		/// Comment: zone number used as the index</summary>
+		/// <param name="index">0 based index of ZoneCount element to retrieve</param>
+		/// <returns>Returns nullable ushort representing the ZoneCount field</returns>
+		public ushort? GetZoneCount(int index)
+		{
+			Object val = GetFieldValue(76, index, Fit.SubfieldIndexMainField);
+			if (val == null)
+			{
+				return null;
+			}
+
+			return (Convert.ToUInt16(val));
+
+		}
+
+		/// <summary>
+		/// Set ZoneCount field
+		/// Units: counts
+		/// Comment: zone number used as the index</summary>
+		/// <param name="index">0 based index of zone_count</param>
+		/// <param name="zoneCount_">Nullable field value to be set</param>
+		public void SetZoneCount(int index, ushort? zoneCount_)
+		{
+			SetFieldValue(76, index, zoneCount_, Fit.SubfieldIndexMainField);
+		}
+
+		///<summary>
+		/// Retrieves the AvgVerticalOscillation field
+		/// Units: mm</summary>
+		/// <returns>Returns nullable float representing the AvgVerticalOscillation field</returns>
+		public float? AvgVerticalOscillation
+		{
+			get
+			{
+				Object val = GetFieldValue(77, 0, Fit.SubfieldIndexMainField);
+				if (val == null)
+				{
+					return null;
+				}
+
+				return (Convert.ToSingle(val));
+
+			}
+			set
+			{
+				SetFieldValue(77, 0, value, Fit.SubfieldIndexMainField);
+			}
+		}
+
+		///<summary>
+		/// Retrieves the AvgStanceTimePercent field
+		/// Units: percent</summary>
+		/// <returns>Returns nullable float representing the AvgStanceTimePercent field</returns>
+		public float? AvgStanceTimePercent
+		{
+			get
+			{
+				Object val = GetFieldValue(78, 0, Fit.SubfieldIndexMainField);
+				if (val == null)
+				{
+					return null;
+				}
+
+				return (Convert.ToSingle(val));
+
+			}
+			set
+			{
+				SetFieldValue(78, 0, value, Fit.SubfieldIndexMainField);
+			}
+		}
+
+		///<summary>
+		/// Retrieves the AvgStanceTime field
+		/// Units: ms</summary>
+		/// <returns>Returns nullable float representing the AvgStanceTime field</returns>
+		public float? AvgStanceTime
+		{
+			get
+			{
+				Object val = GetFieldValue(79, 0, Fit.SubfieldIndexMainField);
+				if (val == null)
+				{
+					return null;
+				}
+
+				return (Convert.ToSingle(val));
+
+			}
+			set
+			{
+				SetFieldValue(79, 0, value, Fit.SubfieldIndexMainField);
+			}
+		}
+
+		///<summary>
+		/// Retrieves the AvgFractionalCadence field
+		/// Units: rpm
+		/// Comment: fractional part of the avg_cadence</summary>
+		/// <returns>Returns nullable float representing the AvgFractionalCadence field</returns>
+		public float? AvgFractionalCadence
+		{
+			get
+			{
+				Object val = GetFieldValue(80, 0, Fit.SubfieldIndexMainField);
+				if (val == null)
+				{
+					return null;
+				}
+
+				return (Convert.ToSingle(val));
+
+			}
+			set
+			{
+				SetFieldValue(80, 0, value, Fit.SubfieldIndexMainField);
+			}
+		}
+
+		///<summary>
+		/// Retrieves the MaxFractionalCadence field
+		/// Units: rpm
+		/// Comment: fractional part of the max_cadence</summary>
+		/// <returns>Returns nullable float representing the MaxFractionalCadence field</returns>
+		public float? MaxFractionalCadence
+		{
+			get
+			{
+				Object val = GetFieldValue(81, 0, Fit.SubfieldIndexMainField);
+				if (val == null)
+				{
+					return null;
+				}
+
+				return (Convert.ToSingle(val));
+
+			}
+			set
+			{
+				SetFieldValue(81, 0, value, Fit.SubfieldIndexMainField);
+			}
+		}
+
+		///<summary>
+		/// Retrieves the TotalFractionalCycles field
+		/// Units: cycles
+		/// Comment: fractional part of the total_cycles</summary>
+		/// <returns>Returns nullable float representing the TotalFractionalCycles field</returns>
+		public float? TotalFractionalCycles
+		{
+			get
+			{
+				Object val = GetFieldValue(82, 0, Fit.SubfieldIndexMainField);
+				if (val == null)
+				{
+					return null;
+				}
+
+				return (Convert.ToSingle(val));
+
+			}
+			set
+			{
+				SetFieldValue(82, 0, value, Fit.SubfieldIndexMainField);
+			}
+		}
+
+		///<summary>
+		/// Retrieves the PlayerScore field</summary>
+		/// <returns>Returns nullable ushort representing the PlayerScore field</returns>
+		public ushort? PlayerScore
+		{
+			get
+			{
+				Object val = GetFieldValue(83, 0, Fit.SubfieldIndexMainField);
+				if (val == null)
+				{
+					return null;
+				}
+
+				return (Convert.ToUInt16(val));
+
+			}
+			set
+			{
+				SetFieldValue(83, 0, value, Fit.SubfieldIndexMainField);
+			}
+		}
+
+
+		/// <summary>
+		///
+		/// </summary>
+		/// <returns>returns number of elements in field AvgTotalHemoglobinConc</returns>
+		public int GetNumAvgTotalHemoglobinConc()
+		{
+			return GetNumFieldValues(84, Fit.SubfieldIndexMainField);
+		}
+
+		///<summary>
+		/// Retrieves the AvgTotalHemoglobinConc field
+		/// Units: g/dL
+		/// Comment: Avg saturated and unsaturated hemoglobin</summary>
+		/// <param name="index">0 based index of AvgTotalHemoglobinConc element to retrieve</param>
+		/// <returns>Returns nullable float representing the AvgTotalHemoglobinConc field</returns>
+		public float? GetAvgTotalHemoglobinConc(int index)
+		{
+			Object val = GetFieldValue(84, index, Fit.SubfieldIndexMainField);
+			if (val == null)
+			{
+				return null;
+			}
+
+			return (Convert.ToSingle(val));
+
+		}
+
+		/// <summary>
+		/// Set AvgTotalHemoglobinConc field
+		/// Units: g/dL
+		/// Comment: Avg saturated and unsaturated hemoglobin</summary>
+		/// <param name="index">0 based index of avg_total_hemoglobin_conc</param>
+		/// <param name="avgTotalHemoglobinConc_">Nullable field value to be set</param>
+		public void SetAvgTotalHemoglobinConc(int index, float? avgTotalHemoglobinConc_)
+		{
+			SetFieldValue(84, index, avgTotalHemoglobinConc_, Fit.SubfieldIndexMainField);
+		}
+
+
+		/// <summary>
+		///
+		/// </summary>
+		/// <returns>returns number of elements in field MinTotalHemoglobinConc</returns>
+		public int GetNumMinTotalHemoglobinConc()
+		{
+			return GetNumFieldValues(85, Fit.SubfieldIndexMainField);
+		}
+
+		///<summary>
+		/// Retrieves the MinTotalHemoglobinConc field
+		/// Units: g/dL
+		/// Comment: Min saturated and unsaturated hemoglobin</summary>
+		/// <param name="index">0 based index of MinTotalHemoglobinConc element to retrieve</param>
+		/// <returns>Returns nullable float representing the MinTotalHemoglobinConc field</returns>
+		public float? GetMinTotalHemoglobinConc(int index)
+		{
+			Object val = GetFieldValue(85, index, Fit.SubfieldIndexMainField);
+			if (val == null)
+			{
+				return null;
+			}
+
+			return (Convert.ToSingle(val));
+
+		}
+
+		/// <summary>
+		/// Set MinTotalHemoglobinConc field
+		/// Units: g/dL
+		/// Comment: Min saturated and unsaturated hemoglobin</summary>
+		/// <param name="index">0 based index of min_total_hemoglobin_conc</param>
+		/// <param name="minTotalHemoglobinConc_">Nullable field value to be set</param>
+		public void SetMinTotalHemoglobinConc(int index, float? minTotalHemoglobinConc_)
+		{
+			SetFieldValue(85, index, minTotalHemoglobinConc_, Fit.SubfieldIndexMainField);
+		}
+
+
+		/// <summary>
+		///
+		/// </summary>
+		/// <returns>returns number of elements in field MaxTotalHemoglobinConc</returns>
+		public int GetNumMaxTotalHemoglobinConc()
+		{
+			return GetNumFieldValues(86, Fit.SubfieldIndexMainField);
+		}
+
+		///<summary>
+		/// Retrieves the MaxTotalHemoglobinConc field
+		/// Units: g/dL
+		/// Comment: Max saturated and unsaturated hemoglobin</summary>
+		/// <param name="index">0 based index of MaxTotalHemoglobinConc element to retrieve</param>
+		/// <returns>Returns nullable float representing the MaxTotalHemoglobinConc field</returns>
+		public float? GetMaxTotalHemoglobinConc(int index)
+		{
+			Object val = GetFieldValue(86, index, Fit.SubfieldIndexMainField);
+			if (val == null)
+			{
+				return null;
+			}
+
+			return (Convert.ToSingle(val));
+
+		}
+
+		/// <summary>
+		/// Set MaxTotalHemoglobinConc field
+		/// Units: g/dL
+		/// Comment: Max saturated and unsaturated hemoglobin</summary>
+		/// <param name="index">0 based index of max_total_hemoglobin_conc</param>
+		/// <param name="maxTotalHemoglobinConc_">Nullable field value to be set</param>
+		public void SetMaxTotalHemoglobinConc(int index, float? maxTotalHemoglobinConc_)
+		{
+			SetFieldValue(86, index, maxTotalHemoglobinConc_, Fit.SubfieldIndexMainField);
+		}
+
+
+		/// <summary>
+		///
+		/// </summary>
+		/// <returns>returns number of elements in field AvgSaturatedHemoglobinPercent</returns>
+		public int GetNumAvgSaturatedHemoglobinPercent()
+		{
+			return GetNumFieldValues(87, Fit.SubfieldIndexMainField);
+		}
+
+		///<summary>
+		/// Retrieves the AvgSaturatedHemoglobinPercent field
+		/// Units: %
+		/// Comment: Avg percentage of hemoglobin saturated with oxygen</summary>
+		/// <param name="index">0 based index of AvgSaturatedHemoglobinPercent element to retrieve</param>
+		/// <returns>Returns nullable float representing the AvgSaturatedHemoglobinPercent field</returns>
+		public float? GetAvgSaturatedHemoglobinPercent(int index)
+		{
+			Object val = GetFieldValue(87, index, Fit.SubfieldIndexMainField);
+			if (val == null)
+			{
+				return null;
+			}
+
+			return (Convert.ToSingle(val));
+
+		}
+
+		/// <summary>
+		/// Set AvgSaturatedHemoglobinPercent field
+		/// Units: %
+		/// Comment: Avg percentage of hemoglobin saturated with oxygen</summary>
+		/// <param name="index">0 based index of avg_saturated_hemoglobin_percent</param>
+		/// <param name="avgSaturatedHemoglobinPercent_">Nullable field value to be set</param>
+		public void SetAvgSaturatedHemoglobinPercent(int index, float? avgSaturatedHemoglobinPercent_)
+		{
+			SetFieldValue(87, index, avgSaturatedHemoglobinPercent_, Fit.SubfieldIndexMainField);
+		}
+
+
+		/// <summary>
+		///
+		/// </summary>
+		/// <returns>returns number of elements in field MinSaturatedHemoglobinPercent</returns>
+		public int GetNumMinSaturatedHemoglobinPercent()
+		{
+			return GetNumFieldValues(88, Fit.SubfieldIndexMainField);
+		}
+
+		///<summary>
+		/// Retrieves the MinSaturatedHemoglobinPercent field
+		/// Units: %
+		/// Comment: Min percentage of hemoglobin saturated with oxygen</summary>
+		/// <param name="index">0 based index of MinSaturatedHemoglobinPercent element to retrieve</param>
+		/// <returns>Returns nullable float representing the MinSaturatedHemoglobinPercent field</returns>
+		public float? GetMinSaturatedHemoglobinPercent(int index)
+		{
+			Object val = GetFieldValue(88, index, Fit.SubfieldIndexMainField);
+			if (val == null)
+			{
+				return null;
+			}
+
+			return (Convert.ToSingle(val));
+
+		}
+
+		/// <summary>
+		/// Set MinSaturatedHemoglobinPercent field
+		/// Units: %
+		/// Comment: Min percentage of hemoglobin saturated with oxygen</summary>
+		/// <param name="index">0 based index of min_saturated_hemoglobin_percent</param>
+		/// <param name="minSaturatedHemoglobinPercent_">Nullable field value to be set</param>
+		public void SetMinSaturatedHemoglobinPercent(int index, float? minSaturatedHemoglobinPercent_)
+		{
+			SetFieldValue(88, index, minSaturatedHemoglobinPercent_, Fit.SubfieldIndexMainField);
+		}
+
+
+		/// <summary>
+		///
+		/// </summary>
+		/// <returns>returns number of elements in field MaxSaturatedHemoglobinPercent</returns>
+		public int GetNumMaxSaturatedHemoglobinPercent()
+		{
+			return GetNumFieldValues(89, Fit.SubfieldIndexMainField);
+		}
+
+		///<summary>
+		/// Retrieves the MaxSaturatedHemoglobinPercent field
+		/// Units: %
+		/// Comment: Max percentage of hemoglobin saturated with oxygen</summary>
+		/// <param name="index">0 based index of MaxSaturatedHemoglobinPercent element to retrieve</param>
+		/// <returns>Returns nullable float representing the MaxSaturatedHemoglobinPercent field</returns>
+		public float? GetMaxSaturatedHemoglobinPercent(int index)
+		{
+			Object val = GetFieldValue(89, index, Fit.SubfieldIndexMainField);
+			if (val == null)
+			{
+				return null;
+			}
+
+			return (Convert.ToSingle(val));
+
+		}
+
+		/// <summary>
+		/// Set MaxSaturatedHemoglobinPercent field
+		/// Units: %
+		/// Comment: Max percentage of hemoglobin saturated with oxygen</summary>
+		/// <param name="index">0 based index of max_saturated_hemoglobin_percent</param>
+		/// <param name="maxSaturatedHemoglobinPercent_">Nullable field value to be set</param>
+		public void SetMaxSaturatedHemoglobinPercent(int index, float? maxSaturatedHemoglobinPercent_)
+		{
+			SetFieldValue(89, index, maxSaturatedHemoglobinPercent_, Fit.SubfieldIndexMainField);
+		}
+
+		///<summary>
+		/// Retrieves the AvgLeftTorqueEffectiveness field
+		/// Units: percent</summary>
+		/// <returns>Returns nullable float representing the AvgLeftTorqueEffectiveness field</returns>
+		public float? AvgLeftTorqueEffectiveness
+		{
+			get
+			{
+				Object val = GetFieldValue(91, 0, Fit.SubfieldIndexMainField);
+				if (val == null)
+				{
+					return null;
+				}
+
+				return (Convert.ToSingle(val));
+
+			}
+			set
+			{
+				SetFieldValue(91, 0, value, Fit.SubfieldIndexMainField);
+			}
+		}
+
+		///<summary>
+		/// Retrieves the AvgRightTorqueEffectiveness field
+		/// Units: percent</summary>
+		/// <returns>Returns nullable float representing the AvgRightTorqueEffectiveness field</returns>
+		public float? AvgRightTorqueEffectiveness
+		{
+			get
+			{
+				Object val = GetFieldValue(92, 0, Fit.SubfieldIndexMainField);
+				if (val == null)
+				{
+					return null;
+				}
+
+				return (Convert.ToSingle(val));
+
+			}
+			set
+			{
+				SetFieldValue(92, 0, value, Fit.SubfieldIndexMainField);
+			}
+		}
+
+		///<summary>
+		/// Retrieves the AvgLeftPedalSmoothness field
+		/// Units: percent</summary>
+		/// <returns>Returns nullable float representing the AvgLeftPedalSmoothness field</returns>
+		public float? AvgLeftPedalSmoothness
+		{
+			get
+			{
+				Object val = GetFieldValue(93, 0, Fit.SubfieldIndexMainField);
+				if (val == null)
+				{
+					return null;
+				}
+
+				return (Convert.ToSingle(val));
+
+			}
+			set
+			{
+				SetFieldValue(93, 0, value, Fit.SubfieldIndexMainField);
+			}
+		}
+
+		///<summary>
+		/// Retrieves the AvgRightPedalSmoothness field
+		/// Units: percent</summary>
+		/// <returns>Returns nullable float representing the AvgRightPedalSmoothness field</returns>
+		public float? AvgRightPedalSmoothness
+		{
+			get
+			{
+				Object val = GetFieldValue(94, 0, Fit.SubfieldIndexMainField);
+				if (val == null)
+				{
+					return null;
+				}
+
+				return (Convert.ToSingle(val));
+
+			}
+			set
+			{
+				SetFieldValue(94, 0, value, Fit.SubfieldIndexMainField);
+			}
+		}
+
+		///<summary>
+		/// Retrieves the AvgCombinedPedalSmoothness field
+		/// Units: percent</summary>
+		/// <returns>Returns nullable float representing the AvgCombinedPedalSmoothness field</returns>
+		public float? AvgCombinedPedalSmoothness
+		{
+			get
+			{
+				Object val = GetFieldValue(95, 0, Fit.SubfieldIndexMainField);
+				if (val == null)
+				{
+					return null;
+				}
+
+				return (Convert.ToSingle(val));
+
+			}
+			set
+			{
+				SetFieldValue(95, 0, value, Fit.SubfieldIndexMainField);
+			}
+		}
+
+		///<summary>
+		/// Retrieves the TimeStanding field
+		/// Units: s
+		/// Comment: Total time spent in the standing position</summary>
+		/// <returns>Returns nullable float representing the TimeStanding field</returns>
+		public float? TimeStanding
+		{
+			get
+			{
+				Object val = GetFieldValue(98, 0, Fit.SubfieldIndexMainField);
+				if (val == null)
+				{
+					return null;
+				}
+
+				return (Convert.ToSingle(val));
+
+			}
+			set
+			{
+				SetFieldValue(98, 0, value, Fit.SubfieldIndexMainField);
+			}
+		}
+
+		///<summary>
+		/// Retrieves the StandCount field
+		/// Comment: Number of transitions to the standing state</summary>
+		/// <returns>Returns nullable ushort representing the StandCount field</returns>
+		public ushort? StandCount
+		{
+			get
+			{
+				Object val = GetFieldValue(99, 0, Fit.SubfieldIndexMainField);
+				if (val == null)
+				{
+					return null;
+				}
+
+				return (Convert.ToUInt16(val));
+
+			}
+			set
+			{
+				SetFieldValue(99, 0, value, Fit.SubfieldIndexMainField);
+			}
+		}
+
+		///<summary>
+		/// Retrieves the AvgLeftPco field
+		/// Units: mm
+		/// Comment: Average left platform center offset</summary>
+		/// <returns>Returns nullable sbyte representing the AvgLeftPco field</returns>
+		public sbyte? AvgLeftPco
+		{
+			get
+			{
+				Object val = GetFieldValue(100, 0, Fit.SubfieldIndexMainField);
+				if (val == null)
+				{
+					return null;
+				}
+
+				return (Convert.ToSByte(val));
+
+			}
+			set
+			{
+				SetFieldValue(100, 0, value, Fit.SubfieldIndexMainField);
+			}
+		}
+
+		///<summary>
+		/// Retrieves the AvgRightPco field
+		/// Units: mm
+		/// Comment: Average right platform center offset</summary>
+		/// <returns>Returns nullable sbyte representing the AvgRightPco field</returns>
+		public sbyte? AvgRightPco
+		{
+			get
+			{
+				Object val = GetFieldValue(101, 0, Fit.SubfieldIndexMainField);
+				if (val == null)
+				{
+					return null;
+				}
+
+				return (Convert.ToSByte(val));
+
+			}
+			set
+			{
+				SetFieldValue(101, 0, value, Fit.SubfieldIndexMainField);
+			}
+		}
+
+
+		/// <summary>
+		///
+		/// </summary>
+		/// <returns>returns number of elements in field AvgLeftPowerPhase</returns>
+		public int GetNumAvgLeftPowerPhase()
+		{
+			return GetNumFieldValues(102, Fit.SubfieldIndexMainField);
+		}
+
+		///<summary>
+		/// Retrieves the AvgLeftPowerPhase field
+		/// Units: degrees
+		/// Comment: Average left power phase angles. Data value indexes defined by power_phase_type.</summary>
+		/// <param name="index">0 based index of AvgLeftPowerPhase element to retrieve</param>
+		/// <returns>Returns nullable float representing the AvgLeftPowerPhase field</returns>
+		public float? GetAvgLeftPowerPhase(int index)
+		{
+			Object val = GetFieldValue(102, index, Fit.SubfieldIndexMainField);
+			if (val == null)
+			{
+				return null;
+			}
+
+			return (Convert.ToSingle(val));
+
+		}
+
+		/// <summary>
+		/// Set AvgLeftPowerPhase field
+		/// Units: degrees
+		/// Comment: Average left power phase angles. Data value indexes defined by power_phase_type.</summary>
+		/// <param name="index">0 based index of avg_left_power_phase</param>
+		/// <param name="avgLeftPowerPhase_">Nullable field value to be set</param>
+		public void SetAvgLeftPowerPhase(int index, float? avgLeftPowerPhase_)
+		{
+			SetFieldValue(102, index, avgLeftPowerPhase_, Fit.SubfieldIndexMainField);
+		}
+
+
+		/// <summary>
+		///
+		/// </summary>
+		/// <returns>returns number of elements in field AvgLeftPowerPhasePeak</returns>
+		public int GetNumAvgLeftPowerPhasePeak()
+		{
+			return GetNumFieldValues(103, Fit.SubfieldIndexMainField);
+		}
+
+		///<summary>
+		/// Retrieves the AvgLeftPowerPhasePeak field
+		/// Units: degrees
+		/// Comment: Average left power phase peak angles. Data value indexes defined by power_phase_type.</summary>
+		/// <param name="index">0 based index of AvgLeftPowerPhasePeak element to retrieve</param>
+		/// <returns>Returns nullable float representing the AvgLeftPowerPhasePeak field</returns>
+		public float? GetAvgLeftPowerPhasePeak(int index)
+		{
+			Object val = GetFieldValue(103, index, Fit.SubfieldIndexMainField);
+			if (val == null)
+			{
+				return null;
+			}
+
+			return (Convert.ToSingle(val));
+
+		}
+
+		/// <summary>
+		/// Set AvgLeftPowerPhasePeak field
+		/// Units: degrees
+		/// Comment: Average left power phase peak angles. Data value indexes defined by power_phase_type.</summary>
+		/// <param name="index">0 based index of avg_left_power_phase_peak</param>
+		/// <param name="avgLeftPowerPhasePeak_">Nullable field value to be set</param>
+		public void SetAvgLeftPowerPhasePeak(int index, float? avgLeftPowerPhasePeak_)
+		{
+			SetFieldValue(103, index, avgLeftPowerPhasePeak_, Fit.SubfieldIndexMainField);
+		}
+
+
+		/// <summary>
+		///
+		/// </summary>
+		/// <returns>returns number of elements in field AvgRightPowerPhase</returns>
+		public int GetNumAvgRightPowerPhase()
+		{
+			return GetNumFieldValues(104, Fit.SubfieldIndexMainField);
+		}
+
+		///<summary>
+		/// Retrieves the AvgRightPowerPhase field
+		/// Units: degrees
+		/// Comment: Average right power phase angles. Data value indexes defined by power_phase_type.</summary>
+		/// <param name="index">0 based index of AvgRightPowerPhase element to retrieve</param>
+		/// <returns>Returns nullable float representing the AvgRightPowerPhase field</returns>
+		public float? GetAvgRightPowerPhase(int index)
+		{
+			Object val = GetFieldValue(104, index, Fit.SubfieldIndexMainField);
+			if (val == null)
+			{
+				return null;
+			}
+
+			return (Convert.ToSingle(val));
+
+		}
+
+		/// <summary>
+		/// Set AvgRightPowerPhase field
+		/// Units: degrees
+		/// Comment: Average right power phase angles. Data value indexes defined by power_phase_type.</summary>
+		/// <param name="index">0 based index of avg_right_power_phase</param>
+		/// <param name="avgRightPowerPhase_">Nullable field value to be set</param>
+		public void SetAvgRightPowerPhase(int index, float? avgRightPowerPhase_)
+		{
+			SetFieldValue(104, index, avgRightPowerPhase_, Fit.SubfieldIndexMainField);
+		}
+
+
+		/// <summary>
+		///
+		/// </summary>
+		/// <returns>returns number of elements in field AvgRightPowerPhasePeak</returns>
+		public int GetNumAvgRightPowerPhasePeak()
+		{
+			return GetNumFieldValues(105, Fit.SubfieldIndexMainField);
+		}
+
+		///<summary>
+		/// Retrieves the AvgRightPowerPhasePeak field
+		/// Units: degrees
+		/// Comment: Average right power phase peak angles. Data value indexes defined by power_phase_type.</summary>
+		/// <param name="index">0 based index of AvgRightPowerPhasePeak element to retrieve</param>
+		/// <returns>Returns nullable float representing the AvgRightPowerPhasePeak field</returns>
+		public float? GetAvgRightPowerPhasePeak(int index)
+		{
+			Object val = GetFieldValue(105, index, Fit.SubfieldIndexMainField);
+			if (val == null)
+			{
+				return null;
+			}
+
+			return (Convert.ToSingle(val));
+
+		}
+
+		/// <summary>
+		/// Set AvgRightPowerPhasePeak field
+		/// Units: degrees
+		/// Comment: Average right power phase peak angles. Data value indexes defined by power_phase_type.</summary>
+		/// <param name="index">0 based index of avg_right_power_phase_peak</param>
+		/// <param name="avgRightPowerPhasePeak_">Nullable field value to be set</param>
+		public void SetAvgRightPowerPhasePeak(int index, float? avgRightPowerPhasePeak_)
+		{
+			SetFieldValue(105, index, avgRightPowerPhasePeak_, Fit.SubfieldIndexMainField);
+		}
+
+
+		/// <summary>
+		///
+		/// </summary>
+		/// <returns>returns number of elements in field AvgPowerPosition</returns>
+		public int GetNumAvgPowerPosition()
+		{
+			return GetNumFieldValues(106, Fit.SubfieldIndexMainField);
+		}
+
+		///<summary>
+		/// Retrieves the AvgPowerPosition field
+		/// Units: watts
+		/// Comment: Average power by position. Data value indexes defined by rider_position_type.</summary>
+		/// <param name="index">0 based index of AvgPowerPosition element to retrieve</param>
+		/// <returns>Returns nullable ushort representing the AvgPowerPosition field</returns>
+		public ushort? GetAvgPowerPosition(int index)
+		{
+			Object val = GetFieldValue(106, index, Fit.SubfieldIndexMainField);
+			if (val == null)
+			{
+				return null;
+			}
+
+			return (Convert.ToUInt16(val));
+
+		}
+
+		/// <summary>
+		/// Set AvgPowerPosition field
+		/// Units: watts
+		/// Comment: Average power by position. Data value indexes defined by rider_position_type.</summary>
+		/// <param name="index">0 based index of avg_power_position</param>
+		/// <param name="avgPowerPosition_">Nullable field value to be set</param>
+		public void SetAvgPowerPosition(int index, ushort? avgPowerPosition_)
+		{
+			SetFieldValue(106, index, avgPowerPosition_, Fit.SubfieldIndexMainField);
+		}
+
+
+		/// <summary>
+		///
+		/// </summary>
+		/// <returns>returns number of elements in field MaxPowerPosition</returns>
+		public int GetNumMaxPowerPosition()
+		{
+			return GetNumFieldValues(107, Fit.SubfieldIndexMainField);
+		}
+
+		///<summary>
+		/// Retrieves the MaxPowerPosition field
+		/// Units: watts
+		/// Comment: Maximum power by position. Data value indexes defined by rider_position_type.</summary>
+		/// <param name="index">0 based index of MaxPowerPosition element to retrieve</param>
+		/// <returns>Returns nullable ushort representing the MaxPowerPosition field</returns>
+		public ushort? GetMaxPowerPosition(int index)
+		{
+			Object val = GetFieldValue(107, index, Fit.SubfieldIndexMainField);
+			if (val == null)
+			{
+				return null;
+			}
+
+			return (Convert.ToUInt16(val));
+
+		}
+
+		/// <summary>
+		/// Set MaxPowerPosition field
+		/// Units: watts
+		/// Comment: Maximum power by position. Data value indexes defined by rider_position_type.</summary>
+		/// <param name="index">0 based index of max_power_position</param>
+		/// <param name="maxPowerPosition_">Nullable field value to be set</param>
+		public void SetMaxPowerPosition(int index, ushort? maxPowerPosition_)
+		{
+			SetFieldValue(107, index, maxPowerPosition_, Fit.SubfieldIndexMainField);
+		}
+
+
+		/// <summary>
+		///
+		/// </summary>
+		/// <returns>returns number of elements in field AvgCadencePosition</returns>
+		public int GetNumAvgCadencePosition()
+		{
+			return GetNumFieldValues(108, Fit.SubfieldIndexMainField);
+		}
+
+		///<summary>
+		/// Retrieves the AvgCadencePosition field
+		/// Units: rpm
+		/// Comment: Average cadence by position. Data value indexes defined by rider_position_type.</summary>
+		/// <param name="index">0 based index of AvgCadencePosition element to retrieve</param>
+		/// <returns>Returns nullable byte representing the AvgCadencePosition field</returns>
+		public byte? GetAvgCadencePosition(int index)
+		{
+			Object val = GetFieldValue(108, index, Fit.SubfieldIndexMainField);
+			if (val == null)
+			{
+				return null;
+			}
+
+			return (Convert.ToByte(val));
+
+		}
+
+		/// <summary>
+		/// Set AvgCadencePosition field
+		/// Units: rpm
+		/// Comment: Average cadence by position. Data value indexes defined by rider_position_type.</summary>
+		/// <param name="index">0 based index of avg_cadence_position</param>
+		/// <param name="avgCadencePosition_">Nullable field value to be set</param>
+		public void SetAvgCadencePosition(int index, byte? avgCadencePosition_)
+		{
+			SetFieldValue(108, index, avgCadencePosition_, Fit.SubfieldIndexMainField);
+		}
+
+
+		/// <summary>
+		///
+		/// </summary>
+		/// <returns>returns number of elements in field MaxCadencePosition</returns>
+		public int GetNumMaxCadencePosition()
+		{
+			return GetNumFieldValues(109, Fit.SubfieldIndexMainField);
+		}
+
+		///<summary>
+		/// Retrieves the MaxCadencePosition field
+		/// Units: rpm
+		/// Comment: Maximum cadence by position. Data value indexes defined by rider_position_type.</summary>
+		/// <param name="index">0 based index of MaxCadencePosition element to retrieve</param>
+		/// <returns>Returns nullable byte representing the MaxCadencePosition field</returns>
+		public byte? GetMaxCadencePosition(int index)
+		{
+			Object val = GetFieldValue(109, index, Fit.SubfieldIndexMainField);
+			if (val == null)
+			{
+				return null;
+			}
+
+			return (Convert.ToByte(val));
+
+		}
+
+		/// <summary>
+		/// Set MaxCadencePosition field
+		/// Units: rpm
+		/// Comment: Maximum cadence by position. Data value indexes defined by rider_position_type.</summary>
+		/// <param name="index">0 based index of max_cadence_position</param>
+		/// <param name="maxCadencePosition_">Nullable field value to be set</param>
+		public void SetMaxCadencePosition(int index, byte? maxCadencePosition_)
+		{
+			SetFieldValue(109, index, maxCadencePosition_, Fit.SubfieldIndexMainField);
+		}
+
+		///<summary>
+		/// Retrieves the EnhancedAvgSpeed field
+		/// Units: m/s</summary>
+		/// <returns>Returns nullable float representing the EnhancedAvgSpeed field</returns>
+		public float? EnhancedAvgSpeed
+		{
+			get
+			{
+				Object val = GetFieldValue(110, 0, Fit.SubfieldIndexMainField);
+				if (val == null)
+				{
+					return null;
+				}
+
+				return (Convert.ToSingle(val));
+
+			}
+			set
+			{
+				SetFieldValue(110, 0, value, Fit.SubfieldIndexMainField);
+			}
+		}
+
+		///<summary>
+		/// Retrieves the EnhancedMaxSpeed field
+		/// Units: m/s</summary>
+		/// <returns>Returns nullable float representing the EnhancedMaxSpeed field</returns>
+		public float? EnhancedMaxSpeed
+		{
+			get
+			{
+				Object val = GetFieldValue(111, 0, Fit.SubfieldIndexMainField);
+				if (val == null)
+				{
+					return null;
+				}
+
+				return (Convert.ToSingle(val));
+
+			}
+			set
+			{
+				SetFieldValue(111, 0, value, Fit.SubfieldIndexMainField);
+			}
+		}
+
+		///<summary>
+		/// Retrieves the EnhancedAvgAltitude field
+		/// Units: m</summary>
+		/// <returns>Returns nullable float representing the EnhancedAvgAltitude field</returns>
+		public float? EnhancedAvgAltitude
+		{
+			get
+			{
+				Object val = GetFieldValue(112, 0, Fit.SubfieldIndexMainField);
+				if (val == null)
+				{
+					return null;
+				}
+
+				return (Convert.ToSingle(val));
+
+			}
+			set
+			{
+				SetFieldValue(112, 0, value, Fit.SubfieldIndexMainField);
+			}
+		}
+
+		///<summary>
+		/// Retrieves the EnhancedMinAltitude field
+		/// Units: m</summary>
+		/// <returns>Returns nullable float representing the EnhancedMinAltitude field</returns>
+		public float? EnhancedMinAltitude
+		{
+			get
+			{
+				Object val = GetFieldValue(113, 0, Fit.SubfieldIndexMainField);
+				if (val == null)
+				{
+					return null;
+				}
+
+				return (Convert.ToSingle(val));
+
+			}
+			set
+			{
+				SetFieldValue(113, 0, value, Fit.SubfieldIndexMainField);
+			}
+		}
+
+		///<summary>
+		/// Retrieves the EnhancedMaxAltitude field
+		/// Units: m</summary>
+		/// <returns>Returns nullable float representing the EnhancedMaxAltitude field</returns>
+		public float? EnhancedMaxAltitude
+		{
+			get
+			{
+				Object val = GetFieldValue(114, 0, Fit.SubfieldIndexMainField);
+				if (val == null)
+				{
+					return null;
+				}
+
+				return (Convert.ToSingle(val));
+
+			}
+			set
+			{
+				SetFieldValue(114, 0, value, Fit.SubfieldIndexMainField);
+			}
+		}
+
+		///<summary>
+		/// Retrieves the AvgLevMotorPower field
+		/// Units: watts
+		/// Comment: lev average motor power during lap</summary>
+		/// <returns>Returns nullable ushort representing the AvgLevMotorPower field</returns>
+		public ushort? AvgLevMotorPower
+		{
+			get
+			{
+				Object val = GetFieldValue(115, 0, Fit.SubfieldIndexMainField);
+				if (val == null)
+				{
+					return null;
+				}
+
+				return (Convert.ToUInt16(val));
+
+			}
+			set
+			{
+				SetFieldValue(115, 0, value, Fit.SubfieldIndexMainField);
+			}
+		}
+
+		///<summary>
+		/// Retrieves the MaxLevMotorPower field
+		/// Units: watts
+		/// Comment: lev maximum motor power during lap</summary>
+		/// <returns>Returns nullable ushort representing the MaxLevMotorPower field</returns>
+		public ushort? MaxLevMotorPower
+		{
+			get
+			{
+				Object val = GetFieldValue(116, 0, Fit.SubfieldIndexMainField);
+				if (val == null)
+				{
+					return null;
+				}
+
+				return (Convert.ToUInt16(val));
+
+			}
+			set
+			{
+				SetFieldValue(116, 0, value, Fit.SubfieldIndexMainField);
+			}
+		}
+
+		///<summary>
+		/// Retrieves the LevBatteryConsumption field
+		/// Units: percent
+		/// Comment: lev battery consumption during lap</summary>
+		/// <returns>Returns nullable float representing the LevBatteryConsumption field</returns>
+		public float? LevBatteryConsumption
+		{
+			get
+			{
+				Object val = GetFieldValue(117, 0, Fit.SubfieldIndexMainField);
+				if (val == null)
+				{
+					return null;
+				}
+
+				return (Convert.ToSingle(val));
+
+			}
+			set
+			{
+				SetFieldValue(117, 0, value, Fit.SubfieldIndexMainField);
+			}
+		}
+
+		///<summary>
+		/// Retrieves the AvgVerticalRatio field
+		/// Units: percent</summary>
+		/// <returns>Returns nullable float representing the AvgVerticalRatio field</returns>
+		public float? AvgVerticalRatio
+		{
+			get
+			{
+				Object val = GetFieldValue(118, 0, Fit.SubfieldIndexMainField);
+				if (val == null)
+				{
+					return null;
+				}
+
+				return (Convert.ToSingle(val));
+
+			}
+			set
+			{
+				SetFieldValue(118, 0, value, Fit.SubfieldIndexMainField);
+			}
+		}
+
+		///<summary>
+		/// Retrieves the AvgStanceTimeBalance field
+		/// Units: percent</summary>
+		/// <returns>Returns nullable float representing the AvgStanceTimeBalance field</returns>
+		public float? AvgStanceTimeBalance
+		{
+			get
+			{
+				Object val = GetFieldValue(119, 0, Fit.SubfieldIndexMainField);
+				if (val == null)
+				{
+					return null;
+				}
+
+				return (Convert.ToSingle(val));
+
+			}
+			set
+			{
+				SetFieldValue(119, 0, value, Fit.SubfieldIndexMainField);
+			}
+		}
+
+		///<summary>
+		/// Retrieves the AvgStepLength field
+		/// Units: mm</summary>
+		/// <returns>Returns nullable float representing the AvgStepLength field</returns>
+		public float? AvgStepLength
+		{
+			get
+			{
+				Object val = GetFieldValue(120, 0, Fit.SubfieldIndexMainField);
+				if (val == null)
+				{
+					return null;
+				}
+
+				return (Convert.ToSingle(val));
+
+			}
+			set
+			{
+				SetFieldValue(120, 0, value, Fit.SubfieldIndexMainField);
+			}
+		}
+
+		///<summary>
+		/// Retrieves the AvgVam field
+		/// Units: m/s</summary>
+		/// <returns>Returns nullable float representing the AvgVam field</returns>
+		public float? AvgVam
+		{
+			get
+			{
+				Object val = GetFieldValue(121, 0, Fit.SubfieldIndexMainField);
+				if (val == null)
+				{
+					return null;
+				}
+
+				return (Convert.ToSingle(val));
+
+			}
+			set
+			{
+				SetFieldValue(121, 0, value, Fit.SubfieldIndexMainField);
+			}
+		}
+
+		///<summary>
+		/// Retrieves the AvgDepth field
+		/// Units: m
+		/// Comment: 0 if above water</summary>
+		/// <returns>Returns nullable float representing the AvgDepth field</returns>
+		public float? AvgDepth
+		{
+			get
+			{
+				Object val = GetFieldValue(122, 0, Fit.SubfieldIndexMainField);
+				if (val == null)
+				{
+					return null;
+				}
+
+				return (Convert.ToSingle(val));
+
+			}
+			set
+			{
+				SetFieldValue(122, 0, value, Fit.SubfieldIndexMainField);
+			}
+		}
+
+		///<summary>
+		/// Retrieves the MaxDepth field
+		/// Units: m
+		/// Comment: 0 if above water</summary>
+		/// <returns>Returns nullable float representing the MaxDepth field</returns>
+		public float? MaxDepth
+		{
+			get
+			{
+				Object val = GetFieldValue(123, 0, Fit.SubfieldIndexMainField);
+				if (val == null)
+				{
+					return null;
+				}
+
+				return (Convert.ToSingle(val));
+
+			}
+			set
+			{
+				SetFieldValue(123, 0, value, Fit.SubfieldIndexMainField);
+			}
+		}
+
+		///<summary>
+		/// Retrieves the MinTemperature field
+		/// Units: C</summary>
+		/// <returns>Returns nullable sbyte representing the MinTemperature field</returns>
+		public sbyte? MinTemperature
+		{
+			get
+			{
+				Object val = GetFieldValue(124, 0, Fit.SubfieldIndexMainField);
+				if (val == null)
+				{
+					return null;
+				}
+
+				return (Convert.ToSByte(val));
+
+			}
+			set
+			{
+				SetFieldValue(124, 0, value, Fit.SubfieldIndexMainField);
+			}
+		}
+
+		///<summary>
+		/// Retrieves the EnhancedAvgRespirationRate field
+		/// Units: Breaths/min</summary>
+		/// <returns>Returns nullable float representing the EnhancedAvgRespirationRate field</returns>
+		public float? EnhancedAvgRespirationRate
+		{
+			get
+			{
+				Object val = GetFieldValue(136, 0, Fit.SubfieldIndexMainField);
+				if (val == null)
+				{
+					return null;
+				}
+
+				return (Convert.ToSingle(val));
+
+			}
+			set
+			{
+				SetFieldValue(136, 0, value, Fit.SubfieldIndexMainField);
+			}
+		}
+
+		///<summary>
+		/// Retrieves the EnhancedMaxRespirationRate field
+		/// Units: Breaths/min</summary>
+		/// <returns>Returns nullable float representing the EnhancedMaxRespirationRate field</returns>
+		public float? EnhancedMaxRespirationRate
+		{
+			get
+			{
+				Object val = GetFieldValue(137, 0, Fit.SubfieldIndexMainField);
+				if (val == null)
+				{
+					return null;
+				}
+
+				return (Convert.ToSingle(val));
+
+			}
+			set
+			{
+				SetFieldValue(137, 0, value, Fit.SubfieldIndexMainField);
+			}
+		}
+
+		///<summary>
+		/// Retrieves the AvgRespirationRate field</summary>
+		/// <returns>Returns nullable byte representing the AvgRespirationRate field</returns>
+		public byte? AvgRespirationRate
+		{
+			get
+			{
+				Object val = GetFieldValue(147, 0, Fit.SubfieldIndexMainField);
+				if (val == null)
+				{
+					return null;
+				}
+
+				return (Convert.ToByte(val));
+
+			}
+			set
+			{
+				SetFieldValue(147, 0, value, Fit.SubfieldIndexMainField);
+			}
+		}
+
+		///<summary>
+		/// Retrieves the MaxRespirationRate field</summary>
+		/// <returns>Returns nullable byte representing the MaxRespirationRate field</returns>
+		public byte? MaxRespirationRate
+		{
+			get
+			{
+				Object val = GetFieldValue(148, 0, Fit.SubfieldIndexMainField);
+				if (val == null)
+				{
+					return null;
+				}
+
+				return (Convert.ToByte(val));
+
+			}
+			set
+			{
+				SetFieldValue(148, 0, value, Fit.SubfieldIndexMainField);
+			}
+		}
+
+		///<summary>
+		/// Retrieves the TotalGrit field
+		/// Units: kGrit
+		/// Comment: The grit score estimates how challenging a route could be for a cyclist in terms of time spent going over sharp turns or large grade slopes.</summary>
+		/// <returns>Returns nullable float representing the TotalGrit field</returns>
+		public float? TotalGrit
+		{
+			get
+			{
+				Object val = GetFieldValue(149, 0, Fit.SubfieldIndexMainField);
+				if (val == null)
+				{
+					return null;
+				}
+
+				return (Convert.ToSingle(val));
+
+			}
+			set
+			{
+				SetFieldValue(149, 0, value, Fit.SubfieldIndexMainField);
+			}
+		}
+
+		///<summary>
+		/// Retrieves the TotalFlow field
+		/// Units: Flow
+		/// Comment: The flow score estimates how long distance wise a cyclist deaccelerates over intervals where deacceleration is unnecessary such as smooth turns or small grade angle intervals.</summary>
+		/// <returns>Returns nullable float representing the TotalFlow field</returns>
+		public float? TotalFlow
+		{
+			get
+			{
+				Object val = GetFieldValue(150, 0, Fit.SubfieldIndexMainField);
+				if (val == null)
+				{
+					return null;
+				}
+
+				return (Convert.ToSingle(val));
+
+			}
+			set
+			{
+				SetFieldValue(150, 0, value, Fit.SubfieldIndexMainField);
+			}
+		}
+
+		///<summary>
+		/// Retrieves the JumpCount field</summary>
+		/// <returns>Returns nullable ushort representing the JumpCount field</returns>
+		public ushort? JumpCount
+		{
+			get
+			{
+				Object val = GetFieldValue(151, 0, Fit.SubfieldIndexMainField);
+				if (val == null)
+				{
+					return null;
+				}
+
+				return (Convert.ToUInt16(val));
+
+			}
+			set
+			{
+				SetFieldValue(151, 0, value, Fit.SubfieldIndexMainField);
+			}
+		}
+
+		///<summary>
+		/// Retrieves the AvgGrit field
+		/// Units: kGrit
+		/// Comment: The grit score estimates how challenging a route could be for a cyclist in terms of time spent going over sharp turns or large grade slopes.</summary>
+		/// <returns>Returns nullable float representing the AvgGrit field</returns>
+		public float? AvgGrit
+		{
+			get
+			{
+				Object val = GetFieldValue(153, 0, Fit.SubfieldIndexMainField);
+				if (val == null)
+				{
+					return null;
+				}
+
+				return (Convert.ToSingle(val));
+
+			}
+			set
+			{
+				SetFieldValue(153, 0, value, Fit.SubfieldIndexMainField);
+			}
+		}
+
+		///<summary>
+		/// Retrieves the AvgFlow field
+		/// Units: Flow
+		/// Comment: The flow score estimates how long distance wise a cyclist deaccelerates over intervals where deacceleration is unnecessary such as smooth turns or small grade angle intervals.</summary>
+		/// <returns>Returns nullable float representing the AvgFlow field</returns>
+		public float? AvgFlow
+		{
+			get
+			{
+				Object val = GetFieldValue(154, 0, Fit.SubfieldIndexMainField);
+				if (val == null)
+				{
+					return null;
+				}
+
+				return (Convert.ToSingle(val));
+
+			}
+			set
+			{
+				SetFieldValue(154, 0, value, Fit.SubfieldIndexMainField);
+			}
+		}
+
+		///<summary>
+		/// Retrieves the TotalFractionalAscent field
+		/// Units: m
+		/// Comment: fractional part of total_ascent</summary>
+		/// <returns>Returns nullable float representing the TotalFractionalAscent field</returns>
+		public float? TotalFractionalAscent
+		{
+			get
+			{
+				Object val = GetFieldValue(156, 0, Fit.SubfieldIndexMainField);
+				if (val == null)
+				{
+					return null;
+				}
+
+				return (Convert.ToSingle(val));
+
+			}
+			set
+			{
+				SetFieldValue(156, 0, value, Fit.SubfieldIndexMainField);
+			}
+		}
+
+		///<summary>
+		/// Retrieves the TotalFractionalDescent field
+		/// Units: m
+		/// Comment: fractional part of total_descent</summary>
+		/// <returns>Returns nullable float representing the TotalFractionalDescent field</returns>
+		public float? TotalFractionalDescent
+		{
+			get
+			{
+				Object val = GetFieldValue(157, 0, Fit.SubfieldIndexMainField);
+				if (val == null)
+				{
+					return null;
+				}
+
+				return (Convert.ToSingle(val));
+
+			}
+			set
+			{
+				SetFieldValue(157, 0, value, Fit.SubfieldIndexMainField);
+			}
+		}
+
+		///<summary>
+		/// Retrieves the AvgCoreTemperature field
+		/// Units: C</summary>
+		/// <returns>Returns nullable float representing the AvgCoreTemperature field</returns>
+		public float? AvgCoreTemperature
+		{
+			get
+			{
+				Object val = GetFieldValue(158, 0, Fit.SubfieldIndexMainField);
+				if (val == null)
+				{
+					return null;
+				}
+
+				return (Convert.ToSingle(val));
+
+			}
+			set
+			{
+				SetFieldValue(158, 0, value, Fit.SubfieldIndexMainField);
+			}
+		}
+
+		///<summary>
+		/// Retrieves the MinCoreTemperature field
+		/// Units: C</summary>
+		/// <returns>Returns nullable float representing the MinCoreTemperature field</returns>
+		public float? MinCoreTemperature
+		{
+			get
+			{
+				Object val = GetFieldValue(159, 0, Fit.SubfieldIndexMainField);
+				if (val == null)
+				{
+					return null;
+				}
+
+				return (Convert.ToSingle(val));
+
+			}
+			set
+			{
+				SetFieldValue(159, 0, value, Fit.SubfieldIndexMainField);
+			}
+		}
+
+		///<summary>
+		/// Retrieves the MaxCoreTemperature field
+		/// Units: C</summary>
+		/// <returns>Returns nullable float representing the MaxCoreTemperature field</returns>
+		public float? MaxCoreTemperature
+		{
+			get
+			{
+				Object val = GetFieldValue(160, 0, Fit.SubfieldIndexMainField);
+				if (val == null)
+				{
+					return null;
+				}
+
+				return (Convert.ToSingle(val));
+
+			}
+			set
+			{
+				SetFieldValue(160, 0, value, Fit.SubfieldIndexMainField);
+			}
+		}
+
+		#endregion // Methods
+	} // Class
 } // namespace

--- a/Dynastream/Fit/Profile/Mesgs/LengthMesg.cs
+++ b/Dynastream/Fit/Profile/Mesgs/LengthMesg.cs
@@ -21,591 +21,562 @@ using System.Linq;
 
 namespace Dynastream.Fit
 {
-    /// <summary>
-    /// Implements the Length profile message.
-    /// </summary>
-    public class LengthMesg : Mesg
-    {
-        #region Fields
-        #endregion
+	/// <summary>
+	/// Implements the Length profile message.
+	/// </summary>
+	public class LengthMesg : Mesg
+	{
+		#region Fields
+		#endregion
 
-        /// <summary>
-        /// Field Numbers for <see cref="LengthMesg"/>
-        /// </summary>
-        public sealed class FieldDefNum
-        {
-            public const byte MessageIndex = 254;
-            public const byte Timestamp = 253;
-            public const byte Event = 0;
-            public const byte EventType = 1;
-            public const byte StartTime = 2;
-            public const byte TotalElapsedTime = 3;
-            public const byte TotalTimerTime = 4;
-            public const byte TotalStrokes = 5;
-            public const byte AvgSpeed = 6;
-            public const byte SwimStroke = 7;
-            public const byte AvgSwimmingCadence = 9;
-            public const byte EventGroup = 10;
-            public const byte TotalCalories = 11;
-            public const byte LengthType = 12;
-            public const byte PlayerScore = 18;
-            public const byte OpponentScore = 19;
-            public const byte StrokeCount = 20;
-            public const byte ZoneCount = 21;
-            public const byte EnhancedAvgRespirationRate = 22;
-            public const byte EnhancedMaxRespirationRate = 23;
-            public const byte AvgRespirationRate = 24;
-            public const byte MaxRespirationRate = 25;
-            public const byte Invalid = Fit.FieldNumInvalid;
-        }
+		/// <summary>
+		/// Field Numbers for <see cref="LengthMesg"/>
+		/// </summary>
+		public sealed class FieldDefNum
+		{
+			public const byte MessageIndex = 254;
+			public const byte Timestamp = 253;
+			public const byte Event = 0;
+			public const byte EventType = 1;
+			public const byte StartTime = 2;
+			public const byte TotalElapsedTime = 3;
+			public const byte TotalTimerTime = 4;
+			public const byte TotalStrokes = 5;
+			public const byte AvgSpeed = 6;
+			public const byte SwimStroke = 7;
+			public const byte AvgSwimmingCadence = 9;
+			public const byte EventGroup = 10;
+			public const byte TotalCalories = 11;
+			public const byte LengthType = 12;
+			public const byte PlayerScore = 18;
+			public const byte OpponentScore = 19;
+			public const byte StrokeCount = 20;
+			public const byte ZoneCount = 21;
+			public const byte EnhancedAvgRespirationRate = 22;
+			public const byte EnhancedMaxRespirationRate = 23;
+			public const byte AvgRespirationRate = 24;
+			public const byte MaxRespirationRate = 25;
+			public const byte Invalid = Fit.FieldNumInvalid;
+		}
 
-        #region Constructors
-        public LengthMesg() : base(Profile.GetMesg(MesgNum.Length))
-        {
-        }
+		#region Constructors
+		public LengthMesg() : base(Profile.GetMesg(MesgNum.Length))
+		{
+		}
 
-        public LengthMesg(Mesg mesg) : base(mesg)
-        {
-        }
-        #endregion // Constructors
+		public LengthMesg(Mesg mesg) : base(mesg)
+		{
+		}
+		#endregion // Constructors
 
-        #region Methods
-        ///<summary>
-        /// Retrieves the MessageIndex field</summary>
-        /// <returns>Returns nullable ushort representing the MessageIndex field</returns>
-        public ushort? GetMessageIndex()
-        {
-            Object val = GetFieldValue(254, 0, Fit.SubfieldIndexMainField);
-            if(val == null)
-            {
-                return null;
-            }
+		#region Methods
+		///<summary>
+		/// Retrieves the MessageIndex field</summary>
+		/// <returns>Returns nullable ushort representing the MessageIndex field</returns>
+		public ushort? MessageIndex
+		{
+			get
+			{
+				Object val = GetFieldValue(254, 0, Fit.SubfieldIndexMainField);
+				if (val == null)
+				{
+					return null;
+				}
 
-            return (Convert.ToUInt16(val));
-            
-        }
+				return (Convert.ToUInt16(val));
 
-        /// <summary>
-        /// Set MessageIndex field</summary>
-        /// <param name="messageIndex_">Nullable field value to be set</param>
-        public void SetMessageIndex(ushort? messageIndex_)
-        {
-            SetFieldValue(254, 0, messageIndex_, Fit.SubfieldIndexMainField);
-        }
-        
-        ///<summary>
-        /// Retrieves the Timestamp field</summary>
-        /// <returns>Returns DateTime representing the Timestamp field</returns>
-        public DateTime GetTimestamp()
-        {
-            Object val = GetFieldValue(253, 0, Fit.SubfieldIndexMainField);
-            if(val == null)
-            {
-                return null;
-            }
+			}
+			set
+			{
+				SetFieldValue(254, 0, value, Fit.SubfieldIndexMainField);
+			}
+		}
 
-            return TimestampToDateTime(Convert.ToUInt32(val));
-            
-        }
+		///<summary>
+		/// Retrieves the Timestamp field</summary>
+		/// <returns>Returns DateTime representing the Timestamp field</returns>
+		public DateTime Timestamp
+		{
+			get
+			{
+				Object val = GetFieldValue(253, 0, Fit.SubfieldIndexMainField);
+				if (val == null)
+				{
+					return null;
+				}
 
-        /// <summary>
-        /// Set Timestamp field</summary>
-        /// <param name="timestamp_">Nullable field value to be set</param>
-        public void SetTimestamp(DateTime timestamp_)
-        {
-            SetFieldValue(253, 0, timestamp_.GetTimeStamp(), Fit.SubfieldIndexMainField);
-        }
-        
-        ///<summary>
-        /// Retrieves the Event field</summary>
-        /// <returns>Returns nullable Event enum representing the Event field</returns>
-        public Event? GetEvent()
-        {
-            object obj = GetFieldValue(0, 0, Fit.SubfieldIndexMainField);
-            Event? value = obj == null ? (Event?)null : (Event)obj;
-            return value;
-        }
+				return TimestampToDateTime(Convert.ToUInt32(val));
 
-        /// <summary>
-        /// Set Event field</summary>
-        /// <param name="event_">Nullable field value to be set</param>
-        public void SetEvent(Event? event_)
-        {
-            SetFieldValue(0, 0, event_, Fit.SubfieldIndexMainField);
-        }
-        
-        ///<summary>
-        /// Retrieves the EventType field</summary>
-        /// <returns>Returns nullable EventType enum representing the EventType field</returns>
-        public EventType? GetEventType()
-        {
-            object obj = GetFieldValue(1, 0, Fit.SubfieldIndexMainField);
-            EventType? value = obj == null ? (EventType?)null : (EventType)obj;
-            return value;
-        }
+			}
+			set
+			{
+				SetFieldValue(253, 0, value.GetTimeStamp(), Fit.SubfieldIndexMainField);
+			}
+		}
 
-        /// <summary>
-        /// Set EventType field</summary>
-        /// <param name="eventType_">Nullable field value to be set</param>
-        public void SetEventType(EventType? eventType_)
-        {
-            SetFieldValue(1, 0, eventType_, Fit.SubfieldIndexMainField);
-        }
-        
-        ///<summary>
-        /// Retrieves the StartTime field</summary>
-        /// <returns>Returns DateTime representing the StartTime field</returns>
-        public DateTime GetStartTime()
-        {
-            Object val = GetFieldValue(2, 0, Fit.SubfieldIndexMainField);
-            if(val == null)
-            {
-                return null;
-            }
+		///<summary>
+		/// Retrieves the Event field</summary>
+		/// <returns>Returns nullable Event enum representing the Event field</returns>
+		public Event? Event
+		{
+			get
+			{
+				object obj = GetFieldValue(0, 0, Fit.SubfieldIndexMainField);
+				Event? value = obj == null ? (Event?)null : (Event)obj;
+				return value;
+			}
+			set
+			{
+				SetFieldValue(0, 0, value, Fit.SubfieldIndexMainField);
+			}
+		}
 
-            return TimestampToDateTime(Convert.ToUInt32(val));
-            
-        }
+		///<summary>
+		/// Retrieves the EventType field</summary>
+		/// <returns>Returns nullable EventType enum representing the EventType field</returns>
+		public EventType? EventType
+		{
+			get
+			{
+				object obj = GetFieldValue(1, 0, Fit.SubfieldIndexMainField);
+				EventType? value = obj == null ? (EventType?)null : (EventType)obj;
+				return value;
+			}
+			set
+			{
+				SetFieldValue(1, 0, value, Fit.SubfieldIndexMainField);
+			}
+		}
 
-        /// <summary>
-        /// Set StartTime field</summary>
-        /// <param name="startTime_">Nullable field value to be set</param>
-        public void SetStartTime(DateTime startTime_)
-        {
-            SetFieldValue(2, 0, startTime_.GetTimeStamp(), Fit.SubfieldIndexMainField);
-        }
-        
-        ///<summary>
-        /// Retrieves the TotalElapsedTime field
-        /// Units: s</summary>
-        /// <returns>Returns nullable float representing the TotalElapsedTime field</returns>
-        public float? GetTotalElapsedTime()
-        {
-            Object val = GetFieldValue(3, 0, Fit.SubfieldIndexMainField);
-            if(val == null)
-            {
-                return null;
-            }
+		///<summary>
+		/// Retrieves the StartTime field</summary>
+		/// <returns>Returns DateTime representing the StartTime field</returns>
+		public DateTime StartTime
+		{
+			get
+			{
+				Object val = GetFieldValue(2, 0, Fit.SubfieldIndexMainField);
+				if (val == null)
+				{
+					return null;
+				}
 
-            return (Convert.ToSingle(val));
-            
-        }
+				return TimestampToDateTime(Convert.ToUInt32(val));
 
-        /// <summary>
-        /// Set TotalElapsedTime field
-        /// Units: s</summary>
-        /// <param name="totalElapsedTime_">Nullable field value to be set</param>
-        public void SetTotalElapsedTime(float? totalElapsedTime_)
-        {
-            SetFieldValue(3, 0, totalElapsedTime_, Fit.SubfieldIndexMainField);
-        }
-        
-        ///<summary>
-        /// Retrieves the TotalTimerTime field
-        /// Units: s</summary>
-        /// <returns>Returns nullable float representing the TotalTimerTime field</returns>
-        public float? GetTotalTimerTime()
-        {
-            Object val = GetFieldValue(4, 0, Fit.SubfieldIndexMainField);
-            if(val == null)
-            {
-                return null;
-            }
+			}
+			set
+			{
+				SetFieldValue(2, 0, value.GetTimeStamp(), Fit.SubfieldIndexMainField);
+			}
+		}
 
-            return (Convert.ToSingle(val));
-            
-        }
+		///<summary>
+		/// Retrieves the TotalElapsedTime field
+		/// Units: s</summary>
+		/// <returns>Returns nullable float representing the TotalElapsedTime field</returns>
+		public float? TotalElapsedTime
+		{
+			get
+			{
+				Object val = GetFieldValue(3, 0, Fit.SubfieldIndexMainField);
+				if (val == null)
+				{
+					return null;
+				}
 
-        /// <summary>
-        /// Set TotalTimerTime field
-        /// Units: s</summary>
-        /// <param name="totalTimerTime_">Nullable field value to be set</param>
-        public void SetTotalTimerTime(float? totalTimerTime_)
-        {
-            SetFieldValue(4, 0, totalTimerTime_, Fit.SubfieldIndexMainField);
-        }
-        
-        ///<summary>
-        /// Retrieves the TotalStrokes field
-        /// Units: strokes</summary>
-        /// <returns>Returns nullable ushort representing the TotalStrokes field</returns>
-        public ushort? GetTotalStrokes()
-        {
-            Object val = GetFieldValue(5, 0, Fit.SubfieldIndexMainField);
-            if(val == null)
-            {
-                return null;
-            }
+				return (Convert.ToSingle(val));
 
-            return (Convert.ToUInt16(val));
-            
-        }
+			}
+			set
+			{
+				SetFieldValue(3, 0, value, Fit.SubfieldIndexMainField);
+			}
+		}
 
-        /// <summary>
-        /// Set TotalStrokes field
-        /// Units: strokes</summary>
-        /// <param name="totalStrokes_">Nullable field value to be set</param>
-        public void SetTotalStrokes(ushort? totalStrokes_)
-        {
-            SetFieldValue(5, 0, totalStrokes_, Fit.SubfieldIndexMainField);
-        }
-        
-        ///<summary>
-        /// Retrieves the AvgSpeed field
-        /// Units: m/s</summary>
-        /// <returns>Returns nullable float representing the AvgSpeed field</returns>
-        public float? GetAvgSpeed()
-        {
-            Object val = GetFieldValue(6, 0, Fit.SubfieldIndexMainField);
-            if(val == null)
-            {
-                return null;
-            }
+		///<summary>
+		/// Retrieves the TotalTimerTime field
+		/// Units: s</summary>
+		/// <returns>Returns nullable float representing the TotalTimerTime field</returns>
+		public float? TotalTimerTime
+		{
+			get
+			{
+				Object val = GetFieldValue(4, 0, Fit.SubfieldIndexMainField);
+				if (val == null)
+				{
+					return null;
+				}
 
-            return (Convert.ToSingle(val));
-            
-        }
+				return (Convert.ToSingle(val));
 
-        /// <summary>
-        /// Set AvgSpeed field
-        /// Units: m/s</summary>
-        /// <param name="avgSpeed_">Nullable field value to be set</param>
-        public void SetAvgSpeed(float? avgSpeed_)
-        {
-            SetFieldValue(6, 0, avgSpeed_, Fit.SubfieldIndexMainField);
-        }
-        
-        ///<summary>
-        /// Retrieves the SwimStroke field
-        /// Units: swim_stroke</summary>
-        /// <returns>Returns nullable SwimStroke enum representing the SwimStroke field</returns>
-        public SwimStroke? GetSwimStroke()
-        {
-            object obj = GetFieldValue(7, 0, Fit.SubfieldIndexMainField);
-            SwimStroke? value = obj == null ? (SwimStroke?)null : (SwimStroke)obj;
-            return value;
-        }
+			}
+			set
+			{
+				SetFieldValue(4, 0, value, Fit.SubfieldIndexMainField);
+			}
+		}
 
-        /// <summary>
-        /// Set SwimStroke field
-        /// Units: swim_stroke</summary>
-        /// <param name="swimStroke_">Nullable field value to be set</param>
-        public void SetSwimStroke(SwimStroke? swimStroke_)
-        {
-            SetFieldValue(7, 0, swimStroke_, Fit.SubfieldIndexMainField);
-        }
-        
-        ///<summary>
-        /// Retrieves the AvgSwimmingCadence field
-        /// Units: strokes/min</summary>
-        /// <returns>Returns nullable byte representing the AvgSwimmingCadence field</returns>
-        public byte? GetAvgSwimmingCadence()
-        {
-            Object val = GetFieldValue(9, 0, Fit.SubfieldIndexMainField);
-            if(val == null)
-            {
-                return null;
-            }
+		///<summary>
+		/// Retrieves the TotalStrokes field
+		/// Units: strokes</summary>
+		/// <returns>Returns nullable ushort representing the TotalStrokes field</returns>
+		public ushort? TotalStrokes
+		{
+			get
+			{
+				Object val = GetFieldValue(5, 0, Fit.SubfieldIndexMainField);
+				if (val == null)
+				{
+					return null;
+				}
 
-            return (Convert.ToByte(val));
-            
-        }
+				return (Convert.ToUInt16(val));
 
-        /// <summary>
-        /// Set AvgSwimmingCadence field
-        /// Units: strokes/min</summary>
-        /// <param name="avgSwimmingCadence_">Nullable field value to be set</param>
-        public void SetAvgSwimmingCadence(byte? avgSwimmingCadence_)
-        {
-            SetFieldValue(9, 0, avgSwimmingCadence_, Fit.SubfieldIndexMainField);
-        }
-        
-        ///<summary>
-        /// Retrieves the EventGroup field</summary>
-        /// <returns>Returns nullable byte representing the EventGroup field</returns>
-        public byte? GetEventGroup()
-        {
-            Object val = GetFieldValue(10, 0, Fit.SubfieldIndexMainField);
-            if(val == null)
-            {
-                return null;
-            }
+			}
+			set
+			{
+				SetFieldValue(5, 0, value, Fit.SubfieldIndexMainField);
+			}
+		}
 
-            return (Convert.ToByte(val));
-            
-        }
+		///<summary>
+		/// Retrieves the AvgSpeed field
+		/// Units: m/s</summary>
+		/// <returns>Returns nullable float representing the AvgSpeed field</returns>
+		public float? AvgSpeed
+		{
+			get
+			{
+				Object val = GetFieldValue(6, 0, Fit.SubfieldIndexMainField);
+				if (val == null)
+				{
+					return null;
+				}
 
-        /// <summary>
-        /// Set EventGroup field</summary>
-        /// <param name="eventGroup_">Nullable field value to be set</param>
-        public void SetEventGroup(byte? eventGroup_)
-        {
-            SetFieldValue(10, 0, eventGroup_, Fit.SubfieldIndexMainField);
-        }
-        
-        ///<summary>
-        /// Retrieves the TotalCalories field
-        /// Units: kcal</summary>
-        /// <returns>Returns nullable ushort representing the TotalCalories field</returns>
-        public ushort? GetTotalCalories()
-        {
-            Object val = GetFieldValue(11, 0, Fit.SubfieldIndexMainField);
-            if(val == null)
-            {
-                return null;
-            }
+				return (Convert.ToSingle(val));
 
-            return (Convert.ToUInt16(val));
-            
-        }
+			}
+			set
+			{
+				SetFieldValue(6, 0, value, Fit.SubfieldIndexMainField);
+			}
+		}
 
-        /// <summary>
-        /// Set TotalCalories field
-        /// Units: kcal</summary>
-        /// <param name="totalCalories_">Nullable field value to be set</param>
-        public void SetTotalCalories(ushort? totalCalories_)
-        {
-            SetFieldValue(11, 0, totalCalories_, Fit.SubfieldIndexMainField);
-        }
-        
-        ///<summary>
-        /// Retrieves the LengthType field</summary>
-        /// <returns>Returns nullable LengthType enum representing the LengthType field</returns>
-        public LengthType? GetLengthType()
-        {
-            object obj = GetFieldValue(12, 0, Fit.SubfieldIndexMainField);
-            LengthType? value = obj == null ? (LengthType?)null : (LengthType)obj;
-            return value;
-        }
+		///<summary>
+		/// Retrieves the SwimStroke field
+		/// Units: swim_stroke</summary>
+		/// <returns>Returns nullable SwimStroke enum representing the SwimStroke field</returns>
+		public SwimStroke? SwimStroke
+		{
+			get
+			{
+				object obj = GetFieldValue(7, 0, Fit.SubfieldIndexMainField);
+				SwimStroke? value = obj == null ? (SwimStroke?)null : (SwimStroke)obj;
+				return value;
+			}
+			set
+			{
+				SetFieldValue(7, 0, value, Fit.SubfieldIndexMainField);
+			}
+		}
 
-        /// <summary>
-        /// Set LengthType field</summary>
-        /// <param name="lengthType_">Nullable field value to be set</param>
-        public void SetLengthType(LengthType? lengthType_)
-        {
-            SetFieldValue(12, 0, lengthType_, Fit.SubfieldIndexMainField);
-        }
-        
-        ///<summary>
-        /// Retrieves the PlayerScore field</summary>
-        /// <returns>Returns nullable ushort representing the PlayerScore field</returns>
-        public ushort? GetPlayerScore()
-        {
-            Object val = GetFieldValue(18, 0, Fit.SubfieldIndexMainField);
-            if(val == null)
-            {
-                return null;
-            }
+		///<summary>
+		/// Retrieves the AvgSwimmingCadence field
+		/// Units: strokes/min</summary>
+		/// <returns>Returns nullable byte representing the AvgSwimmingCadence field</returns>
+		public byte? AvgSwimmingCadence
+		{
+			get
+			{
+				Object val = GetFieldValue(9, 0, Fit.SubfieldIndexMainField);
+				if (val == null)
+				{
+					return null;
+				}
 
-            return (Convert.ToUInt16(val));
-            
-        }
+				return (Convert.ToByte(val));
 
-        /// <summary>
-        /// Set PlayerScore field</summary>
-        /// <param name="playerScore_">Nullable field value to be set</param>
-        public void SetPlayerScore(ushort? playerScore_)
-        {
-            SetFieldValue(18, 0, playerScore_, Fit.SubfieldIndexMainField);
-        }
-        
-        ///<summary>
-        /// Retrieves the OpponentScore field</summary>
-        /// <returns>Returns nullable ushort representing the OpponentScore field</returns>
-        public ushort? GetOpponentScore()
-        {
-            Object val = GetFieldValue(19, 0, Fit.SubfieldIndexMainField);
-            if(val == null)
-            {
-                return null;
-            }
+			}
+			set
+			{
+				SetFieldValue(9, 0, value, Fit.SubfieldIndexMainField);
+			}
+		}
 
-            return (Convert.ToUInt16(val));
-            
-        }
+		///<summary>
+		/// Retrieves the EventGroup field</summary>
+		/// <returns>Returns nullable byte representing the EventGroup field</returns>
+		public byte? EventGroup
+		{
+			get
+			{
+				Object val = GetFieldValue(10, 0, Fit.SubfieldIndexMainField);
+				if (val == null)
+				{
+					return null;
+				}
 
-        /// <summary>
-        /// Set OpponentScore field</summary>
-        /// <param name="opponentScore_">Nullable field value to be set</param>
-        public void SetOpponentScore(ushort? opponentScore_)
-        {
-            SetFieldValue(19, 0, opponentScore_, Fit.SubfieldIndexMainField);
-        }
-        
-        
-        /// <summary>
-        ///
-        /// </summary>
-        /// <returns>returns number of elements in field StrokeCount</returns>
-        public int GetNumStrokeCount()
-        {
-            return GetNumFieldValues(20, Fit.SubfieldIndexMainField);
-        }
+				return (Convert.ToByte(val));
 
-        ///<summary>
-        /// Retrieves the StrokeCount field
-        /// Units: counts
-        /// Comment: stroke_type enum used as the index</summary>
-        /// <param name="index">0 based index of StrokeCount element to retrieve</param>
-        /// <returns>Returns nullable ushort representing the StrokeCount field</returns>
-        public ushort? GetStrokeCount(int index)
-        {
-            Object val = GetFieldValue(20, index, Fit.SubfieldIndexMainField);
-            if(val == null)
-            {
-                return null;
-            }
+			}
+			set
+			{
+				SetFieldValue(10, 0, value, Fit.SubfieldIndexMainField);
+			}
+		}
 
-            return (Convert.ToUInt16(val));
-            
-        }
+		///<summary>
+		/// Retrieves the TotalCalories field
+		/// Units: kcal</summary>
+		/// <returns>Returns nullable ushort representing the TotalCalories field</returns>
+		public ushort? TotalCalories
+		{
+			get
+			{
+				Object val = GetFieldValue(11, 0, Fit.SubfieldIndexMainField);
+				if (val == null)
+				{
+					return null;
+				}
 
-        /// <summary>
-        /// Set StrokeCount field
-        /// Units: counts
-        /// Comment: stroke_type enum used as the index</summary>
-        /// <param name="index">0 based index of stroke_count</param>
-        /// <param name="strokeCount_">Nullable field value to be set</param>
-        public void SetStrokeCount(int index, ushort? strokeCount_)
-        {
-            SetFieldValue(20, index, strokeCount_, Fit.SubfieldIndexMainField);
-        }
-        
-        
-        /// <summary>
-        ///
-        /// </summary>
-        /// <returns>returns number of elements in field ZoneCount</returns>
-        public int GetNumZoneCount()
-        {
-            return GetNumFieldValues(21, Fit.SubfieldIndexMainField);
-        }
+				return (Convert.ToUInt16(val));
 
-        ///<summary>
-        /// Retrieves the ZoneCount field
-        /// Units: counts
-        /// Comment: zone number used as the index</summary>
-        /// <param name="index">0 based index of ZoneCount element to retrieve</param>
-        /// <returns>Returns nullable ushort representing the ZoneCount field</returns>
-        public ushort? GetZoneCount(int index)
-        {
-            Object val = GetFieldValue(21, index, Fit.SubfieldIndexMainField);
-            if(val == null)
-            {
-                return null;
-            }
+			}
+			set
+			{
+				SetFieldValue(11, 0, value, Fit.SubfieldIndexMainField);
+			}
+		}
 
-            return (Convert.ToUInt16(val));
-            
-        }
+		///<summary>
+		/// Retrieves the LengthType field</summary>
+		/// <returns>Returns nullable LengthType enum representing the LengthType field</returns>
+		public LengthType? LengthType
+		{
+			get
+			{
+				object obj = GetFieldValue(12, 0, Fit.SubfieldIndexMainField);
+				LengthType? value = obj == null ? (LengthType?)null : (LengthType)obj;
+				return value;
+			}
+			set
+			{
+				SetFieldValue(12, 0, value, Fit.SubfieldIndexMainField);
+			}
+		}
 
-        /// <summary>
-        /// Set ZoneCount field
-        /// Units: counts
-        /// Comment: zone number used as the index</summary>
-        /// <param name="index">0 based index of zone_count</param>
-        /// <param name="zoneCount_">Nullable field value to be set</param>
-        public void SetZoneCount(int index, ushort? zoneCount_)
-        {
-            SetFieldValue(21, index, zoneCount_, Fit.SubfieldIndexMainField);
-        }
-        
-        ///<summary>
-        /// Retrieves the EnhancedAvgRespirationRate field
-        /// Units: Breaths/min</summary>
-        /// <returns>Returns nullable float representing the EnhancedAvgRespirationRate field</returns>
-        public float? GetEnhancedAvgRespirationRate()
-        {
-            Object val = GetFieldValue(22, 0, Fit.SubfieldIndexMainField);
-            if(val == null)
-            {
-                return null;
-            }
+		///<summary>
+		/// Retrieves the PlayerScore field</summary>
+		/// <returns>Returns nullable ushort representing the PlayerScore field</returns>
+		public ushort? PlayerScore
+		{
+			get
+			{
+				Object val = GetFieldValue(18, 0, Fit.SubfieldIndexMainField);
+				if (val == null)
+				{
+					return null;
+				}
 
-            return (Convert.ToSingle(val));
-            
-        }
+				return (Convert.ToUInt16(val));
 
-        /// <summary>
-        /// Set EnhancedAvgRespirationRate field
-        /// Units: Breaths/min</summary>
-        /// <param name="enhancedAvgRespirationRate_">Nullable field value to be set</param>
-        public void SetEnhancedAvgRespirationRate(float? enhancedAvgRespirationRate_)
-        {
-            SetFieldValue(22, 0, enhancedAvgRespirationRate_, Fit.SubfieldIndexMainField);
-        }
-        
-        ///<summary>
-        /// Retrieves the EnhancedMaxRespirationRate field
-        /// Units: Breaths/min</summary>
-        /// <returns>Returns nullable float representing the EnhancedMaxRespirationRate field</returns>
-        public float? GetEnhancedMaxRespirationRate()
-        {
-            Object val = GetFieldValue(23, 0, Fit.SubfieldIndexMainField);
-            if(val == null)
-            {
-                return null;
-            }
+			}
+			set
+			{
+				SetFieldValue(18, 0, value, Fit.SubfieldIndexMainField);
+			}
+		}
 
-            return (Convert.ToSingle(val));
-            
-        }
+		///<summary>
+		/// Retrieves the OpponentScore field</summary>
+		/// <returns>Returns nullable ushort representing the OpponentScore field</returns>
+		public ushort? OpponentScore
+		{
+			get
+			{
+				Object val = GetFieldValue(19, 0, Fit.SubfieldIndexMainField);
+				if (val == null)
+				{
+					return null;
+				}
 
-        /// <summary>
-        /// Set EnhancedMaxRespirationRate field
-        /// Units: Breaths/min</summary>
-        /// <param name="enhancedMaxRespirationRate_">Nullable field value to be set</param>
-        public void SetEnhancedMaxRespirationRate(float? enhancedMaxRespirationRate_)
-        {
-            SetFieldValue(23, 0, enhancedMaxRespirationRate_, Fit.SubfieldIndexMainField);
-        }
-        
-        ///<summary>
-        /// Retrieves the AvgRespirationRate field</summary>
-        /// <returns>Returns nullable byte representing the AvgRespirationRate field</returns>
-        public byte? GetAvgRespirationRate()
-        {
-            Object val = GetFieldValue(24, 0, Fit.SubfieldIndexMainField);
-            if(val == null)
-            {
-                return null;
-            }
+				return (Convert.ToUInt16(val));
 
-            return (Convert.ToByte(val));
-            
-        }
+			}
+			set
+			{
+				SetFieldValue(19, 0, value, Fit.SubfieldIndexMainField);
+			}
+		}
 
-        /// <summary>
-        /// Set AvgRespirationRate field</summary>
-        /// <param name="avgRespirationRate_">Nullable field value to be set</param>
-        public void SetAvgRespirationRate(byte? avgRespirationRate_)
-        {
-            SetFieldValue(24, 0, avgRespirationRate_, Fit.SubfieldIndexMainField);
-        }
-        
-        ///<summary>
-        /// Retrieves the MaxRespirationRate field</summary>
-        /// <returns>Returns nullable byte representing the MaxRespirationRate field</returns>
-        public byte? GetMaxRespirationRate()
-        {
-            Object val = GetFieldValue(25, 0, Fit.SubfieldIndexMainField);
-            if(val == null)
-            {
-                return null;
-            }
 
-            return (Convert.ToByte(val));
-            
-        }
+		/// <summary>
+		///
+		/// </summary>
+		/// <returns>returns number of elements in field StrokeCount</returns>
+		public int GetNumStrokeCount()
+		{
+			return GetNumFieldValues(20, Fit.SubfieldIndexMainField);
+		}
 
-        /// <summary>
-        /// Set MaxRespirationRate field</summary>
-        /// <param name="maxRespirationRate_">Nullable field value to be set</param>
-        public void SetMaxRespirationRate(byte? maxRespirationRate_)
-        {
-            SetFieldValue(25, 0, maxRespirationRate_, Fit.SubfieldIndexMainField);
-        }
-        
-        #endregion // Methods
-    } // Class
+		///<summary>
+		/// Retrieves the StrokeCount field
+		/// Units: counts
+		/// Comment: stroke_type enum used as the index</summary>
+		/// <param name="index">0 based index of StrokeCount element to retrieve</param>
+		/// <returns>Returns nullable ushort representing the StrokeCount field</returns>
+		public ushort? GetStrokeCount(int index)
+		{
+			Object val = GetFieldValue(20, index, Fit.SubfieldIndexMainField);
+			if (val == null)
+			{
+				return null;
+			}
+
+			return (Convert.ToUInt16(val));
+
+		}
+
+		/// <summary>
+		/// Set StrokeCount field
+		/// Units: counts
+		/// Comment: stroke_type enum used as the index</summary>
+		/// <param name="index">0 based index of stroke_count</param>
+		/// <param name="strokeCount_">Nullable field value to be set</param>
+		public void SetStrokeCount(int index, ushort? strokeCount_)
+		{
+			SetFieldValue(20, index, strokeCount_, Fit.SubfieldIndexMainField);
+		}
+
+
+		/// <summary>
+		///
+		/// </summary>
+		/// <returns>returns number of elements in field ZoneCount</returns>
+		public int GetNumZoneCount()
+		{
+			return GetNumFieldValues(21, Fit.SubfieldIndexMainField);
+		}
+
+		///<summary>
+		/// Retrieves the ZoneCount field
+		/// Units: counts
+		/// Comment: zone number used as the index</summary>
+		/// <param name="index">0 based index of ZoneCount element to retrieve</param>
+		/// <returns>Returns nullable ushort representing the ZoneCount field</returns>
+		public ushort? GetZoneCount(int index)
+		{
+			Object val = GetFieldValue(21, index, Fit.SubfieldIndexMainField);
+			if (val == null)
+			{
+				return null;
+			}
+
+			return (Convert.ToUInt16(val));
+
+		}
+
+		/// <summary>
+		/// Set ZoneCount field
+		/// Units: counts
+		/// Comment: zone number used as the index</summary>
+		/// <param name="index">0 based index of zone_count</param>
+		/// <param name="zoneCount_">Nullable field value to be set</param>
+		public void SetZoneCount(int index, ushort? zoneCount_)
+		{
+			SetFieldValue(21, index, zoneCount_, Fit.SubfieldIndexMainField);
+		}
+
+		///<summary>
+		/// Retrieves the EnhancedAvgRespirationRate field
+		/// Units: Breaths/min</summary>
+		/// <returns>Returns nullable float representing the EnhancedAvgRespirationRate field</returns>
+		public float? EnhancedAvgRespirationRate
+		{
+			get
+			{
+				Object val = GetFieldValue(22, 0, Fit.SubfieldIndexMainField);
+				if (val == null)
+				{
+					return null;
+				}
+
+				return (Convert.ToSingle(val));
+
+			}
+			set
+			{
+				SetFieldValue(22, 0, value, Fit.SubfieldIndexMainField);
+			}
+		}
+
+		///<summary>
+		/// Retrieves the EnhancedMaxRespirationRate field
+		/// Units: Breaths/min</summary>
+		/// <returns>Returns nullable float representing the EnhancedMaxRespirationRate field</returns>
+		public float? EnhancedMaxRespirationRate
+		{
+			get
+			{
+				Object val = GetFieldValue(23, 0, Fit.SubfieldIndexMainField);
+				if (val == null)
+				{
+					return null;
+				}
+
+				return (Convert.ToSingle(val));
+
+			}
+			set
+			{
+				SetFieldValue(23, 0, value, Fit.SubfieldIndexMainField);
+			}
+		}
+
+		///<summary>
+		/// Retrieves the AvgRespirationRate field</summary>
+		/// <returns>Returns nullable byte representing the AvgRespirationRate field</returns>
+		public byte? AvgRespirationRate
+		{
+			get
+			{
+				Object val = GetFieldValue(24, 0, Fit.SubfieldIndexMainField);
+				if (val == null)
+				{
+					return null;
+				}
+
+				return (Convert.ToByte(val));
+
+			}
+			set
+			{
+				SetFieldValue(24, 0, value, Fit.SubfieldIndexMainField);
+			}
+		}
+
+		///<summary>
+		/// Retrieves the MaxRespirationRate field</summary>
+		/// <returns>Returns nullable byte representing the MaxRespirationRate field</returns>
+		public byte? MaxRespirationRate
+		{
+			get
+			{
+				Object val = GetFieldValue(25, 0, Fit.SubfieldIndexMainField);
+				if (val == null)
+				{
+					return null;
+				}
+
+				return (Convert.ToByte(val));
+
+			}
+			set
+			{
+				SetFieldValue(25, 0, value, Fit.SubfieldIndexMainField);
+			}
+		}
+
+		#endregion // Methods
+	} // Class
 } // namespace

--- a/Dynastream/Fit/Profile/Mesgs/MagnetometerDataMesg.cs
+++ b/Dynastream/Fit/Profile/Mesgs/MagnetometerDataMesg.cs
@@ -21,369 +21,363 @@ using System.Linq;
 
 namespace Dynastream.Fit
 {
-    /// <summary>
-    /// Implements the MagnetometerData profile message.
-    /// </summary>
-    public class MagnetometerDataMesg : Mesg
-    {
-        #region Fields
-        #endregion
+	/// <summary>
+	/// Implements the MagnetometerData profile message.
+	/// </summary>
+	public class MagnetometerDataMesg : Mesg
+	{
+		#region Fields
+		#endregion
 
-        /// <summary>
-        /// Field Numbers for <see cref="MagnetometerDataMesg"/>
-        /// </summary>
-        public sealed class FieldDefNum
-        {
-            public const byte Timestamp = 253;
-            public const byte TimestampMs = 0;
-            public const byte SampleTimeOffset = 1;
-            public const byte MagX = 2;
-            public const byte MagY = 3;
-            public const byte MagZ = 4;
-            public const byte CalibratedMagX = 5;
-            public const byte CalibratedMagY = 6;
-            public const byte CalibratedMagZ = 7;
-            public const byte Invalid = Fit.FieldNumInvalid;
-        }
+		/// <summary>
+		/// Field Numbers for <see cref="MagnetometerDataMesg"/>
+		/// </summary>
+		public sealed class FieldDefNum
+		{
+			public const byte Timestamp = 253;
+			public const byte TimestampMs = 0;
+			public const byte SampleTimeOffset = 1;
+			public const byte MagX = 2;
+			public const byte MagY = 3;
+			public const byte MagZ = 4;
+			public const byte CalibratedMagX = 5;
+			public const byte CalibratedMagY = 6;
+			public const byte CalibratedMagZ = 7;
+			public const byte Invalid = Fit.FieldNumInvalid;
+		}
 
-        #region Constructors
-        public MagnetometerDataMesg() : base(Profile.GetMesg(MesgNum.MagnetometerData))
-        {
-        }
+		#region Constructors
+		public MagnetometerDataMesg() : base(Profile.GetMesg(MesgNum.MagnetometerData))
+		{
+		}
 
-        public MagnetometerDataMesg(Mesg mesg) : base(mesg)
-        {
-        }
-        #endregion // Constructors
+		public MagnetometerDataMesg(Mesg mesg) : base(mesg)
+		{
+		}
+		#endregion // Constructors
 
-        #region Methods
-        ///<summary>
-        /// Retrieves the Timestamp field
-        /// Units: s
-        /// Comment: Whole second part of the timestamp</summary>
-        /// <returns>Returns DateTime representing the Timestamp field</returns>
-        public DateTime GetTimestamp()
-        {
-            Object val = GetFieldValue(253, 0, Fit.SubfieldIndexMainField);
-            if(val == null)
-            {
-                return null;
-            }
+		#region Methods
+		///<summary>
+		/// Retrieves the Timestamp field
+		/// Units: s
+		/// Comment: Whole second part of the timestamp</summary>
+		/// <returns>Returns DateTime representing the Timestamp field</returns>
+		public DateTime Timestamp
+		{
+			get
+			{
+				Object val = GetFieldValue(253, 0, Fit.SubfieldIndexMainField);
+				if (val == null)
+				{
+					return null;
+				}
 
-            return TimestampToDateTime(Convert.ToUInt32(val));
-            
-        }
+				return TimestampToDateTime(Convert.ToUInt32(val));
 
-        /// <summary>
-        /// Set Timestamp field
-        /// Units: s
-        /// Comment: Whole second part of the timestamp</summary>
-        /// <param name="timestamp_">Nullable field value to be set</param>
-        public void SetTimestamp(DateTime timestamp_)
-        {
-            SetFieldValue(253, 0, timestamp_.GetTimeStamp(), Fit.SubfieldIndexMainField);
-        }
-        
-        ///<summary>
-        /// Retrieves the TimestampMs field
-        /// Units: ms
-        /// Comment: Millisecond part of the timestamp.</summary>
-        /// <returns>Returns nullable ushort representing the TimestampMs field</returns>
-        public ushort? GetTimestampMs()
-        {
-            Object val = GetFieldValue(0, 0, Fit.SubfieldIndexMainField);
-            if(val == null)
-            {
-                return null;
-            }
+			}
+			set
+			{
+				SetFieldValue(253, 0, value.GetTimeStamp(), Fit.SubfieldIndexMainField);
+			}
+		}
 
-            return (Convert.ToUInt16(val));
-            
-        }
+		///<summary>
+		/// Retrieves the TimestampMs field
+		/// Units: ms
+		/// Comment: Millisecond part of the timestamp.</summary>
+		/// <returns>Returns nullable ushort representing the TimestampMs field</returns>
+		public ushort? TimestampMs
+		{
+			get
+			{
+				Object val = GetFieldValue(0, 0, Fit.SubfieldIndexMainField);
+				if (val == null)
+				{
+					return null;
+				}
 
-        /// <summary>
-        /// Set TimestampMs field
-        /// Units: ms
-        /// Comment: Millisecond part of the timestamp.</summary>
-        /// <param name="timestampMs_">Nullable field value to be set</param>
-        public void SetTimestampMs(ushort? timestampMs_)
-        {
-            SetFieldValue(0, 0, timestampMs_, Fit.SubfieldIndexMainField);
-        }
-        
-        
-        /// <summary>
-        ///
-        /// </summary>
-        /// <returns>returns number of elements in field SampleTimeOffset</returns>
-        public int GetNumSampleTimeOffset()
-        {
-            return GetNumFieldValues(1, Fit.SubfieldIndexMainField);
-        }
+				return (Convert.ToUInt16(val));
 
-        ///<summary>
-        /// Retrieves the SampleTimeOffset field
-        /// Units: ms
-        /// Comment: Each time in the array describes the time at which the compass sample with the corrosponding index was taken. Limited to 30 samples in each message. The samples may span across seconds. Array size must match the number of samples in cmps_x and cmps_y and cmps_z</summary>
-        /// <param name="index">0 based index of SampleTimeOffset element to retrieve</param>
-        /// <returns>Returns nullable ushort representing the SampleTimeOffset field</returns>
-        public ushort? GetSampleTimeOffset(int index)
-        {
-            Object val = GetFieldValue(1, index, Fit.SubfieldIndexMainField);
-            if(val == null)
-            {
-                return null;
-            }
+			}
+			set
+			{
+				SetFieldValue(0, 0, value, Fit.SubfieldIndexMainField);
+			}
+		}
 
-            return (Convert.ToUInt16(val));
-            
-        }
 
-        /// <summary>
-        /// Set SampleTimeOffset field
-        /// Units: ms
-        /// Comment: Each time in the array describes the time at which the compass sample with the corrosponding index was taken. Limited to 30 samples in each message. The samples may span across seconds. Array size must match the number of samples in cmps_x and cmps_y and cmps_z</summary>
-        /// <param name="index">0 based index of sample_time_offset</param>
-        /// <param name="sampleTimeOffset_">Nullable field value to be set</param>
-        public void SetSampleTimeOffset(int index, ushort? sampleTimeOffset_)
-        {
-            SetFieldValue(1, index, sampleTimeOffset_, Fit.SubfieldIndexMainField);
-        }
-        
-        
-        /// <summary>
-        ///
-        /// </summary>
-        /// <returns>returns number of elements in field MagX</returns>
-        public int GetNumMagX()
-        {
-            return GetNumFieldValues(2, Fit.SubfieldIndexMainField);
-        }
+		/// <summary>
+		///
+		/// </summary>
+		/// <returns>returns number of elements in field SampleTimeOffset</returns>
+		public int GetNumSampleTimeOffset()
+		{
+			return GetNumFieldValues(1, Fit.SubfieldIndexMainField);
+		}
 
-        ///<summary>
-        /// Retrieves the MagX field
-        /// Units: counts
-        /// Comment: These are the raw ADC reading. Maximum number of samples is 30 in each message. The samples may span across seconds. A conversion will need to be done on this data once read.</summary>
-        /// <param name="index">0 based index of MagX element to retrieve</param>
-        /// <returns>Returns nullable ushort representing the MagX field</returns>
-        public ushort? GetMagX(int index)
-        {
-            Object val = GetFieldValue(2, index, Fit.SubfieldIndexMainField);
-            if(val == null)
-            {
-                return null;
-            }
+		///<summary>
+		/// Retrieves the SampleTimeOffset field
+		/// Units: ms
+		/// Comment: Each time in the array describes the time at which the compass sample with the corrosponding index was taken. Limited to 30 samples in each message. The samples may span across seconds. Array size must match the number of samples in cmps_x and cmps_y and cmps_z</summary>
+		/// <param name="index">0 based index of SampleTimeOffset element to retrieve</param>
+		/// <returns>Returns nullable ushort representing the SampleTimeOffset field</returns>
+		public ushort? GetSampleTimeOffset(int index)
+		{
+			Object val = GetFieldValue(1, index, Fit.SubfieldIndexMainField);
+			if (val == null)
+			{
+				return null;
+			}
 
-            return (Convert.ToUInt16(val));
-            
-        }
+			return (Convert.ToUInt16(val));
 
-        /// <summary>
-        /// Set MagX field
-        /// Units: counts
-        /// Comment: These are the raw ADC reading. Maximum number of samples is 30 in each message. The samples may span across seconds. A conversion will need to be done on this data once read.</summary>
-        /// <param name="index">0 based index of mag_x</param>
-        /// <param name="magX_">Nullable field value to be set</param>
-        public void SetMagX(int index, ushort? magX_)
-        {
-            SetFieldValue(2, index, magX_, Fit.SubfieldIndexMainField);
-        }
-        
-        
-        /// <summary>
-        ///
-        /// </summary>
-        /// <returns>returns number of elements in field MagY</returns>
-        public int GetNumMagY()
-        {
-            return GetNumFieldValues(3, Fit.SubfieldIndexMainField);
-        }
+		}
 
-        ///<summary>
-        /// Retrieves the MagY field
-        /// Units: counts
-        /// Comment: These are the raw ADC reading. Maximum number of samples is 30 in each message. The samples may span across seconds. A conversion will need to be done on this data once read.</summary>
-        /// <param name="index">0 based index of MagY element to retrieve</param>
-        /// <returns>Returns nullable ushort representing the MagY field</returns>
-        public ushort? GetMagY(int index)
-        {
-            Object val = GetFieldValue(3, index, Fit.SubfieldIndexMainField);
-            if(val == null)
-            {
-                return null;
-            }
+		/// <summary>
+		/// Set SampleTimeOffset field
+		/// Units: ms
+		/// Comment: Each time in the array describes the time at which the compass sample with the corrosponding index was taken. Limited to 30 samples in each message. The samples may span across seconds. Array size must match the number of samples in cmps_x and cmps_y and cmps_z</summary>
+		/// <param name="index">0 based index of sample_time_offset</param>
+		/// <param name="sampleTimeOffset_">Nullable field value to be set</param>
+		public void SetSampleTimeOffset(int index, ushort? sampleTimeOffset_)
+		{
+			SetFieldValue(1, index, sampleTimeOffset_, Fit.SubfieldIndexMainField);
+		}
 
-            return (Convert.ToUInt16(val));
-            
-        }
 
-        /// <summary>
-        /// Set MagY field
-        /// Units: counts
-        /// Comment: These are the raw ADC reading. Maximum number of samples is 30 in each message. The samples may span across seconds. A conversion will need to be done on this data once read.</summary>
-        /// <param name="index">0 based index of mag_y</param>
-        /// <param name="magY_">Nullable field value to be set</param>
-        public void SetMagY(int index, ushort? magY_)
-        {
-            SetFieldValue(3, index, magY_, Fit.SubfieldIndexMainField);
-        }
-        
-        
-        /// <summary>
-        ///
-        /// </summary>
-        /// <returns>returns number of elements in field MagZ</returns>
-        public int GetNumMagZ()
-        {
-            return GetNumFieldValues(4, Fit.SubfieldIndexMainField);
-        }
+		/// <summary>
+		///
+		/// </summary>
+		/// <returns>returns number of elements in field MagX</returns>
+		public int GetNumMagX()
+		{
+			return GetNumFieldValues(2, Fit.SubfieldIndexMainField);
+		}
 
-        ///<summary>
-        /// Retrieves the MagZ field
-        /// Units: counts
-        /// Comment: These are the raw ADC reading. Maximum number of samples is 30 in each message. The samples may span across seconds. A conversion will need to be done on this data once read.</summary>
-        /// <param name="index">0 based index of MagZ element to retrieve</param>
-        /// <returns>Returns nullable ushort representing the MagZ field</returns>
-        public ushort? GetMagZ(int index)
-        {
-            Object val = GetFieldValue(4, index, Fit.SubfieldIndexMainField);
-            if(val == null)
-            {
-                return null;
-            }
+		///<summary>
+		/// Retrieves the MagX field
+		/// Units: counts
+		/// Comment: These are the raw ADC reading. Maximum number of samples is 30 in each message. The samples may span across seconds. A conversion will need to be done on this data once read.</summary>
+		/// <param name="index">0 based index of MagX element to retrieve</param>
+		/// <returns>Returns nullable ushort representing the MagX field</returns>
+		public ushort? GetMagX(int index)
+		{
+			Object val = GetFieldValue(2, index, Fit.SubfieldIndexMainField);
+			if (val == null)
+			{
+				return null;
+			}
 
-            return (Convert.ToUInt16(val));
-            
-        }
+			return (Convert.ToUInt16(val));
 
-        /// <summary>
-        /// Set MagZ field
-        /// Units: counts
-        /// Comment: These are the raw ADC reading. Maximum number of samples is 30 in each message. The samples may span across seconds. A conversion will need to be done on this data once read.</summary>
-        /// <param name="index">0 based index of mag_z</param>
-        /// <param name="magZ_">Nullable field value to be set</param>
-        public void SetMagZ(int index, ushort? magZ_)
-        {
-            SetFieldValue(4, index, magZ_, Fit.SubfieldIndexMainField);
-        }
-        
-        
-        /// <summary>
-        ///
-        /// </summary>
-        /// <returns>returns number of elements in field CalibratedMagX</returns>
-        public int GetNumCalibratedMagX()
-        {
-            return GetNumFieldValues(5, Fit.SubfieldIndexMainField);
-        }
+		}
 
-        ///<summary>
-        /// Retrieves the CalibratedMagX field
-        /// Units: G
-        /// Comment: Calibrated Magnetometer reading</summary>
-        /// <param name="index">0 based index of CalibratedMagX element to retrieve</param>
-        /// <returns>Returns nullable float representing the CalibratedMagX field</returns>
-        public float? GetCalibratedMagX(int index)
-        {
-            Object val = GetFieldValue(5, index, Fit.SubfieldIndexMainField);
-            if(val == null)
-            {
-                return null;
-            }
+		/// <summary>
+		/// Set MagX field
+		/// Units: counts
+		/// Comment: These are the raw ADC reading. Maximum number of samples is 30 in each message. The samples may span across seconds. A conversion will need to be done on this data once read.</summary>
+		/// <param name="index">0 based index of mag_x</param>
+		/// <param name="magX_">Nullable field value to be set</param>
+		public void SetMagX(int index, ushort? magX_)
+		{
+			SetFieldValue(2, index, magX_, Fit.SubfieldIndexMainField);
+		}
 
-            return (Convert.ToSingle(val));
-            
-        }
 
-        /// <summary>
-        /// Set CalibratedMagX field
-        /// Units: G
-        /// Comment: Calibrated Magnetometer reading</summary>
-        /// <param name="index">0 based index of calibrated_mag_x</param>
-        /// <param name="calibratedMagX_">Nullable field value to be set</param>
-        public void SetCalibratedMagX(int index, float? calibratedMagX_)
-        {
-            SetFieldValue(5, index, calibratedMagX_, Fit.SubfieldIndexMainField);
-        }
-        
-        
-        /// <summary>
-        ///
-        /// </summary>
-        /// <returns>returns number of elements in field CalibratedMagY</returns>
-        public int GetNumCalibratedMagY()
-        {
-            return GetNumFieldValues(6, Fit.SubfieldIndexMainField);
-        }
+		/// <summary>
+		///
+		/// </summary>
+		/// <returns>returns number of elements in field MagY</returns>
+		public int GetNumMagY()
+		{
+			return GetNumFieldValues(3, Fit.SubfieldIndexMainField);
+		}
 
-        ///<summary>
-        /// Retrieves the CalibratedMagY field
-        /// Units: G
-        /// Comment: Calibrated Magnetometer reading</summary>
-        /// <param name="index">0 based index of CalibratedMagY element to retrieve</param>
-        /// <returns>Returns nullable float representing the CalibratedMagY field</returns>
-        public float? GetCalibratedMagY(int index)
-        {
-            Object val = GetFieldValue(6, index, Fit.SubfieldIndexMainField);
-            if(val == null)
-            {
-                return null;
-            }
+		///<summary>
+		/// Retrieves the MagY field
+		/// Units: counts
+		/// Comment: These are the raw ADC reading. Maximum number of samples is 30 in each message. The samples may span across seconds. A conversion will need to be done on this data once read.</summary>
+		/// <param name="index">0 based index of MagY element to retrieve</param>
+		/// <returns>Returns nullable ushort representing the MagY field</returns>
+		public ushort? GetMagY(int index)
+		{
+			Object val = GetFieldValue(3, index, Fit.SubfieldIndexMainField);
+			if (val == null)
+			{
+				return null;
+			}
 
-            return (Convert.ToSingle(val));
-            
-        }
+			return (Convert.ToUInt16(val));
 
-        /// <summary>
-        /// Set CalibratedMagY field
-        /// Units: G
-        /// Comment: Calibrated Magnetometer reading</summary>
-        /// <param name="index">0 based index of calibrated_mag_y</param>
-        /// <param name="calibratedMagY_">Nullable field value to be set</param>
-        public void SetCalibratedMagY(int index, float? calibratedMagY_)
-        {
-            SetFieldValue(6, index, calibratedMagY_, Fit.SubfieldIndexMainField);
-        }
-        
-        
-        /// <summary>
-        ///
-        /// </summary>
-        /// <returns>returns number of elements in field CalibratedMagZ</returns>
-        public int GetNumCalibratedMagZ()
-        {
-            return GetNumFieldValues(7, Fit.SubfieldIndexMainField);
-        }
+		}
 
-        ///<summary>
-        /// Retrieves the CalibratedMagZ field
-        /// Units: G
-        /// Comment: Calibrated Magnetometer reading</summary>
-        /// <param name="index">0 based index of CalibratedMagZ element to retrieve</param>
-        /// <returns>Returns nullable float representing the CalibratedMagZ field</returns>
-        public float? GetCalibratedMagZ(int index)
-        {
-            Object val = GetFieldValue(7, index, Fit.SubfieldIndexMainField);
-            if(val == null)
-            {
-                return null;
-            }
+		/// <summary>
+		/// Set MagY field
+		/// Units: counts
+		/// Comment: These are the raw ADC reading. Maximum number of samples is 30 in each message. The samples may span across seconds. A conversion will need to be done on this data once read.</summary>
+		/// <param name="index">0 based index of mag_y</param>
+		/// <param name="magY_">Nullable field value to be set</param>
+		public void SetMagY(int index, ushort? magY_)
+		{
+			SetFieldValue(3, index, magY_, Fit.SubfieldIndexMainField);
+		}
 
-            return (Convert.ToSingle(val));
-            
-        }
 
-        /// <summary>
-        /// Set CalibratedMagZ field
-        /// Units: G
-        /// Comment: Calibrated Magnetometer reading</summary>
-        /// <param name="index">0 based index of calibrated_mag_z</param>
-        /// <param name="calibratedMagZ_">Nullable field value to be set</param>
-        public void SetCalibratedMagZ(int index, float? calibratedMagZ_)
-        {
-            SetFieldValue(7, index, calibratedMagZ_, Fit.SubfieldIndexMainField);
-        }
-        
-        #endregion // Methods
-    } // Class
+		/// <summary>
+		///
+		/// </summary>
+		/// <returns>returns number of elements in field MagZ</returns>
+		public int GetNumMagZ()
+		{
+			return GetNumFieldValues(4, Fit.SubfieldIndexMainField);
+		}
+
+		///<summary>
+		/// Retrieves the MagZ field
+		/// Units: counts
+		/// Comment: These are the raw ADC reading. Maximum number of samples is 30 in each message. The samples may span across seconds. A conversion will need to be done on this data once read.</summary>
+		/// <param name="index">0 based index of MagZ element to retrieve</param>
+		/// <returns>Returns nullable ushort representing the MagZ field</returns>
+		public ushort? GetMagZ(int index)
+		{
+			Object val = GetFieldValue(4, index, Fit.SubfieldIndexMainField);
+			if (val == null)
+			{
+				return null;
+			}
+
+			return (Convert.ToUInt16(val));
+
+		}
+
+		/// <summary>
+		/// Set MagZ field
+		/// Units: counts
+		/// Comment: These are the raw ADC reading. Maximum number of samples is 30 in each message. The samples may span across seconds. A conversion will need to be done on this data once read.</summary>
+		/// <param name="index">0 based index of mag_z</param>
+		/// <param name="magZ_">Nullable field value to be set</param>
+		public void SetMagZ(int index, ushort? magZ_)
+		{
+			SetFieldValue(4, index, magZ_, Fit.SubfieldIndexMainField);
+		}
+
+
+		/// <summary>
+		///
+		/// </summary>
+		/// <returns>returns number of elements in field CalibratedMagX</returns>
+		public int GetNumCalibratedMagX()
+		{
+			return GetNumFieldValues(5, Fit.SubfieldIndexMainField);
+		}
+
+		///<summary>
+		/// Retrieves the CalibratedMagX field
+		/// Units: G
+		/// Comment: Calibrated Magnetometer reading</summary>
+		/// <param name="index">0 based index of CalibratedMagX element to retrieve</param>
+		/// <returns>Returns nullable float representing the CalibratedMagX field</returns>
+		public float? GetCalibratedMagX(int index)
+		{
+			Object val = GetFieldValue(5, index, Fit.SubfieldIndexMainField);
+			if (val == null)
+			{
+				return null;
+			}
+
+			return (Convert.ToSingle(val));
+
+		}
+
+		/// <summary>
+		/// Set CalibratedMagX field
+		/// Units: G
+		/// Comment: Calibrated Magnetometer reading</summary>
+		/// <param name="index">0 based index of calibrated_mag_x</param>
+		/// <param name="calibratedMagX_">Nullable field value to be set</param>
+		public void SetCalibratedMagX(int index, float? calibratedMagX_)
+		{
+			SetFieldValue(5, index, calibratedMagX_, Fit.SubfieldIndexMainField);
+		}
+
+
+		/// <summary>
+		///
+		/// </summary>
+		/// <returns>returns number of elements in field CalibratedMagY</returns>
+		public int GetNumCalibratedMagY()
+		{
+			return GetNumFieldValues(6, Fit.SubfieldIndexMainField);
+		}
+
+		///<summary>
+		/// Retrieves the CalibratedMagY field
+		/// Units: G
+		/// Comment: Calibrated Magnetometer reading</summary>
+		/// <param name="index">0 based index of CalibratedMagY element to retrieve</param>
+		/// <returns>Returns nullable float representing the CalibratedMagY field</returns>
+		public float? GetCalibratedMagY(int index)
+		{
+			Object val = GetFieldValue(6, index, Fit.SubfieldIndexMainField);
+			if (val == null)
+			{
+				return null;
+			}
+
+			return (Convert.ToSingle(val));
+
+		}
+
+		/// <summary>
+		/// Set CalibratedMagY field
+		/// Units: G
+		/// Comment: Calibrated Magnetometer reading</summary>
+		/// <param name="index">0 based index of calibrated_mag_y</param>
+		/// <param name="calibratedMagY_">Nullable field value to be set</param>
+		public void SetCalibratedMagY(int index, float? calibratedMagY_)
+		{
+			SetFieldValue(6, index, calibratedMagY_, Fit.SubfieldIndexMainField);
+		}
+
+
+		/// <summary>
+		///
+		/// </summary>
+		/// <returns>returns number of elements in field CalibratedMagZ</returns>
+		public int GetNumCalibratedMagZ()
+		{
+			return GetNumFieldValues(7, Fit.SubfieldIndexMainField);
+		}
+
+		///<summary>
+		/// Retrieves the CalibratedMagZ field
+		/// Units: G
+		/// Comment: Calibrated Magnetometer reading</summary>
+		/// <param name="index">0 based index of CalibratedMagZ element to retrieve</param>
+		/// <returns>Returns nullable float representing the CalibratedMagZ field</returns>
+		public float? GetCalibratedMagZ(int index)
+		{
+			Object val = GetFieldValue(7, index, Fit.SubfieldIndexMainField);
+			if (val == null)
+			{
+				return null;
+			}
+
+			return (Convert.ToSingle(val));
+
+		}
+
+		/// <summary>
+		/// Set CalibratedMagZ field
+		/// Units: G
+		/// Comment: Calibrated Magnetometer reading</summary>
+		/// <param name="index">0 based index of calibrated_mag_z</param>
+		/// <param name="calibratedMagZ_">Nullable field value to be set</param>
+		public void SetCalibratedMagZ(int index, float? calibratedMagZ_)
+		{
+			SetFieldValue(7, index, calibratedMagZ_, Fit.SubfieldIndexMainField);
+		}
+
+		#endregion // Methods
+	} // Class
 } // namespace

--- a/Dynastream/Fit/Profile/Mesgs/MaxMetDataMesg.cs
+++ b/Dynastream/Fit/Profile/Mesgs/MaxMetDataMesg.cs
@@ -21,205 +21,192 @@ using System.Linq;
 
 namespace Dynastream.Fit
 {
-    /// <summary>
-    /// Implements the MaxMetData profile message.
-    /// </summary>
-    public class MaxMetDataMesg : Mesg
-    {
-        #region Fields
-        #endregion
+	/// <summary>
+	/// Implements the MaxMetData profile message.
+	/// </summary>
+	public class MaxMetDataMesg : Mesg
+	{
+		#region Fields
+		#endregion
 
-        /// <summary>
-        /// Field Numbers for <see cref="MaxMetDataMesg"/>
-        /// </summary>
-        public sealed class FieldDefNum
-        {
-            public const byte UpdateTime = 0;
-            public const byte Vo2Max = 2;
-            public const byte Sport = 5;
-            public const byte SubSport = 6;
-            public const byte MaxMetCategory = 8;
-            public const byte CalibratedData = 9;
-            public const byte HrSource = 12;
-            public const byte SpeedSource = 13;
-            public const byte Invalid = Fit.FieldNumInvalid;
-        }
+		/// <summary>
+		/// Field Numbers for <see cref="MaxMetDataMesg"/>
+		/// </summary>
+		public sealed class FieldDefNum
+		{
+			public const byte UpdateTime = 0;
+			public const byte Vo2Max = 2;
+			public const byte Sport = 5;
+			public const byte SubSport = 6;
+			public const byte MaxMetCategory = 8;
+			public const byte CalibratedData = 9;
+			public const byte HrSource = 12;
+			public const byte SpeedSource = 13;
+			public const byte Invalid = Fit.FieldNumInvalid;
+		}
 
-        #region Constructors
-        public MaxMetDataMesg() : base(Profile.GetMesg(MesgNum.MaxMetData))
-        {
-        }
+		#region Constructors
+		public MaxMetDataMesg() : base(Profile.GetMesg(MesgNum.MaxMetData))
+		{
+		}
 
-        public MaxMetDataMesg(Mesg mesg) : base(mesg)
-        {
-        }
-        #endregion // Constructors
+		public MaxMetDataMesg(Mesg mesg) : base(mesg)
+		{
+		}
+		#endregion // Constructors
 
-        #region Methods
-        ///<summary>
-        /// Retrieves the UpdateTime field
-        /// Comment: Time maxMET and vo2 were calculated</summary>
-        /// <returns>Returns DateTime representing the UpdateTime field</returns>
-        public DateTime GetUpdateTime()
-        {
-            Object val = GetFieldValue(0, 0, Fit.SubfieldIndexMainField);
-            if(val == null)
-            {
-                return null;
-            }
+		#region Methods
+		///<summary>
+		/// Retrieves the UpdateTime field
+		/// Comment: Time maxMET and vo2 were calculated</summary>
+		/// <returns>Returns DateTime representing the UpdateTime field</returns>
+		public DateTime UpdateTime
+		{
+			get
+			{
+				Object val = GetFieldValue(0, 0, Fit.SubfieldIndexMainField);
+				if (val == null)
+				{
+					return null;
+				}
 
-            return TimestampToDateTime(Convert.ToUInt32(val));
-            
-        }
+				return TimestampToDateTime(Convert.ToUInt32(val));
 
-        /// <summary>
-        /// Set UpdateTime field
-        /// Comment: Time maxMET and vo2 were calculated</summary>
-        /// <param name="updateTime_">Nullable field value to be set</param>
-        public void SetUpdateTime(DateTime updateTime_)
-        {
-            SetFieldValue(0, 0, updateTime_.GetTimeStamp(), Fit.SubfieldIndexMainField);
-        }
-        
-        ///<summary>
-        /// Retrieves the Vo2Max field
-        /// Units: mL/kg/min</summary>
-        /// <returns>Returns nullable float representing the Vo2Max field</returns>
-        public float? GetVo2Max()
-        {
-            Object val = GetFieldValue(2, 0, Fit.SubfieldIndexMainField);
-            if(val == null)
-            {
-                return null;
-            }
+			}
+			set
+			{
+				SetFieldValue(0, 0, value.GetTimeStamp(), Fit.SubfieldIndexMainField);
+			}
+		}
 
-            return (Convert.ToSingle(val));
-            
-        }
+		///<summary>
+		/// Retrieves the Vo2Max field
+		/// Units: mL/kg/min</summary>
+		/// <returns>Returns nullable float representing the Vo2Max field</returns>
+		public float? Vo2Max
+		{
+			get
+			{
+				Object val = GetFieldValue(2, 0, Fit.SubfieldIndexMainField);
+				if (val == null)
+				{
+					return null;
+				}
 
-        /// <summary>
-        /// Set Vo2Max field
-        /// Units: mL/kg/min</summary>
-        /// <param name="vo2Max_">Nullable field value to be set</param>
-        public void SetVo2Max(float? vo2Max_)
-        {
-            SetFieldValue(2, 0, vo2Max_, Fit.SubfieldIndexMainField);
-        }
-        
-        ///<summary>
-        /// Retrieves the Sport field</summary>
-        /// <returns>Returns nullable Sport enum representing the Sport field</returns>
-        public Sport? GetSport()
-        {
-            object obj = GetFieldValue(5, 0, Fit.SubfieldIndexMainField);
-            Sport? value = obj == null ? (Sport?)null : (Sport)obj;
-            return value;
-        }
+				return (Convert.ToSingle(val));
 
-        /// <summary>
-        /// Set Sport field</summary>
-        /// <param name="sport_">Nullable field value to be set</param>
-        public void SetSport(Sport? sport_)
-        {
-            SetFieldValue(5, 0, sport_, Fit.SubfieldIndexMainField);
-        }
-        
-        ///<summary>
-        /// Retrieves the SubSport field</summary>
-        /// <returns>Returns nullable SubSport enum representing the SubSport field</returns>
-        public SubSport? GetSubSport()
-        {
-            object obj = GetFieldValue(6, 0, Fit.SubfieldIndexMainField);
-            SubSport? value = obj == null ? (SubSport?)null : (SubSport)obj;
-            return value;
-        }
+			}
+			set
+			{
+				SetFieldValue(2, 0, value, Fit.SubfieldIndexMainField);
+			}
+		}
 
-        /// <summary>
-        /// Set SubSport field</summary>
-        /// <param name="subSport_">Nullable field value to be set</param>
-        public void SetSubSport(SubSport? subSport_)
-        {
-            SetFieldValue(6, 0, subSport_, Fit.SubfieldIndexMainField);
-        }
-        
-        ///<summary>
-        /// Retrieves the MaxMetCategory field</summary>
-        /// <returns>Returns nullable MaxMetCategory enum representing the MaxMetCategory field</returns>
-        public MaxMetCategory? GetMaxMetCategory()
-        {
-            object obj = GetFieldValue(8, 0, Fit.SubfieldIndexMainField);
-            MaxMetCategory? value = obj == null ? (MaxMetCategory?)null : (MaxMetCategory)obj;
-            return value;
-        }
+		///<summary>
+		/// Retrieves the Sport field</summary>
+		/// <returns>Returns nullable Sport enum representing the Sport field</returns>
+		public Sport? Sport
+		{
+			get
+			{
+				object obj = GetFieldValue(5, 0, Fit.SubfieldIndexMainField);
+				Sport? value = obj == null ? (Sport?)null : (Sport)obj;
+				return value;
+			}
+			set
+			{
+				SetFieldValue(5, 0, value, Fit.SubfieldIndexMainField);
+			}
+		}
 
-        /// <summary>
-        /// Set MaxMetCategory field</summary>
-        /// <param name="maxMetCategory_">Nullable field value to be set</param>
-        public void SetMaxMetCategory(MaxMetCategory? maxMetCategory_)
-        {
-            SetFieldValue(8, 0, maxMetCategory_, Fit.SubfieldIndexMainField);
-        }
-        
-        ///<summary>
-        /// Retrieves the CalibratedData field
-        /// Comment: Indicates if calibrated data was used in the calculation</summary>
-        /// <returns>Returns nullable Bool enum representing the CalibratedData field</returns>
-        public Bool? GetCalibratedData()
-        {
-            object obj = GetFieldValue(9, 0, Fit.SubfieldIndexMainField);
-            Bool? value = obj == null ? (Bool?)null : (Bool)obj;
-            return value;
-        }
+		///<summary>
+		/// Retrieves the SubSport field</summary>
+		/// <returns>Returns nullable SubSport enum representing the SubSport field</returns>
+		public SubSport? SubSport
+		{
+			get
+			{
+				object obj = GetFieldValue(6, 0, Fit.SubfieldIndexMainField);
+				SubSport? value = obj == null ? (SubSport?)null : (SubSport)obj;
+				return value;
+			}
+			set
+			{
+				SetFieldValue(6, 0, value, Fit.SubfieldIndexMainField);
+			}
+		}
 
-        /// <summary>
-        /// Set CalibratedData field
-        /// Comment: Indicates if calibrated data was used in the calculation</summary>
-        /// <param name="calibratedData_">Nullable field value to be set</param>
-        public void SetCalibratedData(Bool? calibratedData_)
-        {
-            SetFieldValue(9, 0, calibratedData_, Fit.SubfieldIndexMainField);
-        }
-        
-        ///<summary>
-        /// Retrieves the HrSource field
-        /// Comment: Indicates if the estimate was obtained using a chest strap or wrist heart rate</summary>
-        /// <returns>Returns nullable MaxMetHeartRateSource enum representing the HrSource field</returns>
-        public MaxMetHeartRateSource? GetHrSource()
-        {
-            object obj = GetFieldValue(12, 0, Fit.SubfieldIndexMainField);
-            MaxMetHeartRateSource? value = obj == null ? (MaxMetHeartRateSource?)null : (MaxMetHeartRateSource)obj;
-            return value;
-        }
+		///<summary>
+		/// Retrieves the MaxMetCategory field</summary>
+		/// <returns>Returns nullable MaxMetCategory enum representing the MaxMetCategory field</returns>
+		public MaxMetCategory? MaxMetCategory
+		{
+			get
+			{
+				object obj = GetFieldValue(8, 0, Fit.SubfieldIndexMainField);
+				MaxMetCategory? value = obj == null ? (MaxMetCategory?)null : (MaxMetCategory)obj;
+				return value;
+			}
+			set
+			{
+				SetFieldValue(8, 0, value, Fit.SubfieldIndexMainField);
+			}
+		}
 
-        /// <summary>
-        /// Set HrSource field
-        /// Comment: Indicates if the estimate was obtained using a chest strap or wrist heart rate</summary>
-        /// <param name="hrSource_">Nullable field value to be set</param>
-        public void SetHrSource(MaxMetHeartRateSource? hrSource_)
-        {
-            SetFieldValue(12, 0, hrSource_, Fit.SubfieldIndexMainField);
-        }
-        
-        ///<summary>
-        /// Retrieves the SpeedSource field
-        /// Comment: Indidcates if the estimate was obtained using onboard GPS or connected GPS</summary>
-        /// <returns>Returns nullable MaxMetSpeedSource enum representing the SpeedSource field</returns>
-        public MaxMetSpeedSource? GetSpeedSource()
-        {
-            object obj = GetFieldValue(13, 0, Fit.SubfieldIndexMainField);
-            MaxMetSpeedSource? value = obj == null ? (MaxMetSpeedSource?)null : (MaxMetSpeedSource)obj;
-            return value;
-        }
+		///<summary>
+		/// Retrieves the CalibratedData field
+		/// Comment: Indicates if calibrated data was used in the calculation</summary>
+		/// <returns>Returns nullable Bool enum representing the CalibratedData field</returns>
+		public Bool? CalibratedData
+		{
+			get
+			{
+				object obj = GetFieldValue(9, 0, Fit.SubfieldIndexMainField);
+				Bool? value = obj == null ? (Bool?)null : (Bool)obj;
+				return value;
+			}
+			set
+			{
+				SetFieldValue(9, 0, value, Fit.SubfieldIndexMainField);
+			}
+		}
 
-        /// <summary>
-        /// Set SpeedSource field
-        /// Comment: Indidcates if the estimate was obtained using onboard GPS or connected GPS</summary>
-        /// <param name="speedSource_">Nullable field value to be set</param>
-        public void SetSpeedSource(MaxMetSpeedSource? speedSource_)
-        {
-            SetFieldValue(13, 0, speedSource_, Fit.SubfieldIndexMainField);
-        }
-        
-        #endregion // Methods
-    } // Class
+		///<summary>
+		/// Retrieves the HrSource field
+		/// Comment: Indicates if the estimate was obtained using a chest strap or wrist heart rate</summary>
+		/// <returns>Returns nullable MaxMetHeartRateSource enum representing the HrSource field</returns>
+		public MaxMetHeartRateSource? HrSource
+		{
+			get
+			{
+				object obj = GetFieldValue(12, 0, Fit.SubfieldIndexMainField);
+				MaxMetHeartRateSource? value = obj == null ? (MaxMetHeartRateSource?)null : (MaxMetHeartRateSource)obj;
+				return value;
+			}
+			set
+			{
+				SetFieldValue(12, 0, value, Fit.SubfieldIndexMainField);
+			}
+		}
+
+		///<summary>
+		/// Retrieves the SpeedSource field
+		/// Comment: Indidcates if the estimate was obtained using onboard GPS or connected GPS</summary>
+		/// <returns>Returns nullable MaxMetSpeedSource enum representing the SpeedSource field</returns>
+		public MaxMetSpeedSource? SpeedSource
+		{
+			get
+			{
+				object obj = GetFieldValue(13, 0, Fit.SubfieldIndexMainField);
+				MaxMetSpeedSource? value = obj == null ? (MaxMetSpeedSource?)null : (MaxMetSpeedSource)obj;
+				return value;
+			}
+			set
+			{
+				SetFieldValue(13, 0, value, Fit.SubfieldIndexMainField);
+			}
+		}
+
+		#endregion // Methods
+	} // Class
 } // namespace

--- a/Dynastream/Fit/Profile/Mesgs/MemoGlobMesg.cs
+++ b/Dynastream/Fit/Profile/Mesgs/MemoGlobMesg.cs
@@ -21,213 +21,205 @@ using System.Linq;
 
 namespace Dynastream.Fit
 {
-    /// <summary>
-    /// Implements the MemoGlob profile message.
-    /// </summary>
-    public class MemoGlobMesg : Mesg
-    {
-        #region Fields
-        #endregion
+	/// <summary>
+	/// Implements the MemoGlob profile message.
+	/// </summary>
+	public class MemoGlobMesg : Mesg
+	{
+		#region Fields
+		#endregion
 
-        /// <summary>
-        /// Field Numbers for <see cref="MemoGlobMesg"/>
-        /// </summary>
-        public sealed class FieldDefNum
-        {
-            public const byte PartIndex = 250;
-            public const byte Memo = 0;
-            public const byte MesgNum = 1;
-            public const byte ParentIndex = 2;
-            public const byte FieldNum = 3;
-            public const byte Data = 4;
-            public const byte Invalid = Fit.FieldNumInvalid;
-        }
+		/// <summary>
+		/// Field Numbers for <see cref="MemoGlobMesg"/>
+		/// </summary>
+		public sealed class FieldDefNum
+		{
+			public const byte PartIndex = 250;
+			public const byte Memo = 0;
+			public const byte MesgNum = 1;
+			public const byte ParentIndex = 2;
+			public const byte FieldNum = 3;
+			public const byte Data = 4;
+			public const byte Invalid = Fit.FieldNumInvalid;
+		}
 
-        #region Constructors
-        public MemoGlobMesg() : base(Profile.GetMesg(MesgNum.MemoGlob))
-        {
-        }
+		#region Constructors
+		public MemoGlobMesg() : base(Profile.GetMesg(Dynastream.Fit.MesgNum.MemoGlob))
+		{
+		}
 
-        public MemoGlobMesg(Mesg mesg) : base(mesg)
-        {
-        }
-        #endregion // Constructors
+		public MemoGlobMesg(Mesg mesg) : base(mesg)
+		{
+		}
+		#endregion // Constructors
 
-        #region Methods
-        ///<summary>
-        /// Retrieves the PartIndex field
-        /// Comment: Sequence number of memo blocks</summary>
-        /// <returns>Returns nullable uint representing the PartIndex field</returns>
-        public uint? GetPartIndex()
-        {
-            Object val = GetFieldValue(250, 0, Fit.SubfieldIndexMainField);
-            if(val == null)
-            {
-                return null;
-            }
+		#region Methods
+		///<summary>
+		/// Retrieves the PartIndex field
+		/// Comment: Sequence number of memo blocks</summary>
+		/// <returns>Returns nullable uint representing the PartIndex field</returns>
+		public uint? PartIndex
+		{
+			get
+			{
+				Object val = GetFieldValue(250, 0, Fit.SubfieldIndexMainField);
+				if (val == null)
+				{
+					return null;
+				}
 
-            return (Convert.ToUInt32(val));
-            
-        }
+				return (Convert.ToUInt32(val));
 
-        /// <summary>
-        /// Set PartIndex field
-        /// Comment: Sequence number of memo blocks</summary>
-        /// <param name="partIndex_">Nullable field value to be set</param>
-        public void SetPartIndex(uint? partIndex_)
-        {
-            SetFieldValue(250, 0, partIndex_, Fit.SubfieldIndexMainField);
-        }
-        
-        
-        /// <summary>
-        ///
-        /// </summary>
-        /// <returns>returns number of elements in field Memo</returns>
-        public int GetNumMemo()
-        {
-            return GetNumFieldValues(0, Fit.SubfieldIndexMainField);
-        }
+			}
+			set
+			{
+				SetFieldValue(250, 0, value, Fit.SubfieldIndexMainField);
+			}
+		}
 
-        ///<summary>
-        /// Retrieves the Memo field
-        /// Comment: Deprecated. Use data field.</summary>
-        /// <param name="index">0 based index of Memo element to retrieve</param>
-        /// <returns>Returns nullable byte representing the Memo field</returns>
-        public byte? GetMemo(int index)
-        {
-            Object val = GetFieldValue(0, index, Fit.SubfieldIndexMainField);
-            if(val == null)
-            {
-                return null;
-            }
 
-            return (Convert.ToByte(val));
-            
-        }
+		/// <summary>
+		///
+		/// </summary>
+		/// <returns>returns number of elements in field Memo</returns>
+		public int GetNumMemo()
+		{
+			return GetNumFieldValues(0, Fit.SubfieldIndexMainField);
+		}
 
-        /// <summary>
-        /// Set Memo field
-        /// Comment: Deprecated. Use data field.</summary>
-        /// <param name="index">0 based index of memo</param>
-        /// <param name="memo_">Nullable field value to be set</param>
-        public void SetMemo(int index, byte? memo_)
-        {
-            SetFieldValue(0, index, memo_, Fit.SubfieldIndexMainField);
-        }
-        
-        ///<summary>
-        /// Retrieves the MesgNum field
-        /// Comment: Message Number of the parent message</summary>
-        /// <returns>Returns nullable ushort representing the MesgNum field</returns>
-        public ushort? GetMesgNum()
-        {
-            Object val = GetFieldValue(1, 0, Fit.SubfieldIndexMainField);
-            if(val == null)
-            {
-                return null;
-            }
+		///<summary>
+		/// Retrieves the Memo field
+		/// Comment: Deprecated. Use data field.</summary>
+		/// <param name="index">0 based index of Memo element to retrieve</param>
+		/// <returns>Returns nullable byte representing the Memo field</returns>
+		public byte? GetMemo(int index)
+		{
+			Object val = GetFieldValue(0, index, Fit.SubfieldIndexMainField);
+			if (val == null)
+			{
+				return null;
+			}
 
-            return (Convert.ToUInt16(val));
-            
-        }
+			return (Convert.ToByte(val));
 
-        /// <summary>
-        /// Set MesgNum field
-        /// Comment: Message Number of the parent message</summary>
-        /// <param name="mesgNum_">Nullable field value to be set</param>
-        public void SetMesgNum(ushort? mesgNum_)
-        {
-            SetFieldValue(1, 0, mesgNum_, Fit.SubfieldIndexMainField);
-        }
-        
-        ///<summary>
-        /// Retrieves the ParentIndex field
-        /// Comment: Index of mesg that this glob is associated with.</summary>
-        /// <returns>Returns nullable ushort representing the ParentIndex field</returns>
-        public ushort? GetParentIndex()
-        {
-            Object val = GetFieldValue(2, 0, Fit.SubfieldIndexMainField);
-            if(val == null)
-            {
-                return null;
-            }
+		}
 
-            return (Convert.ToUInt16(val));
-            
-        }
+		/// <summary>
+		/// Set Memo field
+		/// Comment: Deprecated. Use data field.</summary>
+		/// <param name="index">0 based index of memo</param>
+		/// <param name="memo_">Nullable field value to be set</param>
+		public void SetMemo(int index, byte? memo_)
+		{
+			SetFieldValue(0, index, memo_, Fit.SubfieldIndexMainField);
+		}
 
-        /// <summary>
-        /// Set ParentIndex field
-        /// Comment: Index of mesg that this glob is associated with.</summary>
-        /// <param name="parentIndex_">Nullable field value to be set</param>
-        public void SetParentIndex(ushort? parentIndex_)
-        {
-            SetFieldValue(2, 0, parentIndex_, Fit.SubfieldIndexMainField);
-        }
-        
-        ///<summary>
-        /// Retrieves the FieldNum field
-        /// Comment: Field within the parent that this glob is associated with</summary>
-        /// <returns>Returns nullable byte representing the FieldNum field</returns>
-        public byte? GetFieldNum()
-        {
-            Object val = GetFieldValue(3, 0, Fit.SubfieldIndexMainField);
-            if(val == null)
-            {
-                return null;
-            }
+		///<summary>
+		/// Retrieves the MesgNum field
+		/// Comment: Message Number of the parent message</summary>
+		/// <returns>Returns nullable ushort representing the MesgNum field</returns>
+		public ushort? MesgNum
+		{
+			get
+			{
+				Object val = GetFieldValue(1, 0, Fit.SubfieldIndexMainField);
+				if (val == null)
+				{
+					return null;
+				}
 
-            return (Convert.ToByte(val));
-            
-        }
+				return (Convert.ToUInt16(val));
 
-        /// <summary>
-        /// Set FieldNum field
-        /// Comment: Field within the parent that this glob is associated with</summary>
-        /// <param name="fieldNum_">Nullable field value to be set</param>
-        public void SetFieldNum(byte? fieldNum_)
-        {
-            SetFieldValue(3, 0, fieldNum_, Fit.SubfieldIndexMainField);
-        }
-        
-        
-        /// <summary>
-        ///
-        /// </summary>
-        /// <returns>returns number of elements in field Data</returns>
-        public int GetNumData()
-        {
-            return GetNumFieldValues(4, Fit.SubfieldIndexMainField);
-        }
+			}
+			set
+			{
+				SetFieldValue(1, 0, value, Fit.SubfieldIndexMainField);
+			}
+		}
 
-        ///<summary>
-        /// Retrieves the Data field
-        /// Comment: Block of utf8 bytes. Note, mutltibyte characters may be split across adjoining memo_glob messages.</summary>
-        /// <param name="index">0 based index of Data element to retrieve</param>
-        /// <returns>Returns nullable byte representing the Data field</returns>
-        public byte? GetData(int index)
-        {
-            Object val = GetFieldValue(4, index, Fit.SubfieldIndexMainField);
-            if(val == null)
-            {
-                return null;
-            }
+		///<summary>
+		/// Retrieves the ParentIndex field
+		/// Comment: Index of mesg that this glob is associated with.</summary>
+		/// <returns>Returns nullable ushort representing the ParentIndex field</returns>
+		public ushort? ParentIndex
+		{
+			get
+			{
+				Object val = GetFieldValue(2, 0, Fit.SubfieldIndexMainField);
+				if (val == null)
+				{
+					return null;
+				}
 
-            return (Convert.ToByte(val));
-            
-        }
+				return (Convert.ToUInt16(val));
 
-        /// <summary>
-        /// Set Data field
-        /// Comment: Block of utf8 bytes. Note, mutltibyte characters may be split across adjoining memo_glob messages.</summary>
-        /// <param name="index">0 based index of data</param>
-        /// <param name="data_">Nullable field value to be set</param>
-        public void SetData(int index, byte? data_)
-        {
-            SetFieldValue(4, index, data_, Fit.SubfieldIndexMainField);
-        }
-        
-        #endregion // Methods
-    } // Class
+			}
+			set
+			{
+				SetFieldValue(2, 0, value, Fit.SubfieldIndexMainField);
+			}
+		}
+
+		///<summary>
+		/// Retrieves the FieldNum field
+		/// Comment: Field within the parent that this glob is associated with</summary>
+		/// <returns>Returns nullable byte representing the FieldNum field</returns>
+		public byte? FieldNum
+		{
+			get
+			{
+				Object val = GetFieldValue(3, 0, Fit.SubfieldIndexMainField);
+				if (val == null)
+				{
+					return null;
+				}
+
+				return (Convert.ToByte(val));
+
+			}
+			set
+			{
+				SetFieldValue(3, 0, value, Fit.SubfieldIndexMainField);
+			}
+		}
+
+
+		/// <summary>
+		///
+		/// </summary>
+		/// <returns>returns number of elements in field Data</returns>
+		public int GetNumData()
+		{
+			return GetNumFieldValues(4, Fit.SubfieldIndexMainField);
+		}
+
+		///<summary>
+		/// Retrieves the Data field
+		/// Comment: Block of utf8 bytes. Note, mutltibyte characters may be split across adjoining memo_glob messages.</summary>
+		/// <param name="index">0 based index of Data element to retrieve</param>
+		/// <returns>Returns nullable byte representing the Data field</returns>
+		public byte? GetData(int index)
+		{
+			Object val = GetFieldValue(4, index, Fit.SubfieldIndexMainField);
+			if (val == null)
+			{
+				return null;
+			}
+
+			return (Convert.ToByte(val));
+
+		}
+
+		/// <summary>
+		/// Set Data field
+		/// Comment: Block of utf8 bytes. Note, mutltibyte characters may be split across adjoining memo_glob messages.</summary>
+		/// <param name="index">0 based index of data</param>
+		/// <param name="data_">Nullable field value to be set</param>
+		public void SetData(int index, byte? data_)
+		{
+			SetFieldValue(4, index, data_, Fit.SubfieldIndexMainField);
+		}
+
+		#endregion // Methods
+	} // Class
 } // namespace

--- a/Dynastream/Fit/Profile/Mesgs/MesgCapabilitiesMesg.cs
+++ b/Dynastream/Fit/Profile/Mesgs/MesgCapabilitiesMesg.cs
@@ -21,224 +21,213 @@ using System.Linq;
 
 namespace Dynastream.Fit
 {
-    /// <summary>
-    /// Implements the MesgCapabilities profile message.
-    /// </summary>
-    public class MesgCapabilitiesMesg : Mesg
-    {
-        #region Fields
-        static class CountSubfield
-        {
-            public static ushort NumPerFile = 0;
-            public static ushort MaxPerFile = 1;
-            public static ushort MaxPerFileType = 2;
-            public static ushort Subfields = 3;
-            public static ushort Active = Fit.SubfieldIndexActiveSubfield;
-            public static ushort MainField = Fit.SubfieldIndexMainField;
-        }
-        #endregion
+	/// <summary>
+	/// Implements the MesgCapabilities profile message.
+	/// </summary>
+	public class MesgCapabilitiesMesg : Mesg
+	{
+		#region Fields
+		static class CountSubfield
+		{
+			public static ushort NumPerFile = 0;
+			public static ushort MaxPerFile = 1;
+			public static ushort MaxPerFileType = 2;
+			public static ushort Subfields = 3;
+			public static ushort Active = Fit.SubfieldIndexActiveSubfield;
+			public static ushort MainField = Fit.SubfieldIndexMainField;
+		}
+		#endregion
 
-        /// <summary>
-        /// Field Numbers for <see cref="MesgCapabilitiesMesg"/>
-        /// </summary>
-        public sealed class FieldDefNum
-        {
-            public const byte MessageIndex = 254;
-            public const byte File = 0;
-            public const byte MesgNum = 1;
-            public const byte CountType = 2;
-            public const byte Count = 3;
-            public const byte Invalid = Fit.FieldNumInvalid;
-        }
+		/// <summary>
+		/// Field Numbers for <see cref="MesgCapabilitiesMesg"/>
+		/// </summary>
+		public sealed class FieldDefNum
+		{
+			public const byte MessageIndex = 254;
+			public const byte File = 0;
+			public const byte MesgNum = 1;
+			public const byte CountType = 2;
+			public const byte Count = 3;
+			public const byte Invalid = Fit.FieldNumInvalid;
+		}
 
-        #region Constructors
-        public MesgCapabilitiesMesg() : base(Profile.GetMesg(MesgNum.MesgCapabilities))
-        {
-        }
+		#region Constructors
+		public MesgCapabilitiesMesg() : base(Profile.GetMesg(Dynastream.Fit.MesgNum.MesgCapabilities))
+		{
+		}
 
-        public MesgCapabilitiesMesg(Mesg mesg) : base(mesg)
-        {
-        }
-        #endregion // Constructors
+		public MesgCapabilitiesMesg(Mesg mesg) : base(mesg)
+		{
+		}
+		#endregion // Constructors
 
-        #region Methods
-        ///<summary>
-        /// Retrieves the MessageIndex field</summary>
-        /// <returns>Returns nullable ushort representing the MessageIndex field</returns>
-        public ushort? GetMessageIndex()
-        {
-            Object val = GetFieldValue(254, 0, Fit.SubfieldIndexMainField);
-            if(val == null)
-            {
-                return null;
-            }
+		#region Methods
+		///<summary>
+		/// Retrieves the MessageIndex field</summary>
+		/// <returns>Returns nullable ushort representing the MessageIndex field</returns>
+		public ushort? MessageIndex
+		{
+			get
+			{
+				Object val = GetFieldValue(254, 0, Fit.SubfieldIndexMainField);
+				if (val == null)
+				{
+					return null;
+				}
 
-            return (Convert.ToUInt16(val));
-            
-        }
+				return (Convert.ToUInt16(val));
 
-        /// <summary>
-        /// Set MessageIndex field</summary>
-        /// <param name="messageIndex_">Nullable field value to be set</param>
-        public void SetMessageIndex(ushort? messageIndex_)
-        {
-            SetFieldValue(254, 0, messageIndex_, Fit.SubfieldIndexMainField);
-        }
-        
-        ///<summary>
-        /// Retrieves the File field</summary>
-        /// <returns>Returns nullable File enum representing the File field</returns>
-        public File? GetFile()
-        {
-            object obj = GetFieldValue(0, 0, Fit.SubfieldIndexMainField);
-            File? value = obj == null ? (File?)null : (File)obj;
-            return value;
-        }
+			}
+			set
+			{
+				SetFieldValue(254, 0, value, Fit.SubfieldIndexMainField);
+			}
+		}
 
-        /// <summary>
-        /// Set File field</summary>
-        /// <param name="file_">Nullable field value to be set</param>
-        public void SetFile(File? file_)
-        {
-            SetFieldValue(0, 0, file_, Fit.SubfieldIndexMainField);
-        }
-        
-        ///<summary>
-        /// Retrieves the MesgNum field</summary>
-        /// <returns>Returns nullable ushort representing the MesgNum field</returns>
-        public ushort? GetMesgNum()
-        {
-            Object val = GetFieldValue(1, 0, Fit.SubfieldIndexMainField);
-            if(val == null)
-            {
-                return null;
-            }
+		///<summary>
+		/// Retrieves the File field</summary>
+		/// <returns>Returns nullable File enum representing the File field</returns>
+		public File? File
+		{
+			get
+			{
+				object obj = GetFieldValue(0, 0, Fit.SubfieldIndexMainField);
+				File? value = obj == null ? (File?)null : (File)obj;
+				return value;
+			}
+			set
+			{
+				SetFieldValue(0, 0, value, Fit.SubfieldIndexMainField);
+			}
+		}
 
-            return (Convert.ToUInt16(val));
-            
-        }
+		///<summary>
+		/// Retrieves the MesgNum field</summary>
+		/// <returns>Returns nullable ushort representing the MesgNum field</returns>
+		public ushort? MesgNum
+		{
+			get
+			{
+				Object val = GetFieldValue(1, 0, Fit.SubfieldIndexMainField);
+				if (val == null)
+				{
+					return null;
+				}
 
-        /// <summary>
-        /// Set MesgNum field</summary>
-        /// <param name="mesgNum_">Nullable field value to be set</param>
-        public void SetMesgNum(ushort? mesgNum_)
-        {
-            SetFieldValue(1, 0, mesgNum_, Fit.SubfieldIndexMainField);
-        }
-        
-        ///<summary>
-        /// Retrieves the CountType field</summary>
-        /// <returns>Returns nullable MesgCount enum representing the CountType field</returns>
-        public MesgCount? GetCountType()
-        {
-            object obj = GetFieldValue(2, 0, Fit.SubfieldIndexMainField);
-            MesgCount? value = obj == null ? (MesgCount?)null : (MesgCount)obj;
-            return value;
-        }
+				return (Convert.ToUInt16(val));
 
-        /// <summary>
-        /// Set CountType field</summary>
-        /// <param name="countType_">Nullable field value to be set</param>
-        public void SetCountType(MesgCount? countType_)
-        {
-            SetFieldValue(2, 0, countType_, Fit.SubfieldIndexMainField);
-        }
-        
-        ///<summary>
-        /// Retrieves the Count field</summary>
-        /// <returns>Returns nullable ushort representing the Count field</returns>
-        public ushort? GetCount()
-        {
-            Object val = GetFieldValue(3, 0, Fit.SubfieldIndexMainField);
-            if(val == null)
-            {
-                return null;
-            }
+			}
+			set
+			{
+				SetFieldValue(1, 0, value, Fit.SubfieldIndexMainField);
+			}
+		}
 
-            return (Convert.ToUInt16(val));
-            
-        }
+		///<summary>
+		/// Retrieves the CountType field</summary>
+		/// <returns>Returns nullable MesgCount enum representing the CountType field</returns>
+		public MesgCount? CountType
+		{
+			get
+			{
+				object obj = GetFieldValue(2, 0, Fit.SubfieldIndexMainField);
+				MesgCount? value = obj == null ? (MesgCount?)null : (MesgCount)obj;
+				return value;
+			}
+			set
+			{
+				SetFieldValue(2, 0, value, Fit.SubfieldIndexMainField);
+			}
+		}
 
-        /// <summary>
-        /// Set Count field</summary>
-        /// <param name="count_">Nullable field value to be set</param>
-        public void SetCount(ushort? count_)
-        {
-            SetFieldValue(3, 0, count_, Fit.SubfieldIndexMainField);
-        }
-        
+		///<summary>
+		/// Retrieves the Count field</summary>
+		/// <returns>Returns nullable ushort representing the Count field</returns>
+		public ushort? Count
+		{
+			get
+			{
+				Object val = GetFieldValue(3, 0, Fit.SubfieldIndexMainField);
+				if (val == null)
+				{
+					return null;
+				}
 
-        /// <summary>
-        /// Retrieves the NumPerFile subfield</summary>
-        /// <returns>Nullable ushort representing the NumPerFile subfield</returns>
-        public ushort? GetNumPerFile()
-        {
-            Object val = GetFieldValue(3, 0, CountSubfield.NumPerFile);
-            if(val == null)
-            {
-                return null;
-            }
+				return (Convert.ToUInt16(val));
 
-            return (Convert.ToUInt16(val));
-            
-        }
+			}
+			set
+			{
+				SetFieldValue(3, 0, value, Fit.SubfieldIndexMainField);
+			}
+		}
 
-        /// <summary>
-        ///
-        /// Set NumPerFile subfield</summary>
-        /// <param name="numPerFile">Subfield value to be set</param>
-        public void SetNumPerFile(ushort? numPerFile)
-        {
-            SetFieldValue(3, 0, numPerFile, CountSubfield.NumPerFile);
-        }
 
-        /// <summary>
-        /// Retrieves the MaxPerFile subfield</summary>
-        /// <returns>Nullable ushort representing the MaxPerFile subfield</returns>
-        public ushort? GetMaxPerFile()
-        {
-            Object val = GetFieldValue(3, 0, CountSubfield.MaxPerFile);
-            if(val == null)
-            {
-                return null;
-            }
+		/// <summary>
+		/// Retrieves the NumPerFile subfield</summary>
+		/// <returns>Nullable ushort representing the NumPerFile subfield</returns>
+		public ushort? NumPerFile
+		{
+			get
+			{
+				Object val = GetFieldValue(3, 0, CountSubfield.NumPerFile);
+				if (val == null)
+				{
+					return null;
+				}
 
-            return (Convert.ToUInt16(val));
-            
-        }
+				return (Convert.ToUInt16(val));
 
-        /// <summary>
-        ///
-        /// Set MaxPerFile subfield</summary>
-        /// <param name="maxPerFile">Subfield value to be set</param>
-        public void SetMaxPerFile(ushort? maxPerFile)
-        {
-            SetFieldValue(3, 0, maxPerFile, CountSubfield.MaxPerFile);
-        }
+			}
+			set
+			{
+				SetFieldValue(3, 0, value, CountSubfield.NumPerFile);
+			}
+		}
 
-        /// <summary>
-        /// Retrieves the MaxPerFileType subfield</summary>
-        /// <returns>Nullable ushort representing the MaxPerFileType subfield</returns>
-        public ushort? GetMaxPerFileType()
-        {
-            Object val = GetFieldValue(3, 0, CountSubfield.MaxPerFileType);
-            if(val == null)
-            {
-                return null;
-            }
+		/// <summary>
+		/// Retrieves the MaxPerFile subfield</summary>
+		/// <returns>Nullable ushort representing the MaxPerFile subfield</returns>
+		public ushort? MaxPerFile
+		{
+			get
+			{
+				Object val = GetFieldValue(3, 0, CountSubfield.MaxPerFile);
+				if (val == null)
+				{
+					return null;
+				}
 
-            return (Convert.ToUInt16(val));
-            
-        }
+				return (Convert.ToUInt16(val));
 
-        /// <summary>
-        ///
-        /// Set MaxPerFileType subfield</summary>
-        /// <param name="maxPerFileType">Subfield value to be set</param>
-        public void SetMaxPerFileType(ushort? maxPerFileType)
-        {
-            SetFieldValue(3, 0, maxPerFileType, CountSubfield.MaxPerFileType);
-        }
-        #endregion // Methods
-    } // Class
+			}
+			set
+			{
+				SetFieldValue(3, 0, value, CountSubfield.MaxPerFile);
+			}
+		}
+
+		/// <summary>
+		/// Retrieves the MaxPerFileType subfield</summary>
+		/// <returns>Nullable ushort representing the MaxPerFileType subfield</returns>
+		public ushort? MaxPerFileType
+		{
+			get
+			{
+				Object val = GetFieldValue(3, 0, CountSubfield.MaxPerFileType);
+				if (val == null)
+				{
+					return null;
+				}
+
+				return (Convert.ToUInt16(val));
+
+			}
+			set
+			{
+				SetFieldValue(3, 0, value, CountSubfield.MaxPerFileType);
+			}
+		}
+		#endregion // Methods
+	} // Class
 } // namespace

--- a/Dynastream/Fit/Profile/Mesgs/MetZoneMesg.cs
+++ b/Dynastream/Fit/Profile/Mesgs/MetZoneMesg.cs
@@ -21,133 +21,127 @@ using System.Linq;
 
 namespace Dynastream.Fit
 {
-    /// <summary>
-    /// Implements the MetZone profile message.
-    /// </summary>
-    public class MetZoneMesg : Mesg
-    {
-        #region Fields
-        #endregion
+	/// <summary>
+	/// Implements the MetZone profile message.
+	/// </summary>
+	public class MetZoneMesg : Mesg
+	{
+		#region Fields
+		#endregion
 
-        /// <summary>
-        /// Field Numbers for <see cref="MetZoneMesg"/>
-        /// </summary>
-        public sealed class FieldDefNum
-        {
-            public const byte MessageIndex = 254;
-            public const byte HighBpm = 1;
-            public const byte Calories = 2;
-            public const byte FatCalories = 3;
-            public const byte Invalid = Fit.FieldNumInvalid;
-        }
+		/// <summary>
+		/// Field Numbers for <see cref="MetZoneMesg"/>
+		/// </summary>
+		public sealed class FieldDefNum
+		{
+			public const byte MessageIndex = 254;
+			public const byte HighBpm = 1;
+			public const byte Calories = 2;
+			public const byte FatCalories = 3;
+			public const byte Invalid = Fit.FieldNumInvalid;
+		}
 
-        #region Constructors
-        public MetZoneMesg() : base(Profile.GetMesg(MesgNum.MetZone))
-        {
-        }
+		#region Constructors
+		public MetZoneMesg() : base(Profile.GetMesg(MesgNum.MetZone))
+		{
+		}
 
-        public MetZoneMesg(Mesg mesg) : base(mesg)
-        {
-        }
-        #endregion // Constructors
+		public MetZoneMesg(Mesg mesg) : base(mesg)
+		{
+		}
+		#endregion // Constructors
 
-        #region Methods
-        ///<summary>
-        /// Retrieves the MessageIndex field</summary>
-        /// <returns>Returns nullable ushort representing the MessageIndex field</returns>
-        public ushort? GetMessageIndex()
-        {
-            Object val = GetFieldValue(254, 0, Fit.SubfieldIndexMainField);
-            if(val == null)
-            {
-                return null;
-            }
+		#region Methods
+		///<summary>
+		/// Retrieves the MessageIndex field</summary>
+		/// <returns>Returns nullable ushort representing the MessageIndex field</returns>
+		public ushort? MessageIndex
+		{
+			get
+			{
+				Object val = GetFieldValue(254, 0, Fit.SubfieldIndexMainField);
+				if (val == null)
+				{
+					return null;
+				}
 
-            return (Convert.ToUInt16(val));
-            
-        }
+				return (Convert.ToUInt16(val));
 
-        /// <summary>
-        /// Set MessageIndex field</summary>
-        /// <param name="messageIndex_">Nullable field value to be set</param>
-        public void SetMessageIndex(ushort? messageIndex_)
-        {
-            SetFieldValue(254, 0, messageIndex_, Fit.SubfieldIndexMainField);
-        }
-        
-        ///<summary>
-        /// Retrieves the HighBpm field</summary>
-        /// <returns>Returns nullable byte representing the HighBpm field</returns>
-        public byte? GetHighBpm()
-        {
-            Object val = GetFieldValue(1, 0, Fit.SubfieldIndexMainField);
-            if(val == null)
-            {
-                return null;
-            }
+			}
+			set
+			{
+				SetFieldValue(254, 0, value, Fit.SubfieldIndexMainField);
+			}
+		}
 
-            return (Convert.ToByte(val));
-            
-        }
+		///<summary>
+		/// Retrieves the HighBpm field</summary>
+		/// <returns>Returns nullable byte representing the HighBpm field</returns>
+		public byte? HighBpm
+		{
+			get
+			{
+				Object val = GetFieldValue(1, 0, Fit.SubfieldIndexMainField);
+				if (val == null)
+				{
+					return null;
+				}
 
-        /// <summary>
-        /// Set HighBpm field</summary>
-        /// <param name="highBpm_">Nullable field value to be set</param>
-        public void SetHighBpm(byte? highBpm_)
-        {
-            SetFieldValue(1, 0, highBpm_, Fit.SubfieldIndexMainField);
-        }
-        
-        ///<summary>
-        /// Retrieves the Calories field
-        /// Units: kcal / min</summary>
-        /// <returns>Returns nullable float representing the Calories field</returns>
-        public float? GetCalories()
-        {
-            Object val = GetFieldValue(2, 0, Fit.SubfieldIndexMainField);
-            if(val == null)
-            {
-                return null;
-            }
+				return (Convert.ToByte(val));
 
-            return (Convert.ToSingle(val));
-            
-        }
+			}
+			set
+			{
+				SetFieldValue(1, 0, value, Fit.SubfieldIndexMainField);
+			}
+		}
 
-        /// <summary>
-        /// Set Calories field
-        /// Units: kcal / min</summary>
-        /// <param name="calories_">Nullable field value to be set</param>
-        public void SetCalories(float? calories_)
-        {
-            SetFieldValue(2, 0, calories_, Fit.SubfieldIndexMainField);
-        }
-        
-        ///<summary>
-        /// Retrieves the FatCalories field
-        /// Units: kcal / min</summary>
-        /// <returns>Returns nullable float representing the FatCalories field</returns>
-        public float? GetFatCalories()
-        {
-            Object val = GetFieldValue(3, 0, Fit.SubfieldIndexMainField);
-            if(val == null)
-            {
-                return null;
-            }
+		///<summary>
+		/// Retrieves the Calories field
+		/// Units: kcal / min</summary>
+		/// <returns>Returns nullable float representing the Calories field</returns>
+		public float? Calories
+		{
+			get
+			{
+				Object val = GetFieldValue(2, 0, Fit.SubfieldIndexMainField);
+				if (val == null)
+				{
+					return null;
+				}
 
-            return (Convert.ToSingle(val));
-            
-        }
+				return (Convert.ToSingle(val));
 
-        /// <summary>
-        /// Set FatCalories field
-        /// Units: kcal / min</summary>
-        /// <param name="fatCalories_">Nullable field value to be set</param>
-        public void SetFatCalories(float? fatCalories_)
-        {
-            SetFieldValue(3, 0, fatCalories_, Fit.SubfieldIndexMainField);
-        }
-        
-        #endregion // Methods
-    } // Class
+			}
+			set
+			{
+				SetFieldValue(2, 0, value, Fit.SubfieldIndexMainField);
+			}
+		}
+
+		///<summary>
+		/// Retrieves the FatCalories field
+		/// Units: kcal / min</summary>
+		/// <returns>Returns nullable float representing the FatCalories field</returns>
+		public float? FatCalories
+		{
+			get
+			{
+				Object val = GetFieldValue(3, 0, Fit.SubfieldIndexMainField);
+				if (val == null)
+				{
+					return null;
+				}
+
+				return (Convert.ToSingle(val));
+
+			}
+			set
+			{
+				SetFieldValue(3, 0, value, Fit.SubfieldIndexMainField);
+			}
+		}
+
+		#endregion // Methods
+	} // Class
 } // namespace

--- a/Dynastream/Fit/Profile/Mesgs/MonitoringHrDataMesg.cs
+++ b/Dynastream/Fit/Profile/Mesgs/MonitoringHrDataMesg.cs
@@ -21,117 +21,108 @@ using System.Linq;
 
 namespace Dynastream.Fit
 {
-    /// <summary>
-    /// Implements the MonitoringHrData profile message.
-    /// </summary>
-    public class MonitoringHrDataMesg : Mesg
-    {
-        #region Fields
-        #endregion
+	/// <summary>
+	/// Implements the MonitoringHrData profile message.
+	/// </summary>
+	public class MonitoringHrDataMesg : Mesg
+	{
+		#region Fields
+		#endregion
 
-        /// <summary>
-        /// Field Numbers for <see cref="MonitoringHrDataMesg"/>
-        /// </summary>
-        public sealed class FieldDefNum
-        {
-            public const byte Timestamp = 253;
-            public const byte RestingHeartRate = 0;
-            public const byte CurrentDayRestingHeartRate = 1;
-            public const byte Invalid = Fit.FieldNumInvalid;
-        }
+		/// <summary>
+		/// Field Numbers for <see cref="MonitoringHrDataMesg"/>
+		/// </summary>
+		public sealed class FieldDefNum
+		{
+			public const byte Timestamp = 253;
+			public const byte RestingHeartRate = 0;
+			public const byte CurrentDayRestingHeartRate = 1;
+			public const byte Invalid = Fit.FieldNumInvalid;
+		}
 
-        #region Constructors
-        public MonitoringHrDataMesg() : base(Profile.GetMesg(MesgNum.MonitoringHrData))
-        {
-        }
+		#region Constructors
+		public MonitoringHrDataMesg() : base(Profile.GetMesg(MesgNum.MonitoringHrData))
+		{
+		}
 
-        public MonitoringHrDataMesg(Mesg mesg) : base(mesg)
-        {
-        }
-        #endregion // Constructors
+		public MonitoringHrDataMesg(Mesg mesg) : base(mesg)
+		{
+		}
+		#endregion // Constructors
 
-        #region Methods
-        ///<summary>
-        /// Retrieves the Timestamp field
-        /// Units: s
-        /// Comment: Must align to logging interval, for example, time must be 00:00:00 for daily log.</summary>
-        /// <returns>Returns DateTime representing the Timestamp field</returns>
-        public DateTime GetTimestamp()
-        {
-            Object val = GetFieldValue(253, 0, Fit.SubfieldIndexMainField);
-            if(val == null)
-            {
-                return null;
-            }
+		#region Methods
+		///<summary>
+		/// Retrieves the Timestamp field
+		/// Units: s
+		/// Comment: Must align to logging interval, for example, time must be 00:00:00 for daily log.</summary>
+		/// <returns>Returns DateTime representing the Timestamp field</returns>
+		public DateTime Timestamp
+		{
+			get
+			{
+				Object val = GetFieldValue(253, 0, Fit.SubfieldIndexMainField);
+				if (val == null)
+				{
+					return null;
+				}
 
-            return TimestampToDateTime(Convert.ToUInt32(val));
-            
-        }
+				return TimestampToDateTime(Convert.ToUInt32(val));
 
-        /// <summary>
-        /// Set Timestamp field
-        /// Units: s
-        /// Comment: Must align to logging interval, for example, time must be 00:00:00 for daily log.</summary>
-        /// <param name="timestamp_">Nullable field value to be set</param>
-        public void SetTimestamp(DateTime timestamp_)
-        {
-            SetFieldValue(253, 0, timestamp_.GetTimeStamp(), Fit.SubfieldIndexMainField);
-        }
-        
-        ///<summary>
-        /// Retrieves the RestingHeartRate field
-        /// Units: bpm
-        /// Comment: 7-day rolling average</summary>
-        /// <returns>Returns nullable byte representing the RestingHeartRate field</returns>
-        public byte? GetRestingHeartRate()
-        {
-            Object val = GetFieldValue(0, 0, Fit.SubfieldIndexMainField);
-            if(val == null)
-            {
-                return null;
-            }
+			}
+			set
+			{
+				SetFieldValue(253, 0, value.GetTimeStamp(), Fit.SubfieldIndexMainField);
+			}
+		}
 
-            return (Convert.ToByte(val));
-            
-        }
+		///<summary>
+		/// Retrieves the RestingHeartRate field
+		/// Units: bpm
+		/// Comment: 7-day rolling average</summary>
+		/// <returns>Returns nullable byte representing the RestingHeartRate field</returns>
+		public byte? RestingHeartRate
+		{
+			get
+			{
+				Object val = GetFieldValue(0, 0, Fit.SubfieldIndexMainField);
+				if (val == null)
+				{
+					return null;
+				}
 
-        /// <summary>
-        /// Set RestingHeartRate field
-        /// Units: bpm
-        /// Comment: 7-day rolling average</summary>
-        /// <param name="restingHeartRate_">Nullable field value to be set</param>
-        public void SetRestingHeartRate(byte? restingHeartRate_)
-        {
-            SetFieldValue(0, 0, restingHeartRate_, Fit.SubfieldIndexMainField);
-        }
-        
-        ///<summary>
-        /// Retrieves the CurrentDayRestingHeartRate field
-        /// Units: bpm
-        /// Comment: RHR for today only. (Feeds into 7-day average)</summary>
-        /// <returns>Returns nullable byte representing the CurrentDayRestingHeartRate field</returns>
-        public byte? GetCurrentDayRestingHeartRate()
-        {
-            Object val = GetFieldValue(1, 0, Fit.SubfieldIndexMainField);
-            if(val == null)
-            {
-                return null;
-            }
+				return (Convert.ToByte(val));
 
-            return (Convert.ToByte(val));
-            
-        }
+			}
+			set
+			{
+				SetFieldValue(0, 0, value, Fit.SubfieldIndexMainField);
+			}
+		}
 
-        /// <summary>
-        /// Set CurrentDayRestingHeartRate field
-        /// Units: bpm
-        /// Comment: RHR for today only. (Feeds into 7-day average)</summary>
-        /// <param name="currentDayRestingHeartRate_">Nullable field value to be set</param>
-        public void SetCurrentDayRestingHeartRate(byte? currentDayRestingHeartRate_)
-        {
-            SetFieldValue(1, 0, currentDayRestingHeartRate_, Fit.SubfieldIndexMainField);
-        }
-        
-        #endregion // Methods
-    } // Class
+		///<summary>
+		/// Retrieves the CurrentDayRestingHeartRate field
+		/// Units: bpm
+		/// Comment: RHR for today only. (Feeds into 7-day average)</summary>
+		/// <returns>Returns nullable byte representing the CurrentDayRestingHeartRate field</returns>
+		public byte? CurrentDayRestingHeartRate
+		{
+			get
+			{
+				Object val = GetFieldValue(1, 0, Fit.SubfieldIndexMainField);
+				if (val == null)
+				{
+					return null;
+				}
+
+				return (Convert.ToByte(val));
+
+			}
+			set
+			{
+				SetFieldValue(1, 0, value, Fit.SubfieldIndexMainField);
+			}
+		}
+
+		#endregion // Methods
+	} // Class
 } // namespace

--- a/Dynastream/Fit/Profile/Mesgs/MonitoringInfoMesg.cs
+++ b/Dynastream/Fit/Profile/Mesgs/MonitoringInfoMesg.cs
@@ -21,224 +21,217 @@ using System.Linq;
 
 namespace Dynastream.Fit
 {
-    /// <summary>
-    /// Implements the MonitoringInfo profile message.
-    /// </summary>
-    public class MonitoringInfoMesg : Mesg
-    {
-        #region Fields
-        #endregion
+	/// <summary>
+	/// Implements the MonitoringInfo profile message.
+	/// </summary>
+	public class MonitoringInfoMesg : Mesg
+	{
+		#region Fields
+		#endregion
 
-        /// <summary>
-        /// Field Numbers for <see cref="MonitoringInfoMesg"/>
-        /// </summary>
-        public sealed class FieldDefNum
-        {
-            public const byte Timestamp = 253;
-            public const byte LocalTimestamp = 0;
-            public const byte ActivityType = 1;
-            public const byte CyclesToDistance = 3;
-            public const byte CyclesToCalories = 4;
-            public const byte RestingMetabolicRate = 5;
-            public const byte Invalid = Fit.FieldNumInvalid;
-        }
+		/// <summary>
+		/// Field Numbers for <see cref="MonitoringInfoMesg"/>
+		/// </summary>
+		public sealed class FieldDefNum
+		{
+			public const byte Timestamp = 253;
+			public const byte LocalTimestamp = 0;
+			public const byte ActivityType = 1;
+			public const byte CyclesToDistance = 3;
+			public const byte CyclesToCalories = 4;
+			public const byte RestingMetabolicRate = 5;
+			public const byte Invalid = Fit.FieldNumInvalid;
+		}
 
-        #region Constructors
-        public MonitoringInfoMesg() : base(Profile.GetMesg(MesgNum.MonitoringInfo))
-        {
-        }
+		#region Constructors
+		public MonitoringInfoMesg() : base(Profile.GetMesg(MesgNum.MonitoringInfo))
+		{
+		}
 
-        public MonitoringInfoMesg(Mesg mesg) : base(mesg)
-        {
-        }
-        #endregion // Constructors
+		public MonitoringInfoMesg(Mesg mesg) : base(mesg)
+		{
+		}
+		#endregion // Constructors
 
-        #region Methods
-        ///<summary>
-        /// Retrieves the Timestamp field
-        /// Units: s</summary>
-        /// <returns>Returns DateTime representing the Timestamp field</returns>
-        public DateTime GetTimestamp()
-        {
-            Object val = GetFieldValue(253, 0, Fit.SubfieldIndexMainField);
-            if(val == null)
-            {
-                return null;
-            }
+		#region Methods
+		///<summary>
+		/// Retrieves the Timestamp field
+		/// Units: s</summary>
+		/// <returns>Returns DateTime representing the Timestamp field</returns>
+		public DateTime Timestamp
+		{
+			get
+			{
+				Object val = GetFieldValue(253, 0, Fit.SubfieldIndexMainField);
+				if (val == null)
+				{
+					return null;
+				}
 
-            return TimestampToDateTime(Convert.ToUInt32(val));
-            
-        }
+				return TimestampToDateTime(Convert.ToUInt32(val));
 
-        /// <summary>
-        /// Set Timestamp field
-        /// Units: s</summary>
-        /// <param name="timestamp_">Nullable field value to be set</param>
-        public void SetTimestamp(DateTime timestamp_)
-        {
-            SetFieldValue(253, 0, timestamp_.GetTimeStamp(), Fit.SubfieldIndexMainField);
-        }
-        
-        ///<summary>
-        /// Retrieves the LocalTimestamp field
-        /// Units: s
-        /// Comment: Use to convert activity timestamps to local time if device does not support time zone and daylight savings time correction.</summary>
-        /// <returns>Returns nullable uint representing the LocalTimestamp field</returns>
-        public uint? GetLocalTimestamp()
-        {
-            Object val = GetFieldValue(0, 0, Fit.SubfieldIndexMainField);
-            if(val == null)
-            {
-                return null;
-            }
+			}
+			set
+			{
+				SetFieldValue(253, 0, value.GetTimeStamp(), Fit.SubfieldIndexMainField);
+			}
+		}
 
-            return (Convert.ToUInt32(val));
-            
-        }
+		///<summary>
+		/// Retrieves the LocalTimestamp field
+		/// Units: s
+		/// Comment: Use to convert activity timestamps to local time if device does not support time zone and daylight savings time correction.</summary>
+		/// <returns>Returns nullable uint representing the LocalTimestamp field</returns>
+		public uint? LocalTimestamp
+		{
+			get
+			{
+				Object val = GetFieldValue(0, 0, Fit.SubfieldIndexMainField);
+				if (val == null)
+				{
+					return null;
+				}
 
-        /// <summary>
-        /// Set LocalTimestamp field
-        /// Units: s
-        /// Comment: Use to convert activity timestamps to local time if device does not support time zone and daylight savings time correction.</summary>
-        /// <param name="localTimestamp_">Nullable field value to be set</param>
-        public void SetLocalTimestamp(uint? localTimestamp_)
-        {
-            SetFieldValue(0, 0, localTimestamp_, Fit.SubfieldIndexMainField);
-        }
-        
-        
-        /// <summary>
-        ///
-        /// </summary>
-        /// <returns>returns number of elements in field ActivityType</returns>
-        public int GetNumActivityType()
-        {
-            return GetNumFieldValues(1, Fit.SubfieldIndexMainField);
-        }
+				return (Convert.ToUInt32(val));
 
-        ///<summary>
-        /// Retrieves the ActivityType field</summary>
-        /// <param name="index">0 based index of ActivityType element to retrieve</param>
-        /// <returns>Returns nullable ActivityType enum representing the ActivityType field</returns>
-        public ActivityType? GetActivityType(int index)
-        {
-            object obj = GetFieldValue(1, index, Fit.SubfieldIndexMainField);
-            ActivityType? value = obj == null ? (ActivityType?)null : (ActivityType)obj;
-            return value;
-        }
+			}
+			set
+			{
+				SetFieldValue(0, 0, value, Fit.SubfieldIndexMainField);
+			}
+		}
 
-        /// <summary>
-        /// Set ActivityType field</summary>
-        /// <param name="index">0 based index of activity_type</param>
-        /// <param name="activityType_">Nullable field value to be set</param>
-        public void SetActivityType(int index, ActivityType? activityType_)
-        {
-            SetFieldValue(1, index, activityType_, Fit.SubfieldIndexMainField);
-        }
-        
-        
-        /// <summary>
-        ///
-        /// </summary>
-        /// <returns>returns number of elements in field CyclesToDistance</returns>
-        public int GetNumCyclesToDistance()
-        {
-            return GetNumFieldValues(3, Fit.SubfieldIndexMainField);
-        }
 
-        ///<summary>
-        /// Retrieves the CyclesToDistance field
-        /// Units: m/cycle
-        /// Comment: Indexed by activity_type</summary>
-        /// <param name="index">0 based index of CyclesToDistance element to retrieve</param>
-        /// <returns>Returns nullable float representing the CyclesToDistance field</returns>
-        public float? GetCyclesToDistance(int index)
-        {
-            Object val = GetFieldValue(3, index, Fit.SubfieldIndexMainField);
-            if(val == null)
-            {
-                return null;
-            }
+		/// <summary>
+		///
+		/// </summary>
+		/// <returns>returns number of elements in field ActivityType</returns>
+		public int GetNumActivityType()
+		{
+			return GetNumFieldValues(1, Fit.SubfieldIndexMainField);
+		}
 
-            return (Convert.ToSingle(val));
-            
-        }
+		///<summary>
+		/// Retrieves the ActivityType field</summary>
+		/// <param name="index">0 based index of ActivityType element to retrieve</param>
+		/// <returns>Returns nullable ActivityType enum representing the ActivityType field</returns>
+		public ActivityType? GetActivityType(int index)
+		{
+			object obj = GetFieldValue(1, index, Fit.SubfieldIndexMainField);
+			ActivityType? value = obj == null ? (ActivityType?)null : (ActivityType)obj;
+			return value;
+		}
 
-        /// <summary>
-        /// Set CyclesToDistance field
-        /// Units: m/cycle
-        /// Comment: Indexed by activity_type</summary>
-        /// <param name="index">0 based index of cycles_to_distance</param>
-        /// <param name="cyclesToDistance_">Nullable field value to be set</param>
-        public void SetCyclesToDistance(int index, float? cyclesToDistance_)
-        {
-            SetFieldValue(3, index, cyclesToDistance_, Fit.SubfieldIndexMainField);
-        }
-        
-        
-        /// <summary>
-        ///
-        /// </summary>
-        /// <returns>returns number of elements in field CyclesToCalories</returns>
-        public int GetNumCyclesToCalories()
-        {
-            return GetNumFieldValues(4, Fit.SubfieldIndexMainField);
-        }
+		/// <summary>
+		/// Set ActivityType field</summary>
+		/// <param name="index">0 based index of activity_type</param>
+		/// <param name="activityType_">Nullable field value to be set</param>
+		public void SetActivityType(int index, ActivityType? activityType_)
+		{
+			SetFieldValue(1, index, activityType_, Fit.SubfieldIndexMainField);
+		}
 
-        ///<summary>
-        /// Retrieves the CyclesToCalories field
-        /// Units: kcal/cycle
-        /// Comment: Indexed by activity_type</summary>
-        /// <param name="index">0 based index of CyclesToCalories element to retrieve</param>
-        /// <returns>Returns nullable float representing the CyclesToCalories field</returns>
-        public float? GetCyclesToCalories(int index)
-        {
-            Object val = GetFieldValue(4, index, Fit.SubfieldIndexMainField);
-            if(val == null)
-            {
-                return null;
-            }
 
-            return (Convert.ToSingle(val));
-            
-        }
+		/// <summary>
+		///
+		/// </summary>
+		/// <returns>returns number of elements in field CyclesToDistance</returns>
+		public int GetNumCyclesToDistance()
+		{
+			return GetNumFieldValues(3, Fit.SubfieldIndexMainField);
+		}
 
-        /// <summary>
-        /// Set CyclesToCalories field
-        /// Units: kcal/cycle
-        /// Comment: Indexed by activity_type</summary>
-        /// <param name="index">0 based index of cycles_to_calories</param>
-        /// <param name="cyclesToCalories_">Nullable field value to be set</param>
-        public void SetCyclesToCalories(int index, float? cyclesToCalories_)
-        {
-            SetFieldValue(4, index, cyclesToCalories_, Fit.SubfieldIndexMainField);
-        }
-        
-        ///<summary>
-        /// Retrieves the RestingMetabolicRate field
-        /// Units: kcal / day</summary>
-        /// <returns>Returns nullable ushort representing the RestingMetabolicRate field</returns>
-        public ushort? GetRestingMetabolicRate()
-        {
-            Object val = GetFieldValue(5, 0, Fit.SubfieldIndexMainField);
-            if(val == null)
-            {
-                return null;
-            }
+		///<summary>
+		/// Retrieves the CyclesToDistance field
+		/// Units: m/cycle
+		/// Comment: Indexed by activity_type</summary>
+		/// <param name="index">0 based index of CyclesToDistance element to retrieve</param>
+		/// <returns>Returns nullable float representing the CyclesToDistance field</returns>
+		public float? GetCyclesToDistance(int index)
+		{
+			Object val = GetFieldValue(3, index, Fit.SubfieldIndexMainField);
+			if (val == null)
+			{
+				return null;
+			}
 
-            return (Convert.ToUInt16(val));
-            
-        }
+			return (Convert.ToSingle(val));
 
-        /// <summary>
-        /// Set RestingMetabolicRate field
-        /// Units: kcal / day</summary>
-        /// <param name="restingMetabolicRate_">Nullable field value to be set</param>
-        public void SetRestingMetabolicRate(ushort? restingMetabolicRate_)
-        {
-            SetFieldValue(5, 0, restingMetabolicRate_, Fit.SubfieldIndexMainField);
-        }
-        
-        #endregion // Methods
-    } // Class
+		}
+
+		/// <summary>
+		/// Set CyclesToDistance field
+		/// Units: m/cycle
+		/// Comment: Indexed by activity_type</summary>
+		/// <param name="index">0 based index of cycles_to_distance</param>
+		/// <param name="cyclesToDistance_">Nullable field value to be set</param>
+		public void SetCyclesToDistance(int index, float? cyclesToDistance_)
+		{
+			SetFieldValue(3, index, cyclesToDistance_, Fit.SubfieldIndexMainField);
+		}
+
+
+		/// <summary>
+		///
+		/// </summary>
+		/// <returns>returns number of elements in field CyclesToCalories</returns>
+		public int GetNumCyclesToCalories()
+		{
+			return GetNumFieldValues(4, Fit.SubfieldIndexMainField);
+		}
+
+		///<summary>
+		/// Retrieves the CyclesToCalories field
+		/// Units: kcal/cycle
+		/// Comment: Indexed by activity_type</summary>
+		/// <param name="index">0 based index of CyclesToCalories element to retrieve</param>
+		/// <returns>Returns nullable float representing the CyclesToCalories field</returns>
+		public float? GetCyclesToCalories(int index)
+		{
+			Object val = GetFieldValue(4, index, Fit.SubfieldIndexMainField);
+			if (val == null)
+			{
+				return null;
+			}
+
+			return (Convert.ToSingle(val));
+
+		}
+
+		/// <summary>
+		/// Set CyclesToCalories field
+		/// Units: kcal/cycle
+		/// Comment: Indexed by activity_type</summary>
+		/// <param name="index">0 based index of cycles_to_calories</param>
+		/// <param name="cyclesToCalories_">Nullable field value to be set</param>
+		public void SetCyclesToCalories(int index, float? cyclesToCalories_)
+		{
+			SetFieldValue(4, index, cyclesToCalories_, Fit.SubfieldIndexMainField);
+		}
+
+		///<summary>
+		/// Retrieves the RestingMetabolicRate field
+		/// Units: kcal / day</summary>
+		/// <returns>Returns nullable ushort representing the RestingMetabolicRate field</returns>
+		public ushort? RestingMetabolicRate
+		{
+			get
+			{
+				Object val = GetFieldValue(5, 0, Fit.SubfieldIndexMainField);
+				if (val == null)
+				{
+					return null;
+				}
+
+				return (Convert.ToUInt16(val));
+
+			}
+			set
+			{
+				SetFieldValue(5, 0, value, Fit.SubfieldIndexMainField);
+			}
+		}
+
+		#endregion // Methods
+	} // Class
 } // namespace

--- a/Dynastream/Fit/Profile/Mesgs/MonitoringMesg.cs
+++ b/Dynastream/Fit/Profile/Mesgs/MonitoringMesg.cs
@@ -21,852 +21,787 @@ using System.Linq;
 
 namespace Dynastream.Fit
 {
-    /// <summary>
-    /// Implements the Monitoring profile message.
-    /// </summary>
-    public class MonitoringMesg : Mesg
-    {
-        #region Fields
-        static class CyclesSubfield
-        {
-            public static ushort Steps = 0;
-            public static ushort Strokes = 1;
-            public static ushort Subfields = 2;
-            public static ushort Active = Fit.SubfieldIndexActiveSubfield;
-            public static ushort MainField = Fit.SubfieldIndexMainField;
-        }
-        #endregion
-
-        /// <summary>
-        /// Field Numbers for <see cref="MonitoringMesg"/>
-        /// </summary>
-        public sealed class FieldDefNum
-        {
-            public const byte Timestamp = 253;
-            public const byte DeviceIndex = 0;
-            public const byte Calories = 1;
-            public const byte Distance = 2;
-            public const byte Cycles = 3;
-            public const byte ActiveTime = 4;
-            public const byte ActivityType = 5;
-            public const byte ActivitySubtype = 6;
-            public const byte ActivityLevel = 7;
-            public const byte Distance16 = 8;
-            public const byte Cycles16 = 9;
-            public const byte ActiveTime16 = 10;
-            public const byte LocalTimestamp = 11;
-            public const byte Temperature = 12;
-            public const byte TemperatureMin = 14;
-            public const byte TemperatureMax = 15;
-            public const byte ActivityTime = 16;
-            public const byte ActiveCalories = 19;
-            public const byte CurrentActivityTypeIntensity = 24;
-            public const byte TimestampMin8 = 25;
-            public const byte Timestamp16 = 26;
-            public const byte HeartRate = 27;
-            public const byte Intensity = 28;
-            public const byte DurationMin = 29;
-            public const byte Duration = 30;
-            public const byte Ascent = 31;
-            public const byte Descent = 32;
-            public const byte ModerateActivityMinutes = 33;
-            public const byte VigorousActivityMinutes = 34;
-            public const byte Invalid = Fit.FieldNumInvalid;
-        }
-
-        #region Constructors
-        public MonitoringMesg() : base(Profile.GetMesg(MesgNum.Monitoring))
-        {
-        }
-
-        public MonitoringMesg(Mesg mesg) : base(mesg)
-        {
-        }
-        #endregion // Constructors
-
-        #region Methods
-        ///<summary>
-        /// Retrieves the Timestamp field
-        /// Units: s
-        /// Comment: Must align to logging interval, for example, time must be 00:00:00 for daily log.</summary>
-        /// <returns>Returns DateTime representing the Timestamp field</returns>
-        public DateTime GetTimestamp()
-        {
-            Object val = GetFieldValue(253, 0, Fit.SubfieldIndexMainField);
-            if(val == null)
-            {
-                return null;
-            }
-
-            return TimestampToDateTime(Convert.ToUInt32(val));
-            
-        }
-
-        /// <summary>
-        /// Set Timestamp field
-        /// Units: s
-        /// Comment: Must align to logging interval, for example, time must be 00:00:00 for daily log.</summary>
-        /// <param name="timestamp_">Nullable field value to be set</param>
-        public void SetTimestamp(DateTime timestamp_)
-        {
-            SetFieldValue(253, 0, timestamp_.GetTimeStamp(), Fit.SubfieldIndexMainField);
-        }
-        
-        ///<summary>
-        /// Retrieves the DeviceIndex field
-        /// Comment: Associates this data to device_info message. Not required for file with single device (sensor).</summary>
-        /// <returns>Returns nullable byte representing the DeviceIndex field</returns>
-        public byte? GetDeviceIndex()
-        {
-            Object val = GetFieldValue(0, 0, Fit.SubfieldIndexMainField);
-            if(val == null)
-            {
-                return null;
-            }
-
-            return (Convert.ToByte(val));
-            
-        }
-
-        /// <summary>
-        /// Set DeviceIndex field
-        /// Comment: Associates this data to device_info message. Not required for file with single device (sensor).</summary>
-        /// <param name="deviceIndex_">Nullable field value to be set</param>
-        public void SetDeviceIndex(byte? deviceIndex_)
-        {
-            SetFieldValue(0, 0, deviceIndex_, Fit.SubfieldIndexMainField);
-        }
-        
-        ///<summary>
-        /// Retrieves the Calories field
-        /// Units: kcal
-        /// Comment: Accumulated total calories. Maintained by MonitoringReader for each activity_type. See SDK documentation</summary>
-        /// <returns>Returns nullable ushort representing the Calories field</returns>
-        public ushort? GetCalories()
-        {
-            Object val = GetFieldValue(1, 0, Fit.SubfieldIndexMainField);
-            if(val == null)
-            {
-                return null;
-            }
-
-            return (Convert.ToUInt16(val));
-            
-        }
-
-        /// <summary>
-        /// Set Calories field
-        /// Units: kcal
-        /// Comment: Accumulated total calories. Maintained by MonitoringReader for each activity_type. See SDK documentation</summary>
-        /// <param name="calories_">Nullable field value to be set</param>
-        public void SetCalories(ushort? calories_)
-        {
-            SetFieldValue(1, 0, calories_, Fit.SubfieldIndexMainField);
-        }
-        
-        ///<summary>
-        /// Retrieves the Distance field
-        /// Units: m
-        /// Comment: Accumulated distance. Maintained by MonitoringReader for each activity_type. See SDK documentation.</summary>
-        /// <returns>Returns nullable float representing the Distance field</returns>
-        public float? GetDistance()
-        {
-            Object val = GetFieldValue(2, 0, Fit.SubfieldIndexMainField);
-            if(val == null)
-            {
-                return null;
-            }
-
-            return (Convert.ToSingle(val));
-            
-        }
-
-        /// <summary>
-        /// Set Distance field
-        /// Units: m
-        /// Comment: Accumulated distance. Maintained by MonitoringReader for each activity_type. See SDK documentation.</summary>
-        /// <param name="distance_">Nullable field value to be set</param>
-        public void SetDistance(float? distance_)
-        {
-            SetFieldValue(2, 0, distance_, Fit.SubfieldIndexMainField);
-        }
-        
-        ///<summary>
-        /// Retrieves the Cycles field
-        /// Units: cycles
-        /// Comment: Accumulated cycles. Maintained by MonitoringReader for each activity_type. See SDK documentation.</summary>
-        /// <returns>Returns nullable float representing the Cycles field</returns>
-        public float? GetCycles()
-        {
-            Object val = GetFieldValue(3, 0, Fit.SubfieldIndexMainField);
-            if(val == null)
-            {
-                return null;
-            }
-
-            return (Convert.ToSingle(val));
-            
-        }
-
-        /// <summary>
-        /// Set Cycles field
-        /// Units: cycles
-        /// Comment: Accumulated cycles. Maintained by MonitoringReader for each activity_type. See SDK documentation.</summary>
-        /// <param name="cycles_">Nullable field value to be set</param>
-        public void SetCycles(float? cycles_)
-        {
-            SetFieldValue(3, 0, cycles_, Fit.SubfieldIndexMainField);
-        }
-        
-
-        /// <summary>
-        /// Retrieves the Steps subfield
-        /// Units: steps</summary>
-        /// <returns>Nullable uint representing the Steps subfield</returns>
-        public uint? GetSteps()
-        {
-            Object val = GetFieldValue(3, 0, CyclesSubfield.Steps);
-            if(val == null)
-            {
-                return null;
-            }
-
-            return (Convert.ToUInt32(val));
-            
-        }
-
-        /// <summary>
-        ///
-        /// Set Steps subfield
-        /// Units: steps</summary>
-        /// <param name="steps">Subfield value to be set</param>
-        public void SetSteps(uint? steps)
-        {
-            SetFieldValue(3, 0, steps, CyclesSubfield.Steps);
-        }
-
-        /// <summary>
-        /// Retrieves the Strokes subfield
-        /// Units: strokes</summary>
-        /// <returns>Nullable float representing the Strokes subfield</returns>
-        public float? GetStrokes()
-        {
-            Object val = GetFieldValue(3, 0, CyclesSubfield.Strokes);
-            if(val == null)
-            {
-                return null;
-            }
-
-            return (Convert.ToSingle(val));
-            
-        }
-
-        /// <summary>
-        ///
-        /// Set Strokes subfield
-        /// Units: strokes</summary>
-        /// <param name="strokes">Subfield value to be set</param>
-        public void SetStrokes(float? strokes)
-        {
-            SetFieldValue(3, 0, strokes, CyclesSubfield.Strokes);
-        }
-        ///<summary>
-        /// Retrieves the ActiveTime field
-        /// Units: s</summary>
-        /// <returns>Returns nullable float representing the ActiveTime field</returns>
-        public float? GetActiveTime()
-        {
-            Object val = GetFieldValue(4, 0, Fit.SubfieldIndexMainField);
-            if(val == null)
-            {
-                return null;
-            }
-
-            return (Convert.ToSingle(val));
-            
-        }
-
-        /// <summary>
-        /// Set ActiveTime field
-        /// Units: s</summary>
-        /// <param name="activeTime_">Nullable field value to be set</param>
-        public void SetActiveTime(float? activeTime_)
-        {
-            SetFieldValue(4, 0, activeTime_, Fit.SubfieldIndexMainField);
-        }
-        
-        ///<summary>
-        /// Retrieves the ActivityType field</summary>
-        /// <returns>Returns nullable ActivityType enum representing the ActivityType field</returns>
-        public ActivityType? GetActivityType()
-        {
-            object obj = GetFieldValue(5, 0, Fit.SubfieldIndexMainField);
-            ActivityType? value = obj == null ? (ActivityType?)null : (ActivityType)obj;
-            return value;
-        }
-
-        /// <summary>
-        /// Set ActivityType field</summary>
-        /// <param name="activityType_">Nullable field value to be set</param>
-        public void SetActivityType(ActivityType? activityType_)
-        {
-            SetFieldValue(5, 0, activityType_, Fit.SubfieldIndexMainField);
-        }
-        
-        ///<summary>
-        /// Retrieves the ActivitySubtype field</summary>
-        /// <returns>Returns nullable ActivitySubtype enum representing the ActivitySubtype field</returns>
-        public ActivitySubtype? GetActivitySubtype()
-        {
-            object obj = GetFieldValue(6, 0, Fit.SubfieldIndexMainField);
-            ActivitySubtype? value = obj == null ? (ActivitySubtype?)null : (ActivitySubtype)obj;
-            return value;
-        }
-
-        /// <summary>
-        /// Set ActivitySubtype field</summary>
-        /// <param name="activitySubtype_">Nullable field value to be set</param>
-        public void SetActivitySubtype(ActivitySubtype? activitySubtype_)
-        {
-            SetFieldValue(6, 0, activitySubtype_, Fit.SubfieldIndexMainField);
-        }
-        
-        ///<summary>
-        /// Retrieves the ActivityLevel field</summary>
-        /// <returns>Returns nullable ActivityLevel enum representing the ActivityLevel field</returns>
-        public ActivityLevel? GetActivityLevel()
-        {
-            object obj = GetFieldValue(7, 0, Fit.SubfieldIndexMainField);
-            ActivityLevel? value = obj == null ? (ActivityLevel?)null : (ActivityLevel)obj;
-            return value;
-        }
-
-        /// <summary>
-        /// Set ActivityLevel field</summary>
-        /// <param name="activityLevel_">Nullable field value to be set</param>
-        public void SetActivityLevel(ActivityLevel? activityLevel_)
-        {
-            SetFieldValue(7, 0, activityLevel_, Fit.SubfieldIndexMainField);
-        }
-        
-        ///<summary>
-        /// Retrieves the Distance16 field
-        /// Units: 100 * m</summary>
-        /// <returns>Returns nullable ushort representing the Distance16 field</returns>
-        public ushort? GetDistance16()
-        {
-            Object val = GetFieldValue(8, 0, Fit.SubfieldIndexMainField);
-            if(val == null)
-            {
-                return null;
-            }
-
-            return (Convert.ToUInt16(val));
-            
-        }
-
-        /// <summary>
-        /// Set Distance16 field
-        /// Units: 100 * m</summary>
-        /// <param name="distance16_">Nullable field value to be set</param>
-        public void SetDistance16(ushort? distance16_)
-        {
-            SetFieldValue(8, 0, distance16_, Fit.SubfieldIndexMainField);
-        }
-        
-        ///<summary>
-        /// Retrieves the Cycles16 field
-        /// Units: 2 * cycles (steps)</summary>
-        /// <returns>Returns nullable ushort representing the Cycles16 field</returns>
-        public ushort? GetCycles16()
-        {
-            Object val = GetFieldValue(9, 0, Fit.SubfieldIndexMainField);
-            if(val == null)
-            {
-                return null;
-            }
-
-            return (Convert.ToUInt16(val));
-            
-        }
-
-        /// <summary>
-        /// Set Cycles16 field
-        /// Units: 2 * cycles (steps)</summary>
-        /// <param name="cycles16_">Nullable field value to be set</param>
-        public void SetCycles16(ushort? cycles16_)
-        {
-            SetFieldValue(9, 0, cycles16_, Fit.SubfieldIndexMainField);
-        }
-        
-        ///<summary>
-        /// Retrieves the ActiveTime16 field
-        /// Units: s</summary>
-        /// <returns>Returns nullable ushort representing the ActiveTime16 field</returns>
-        public ushort? GetActiveTime16()
-        {
-            Object val = GetFieldValue(10, 0, Fit.SubfieldIndexMainField);
-            if(val == null)
-            {
-                return null;
-            }
-
-            return (Convert.ToUInt16(val));
-            
-        }
-
-        /// <summary>
-        /// Set ActiveTime16 field
-        /// Units: s</summary>
-        /// <param name="activeTime16_">Nullable field value to be set</param>
-        public void SetActiveTime16(ushort? activeTime16_)
-        {
-            SetFieldValue(10, 0, activeTime16_, Fit.SubfieldIndexMainField);
-        }
-        
-        ///<summary>
-        /// Retrieves the LocalTimestamp field
-        /// Comment: Must align to logging interval, for example, time must be 00:00:00 for daily log.</summary>
-        /// <returns>Returns nullable uint representing the LocalTimestamp field</returns>
-        public uint? GetLocalTimestamp()
-        {
-            Object val = GetFieldValue(11, 0, Fit.SubfieldIndexMainField);
-            if(val == null)
-            {
-                return null;
-            }
-
-            return (Convert.ToUInt32(val));
-            
-        }
-
-        /// <summary>
-        /// Set LocalTimestamp field
-        /// Comment: Must align to logging interval, for example, time must be 00:00:00 for daily log.</summary>
-        /// <param name="localTimestamp_">Nullable field value to be set</param>
-        public void SetLocalTimestamp(uint? localTimestamp_)
-        {
-            SetFieldValue(11, 0, localTimestamp_, Fit.SubfieldIndexMainField);
-        }
-        
-        ///<summary>
-        /// Retrieves the Temperature field
-        /// Units: C
-        /// Comment: Avg temperature during the logging interval ended at timestamp</summary>
-        /// <returns>Returns nullable float representing the Temperature field</returns>
-        public float? GetTemperature()
-        {
-            Object val = GetFieldValue(12, 0, Fit.SubfieldIndexMainField);
-            if(val == null)
-            {
-                return null;
-            }
-
-            return (Convert.ToSingle(val));
-            
-        }
-
-        /// <summary>
-        /// Set Temperature field
-        /// Units: C
-        /// Comment: Avg temperature during the logging interval ended at timestamp</summary>
-        /// <param name="temperature_">Nullable field value to be set</param>
-        public void SetTemperature(float? temperature_)
-        {
-            SetFieldValue(12, 0, temperature_, Fit.SubfieldIndexMainField);
-        }
-        
-        ///<summary>
-        /// Retrieves the TemperatureMin field
-        /// Units: C
-        /// Comment: Min temperature during the logging interval ended at timestamp</summary>
-        /// <returns>Returns nullable float representing the TemperatureMin field</returns>
-        public float? GetTemperatureMin()
-        {
-            Object val = GetFieldValue(14, 0, Fit.SubfieldIndexMainField);
-            if(val == null)
-            {
-                return null;
-            }
-
-            return (Convert.ToSingle(val));
-            
-        }
-
-        /// <summary>
-        /// Set TemperatureMin field
-        /// Units: C
-        /// Comment: Min temperature during the logging interval ended at timestamp</summary>
-        /// <param name="temperatureMin_">Nullable field value to be set</param>
-        public void SetTemperatureMin(float? temperatureMin_)
-        {
-            SetFieldValue(14, 0, temperatureMin_, Fit.SubfieldIndexMainField);
-        }
-        
-        ///<summary>
-        /// Retrieves the TemperatureMax field
-        /// Units: C
-        /// Comment: Max temperature during the logging interval ended at timestamp</summary>
-        /// <returns>Returns nullable float representing the TemperatureMax field</returns>
-        public float? GetTemperatureMax()
-        {
-            Object val = GetFieldValue(15, 0, Fit.SubfieldIndexMainField);
-            if(val == null)
-            {
-                return null;
-            }
-
-            return (Convert.ToSingle(val));
-            
-        }
-
-        /// <summary>
-        /// Set TemperatureMax field
-        /// Units: C
-        /// Comment: Max temperature during the logging interval ended at timestamp</summary>
-        /// <param name="temperatureMax_">Nullable field value to be set</param>
-        public void SetTemperatureMax(float? temperatureMax_)
-        {
-            SetFieldValue(15, 0, temperatureMax_, Fit.SubfieldIndexMainField);
-        }
-        
-        
-        /// <summary>
-        ///
-        /// </summary>
-        /// <returns>returns number of elements in field ActivityTime</returns>
-        public int GetNumActivityTime()
-        {
-            return GetNumFieldValues(16, Fit.SubfieldIndexMainField);
-        }
-
-        ///<summary>
-        /// Retrieves the ActivityTime field
-        /// Units: minutes
-        /// Comment: Indexed using minute_activity_level enum</summary>
-        /// <param name="index">0 based index of ActivityTime element to retrieve</param>
-        /// <returns>Returns nullable ushort representing the ActivityTime field</returns>
-        public ushort? GetActivityTime(int index)
-        {
-            Object val = GetFieldValue(16, index, Fit.SubfieldIndexMainField);
-            if(val == null)
-            {
-                return null;
-            }
-
-            return (Convert.ToUInt16(val));
-            
-        }
-
-        /// <summary>
-        /// Set ActivityTime field
-        /// Units: minutes
-        /// Comment: Indexed using minute_activity_level enum</summary>
-        /// <param name="index">0 based index of activity_time</param>
-        /// <param name="activityTime_">Nullable field value to be set</param>
-        public void SetActivityTime(int index, ushort? activityTime_)
-        {
-            SetFieldValue(16, index, activityTime_, Fit.SubfieldIndexMainField);
-        }
-        
-        ///<summary>
-        /// Retrieves the ActiveCalories field
-        /// Units: kcal</summary>
-        /// <returns>Returns nullable ushort representing the ActiveCalories field</returns>
-        public ushort? GetActiveCalories()
-        {
-            Object val = GetFieldValue(19, 0, Fit.SubfieldIndexMainField);
-            if(val == null)
-            {
-                return null;
-            }
-
-            return (Convert.ToUInt16(val));
-            
-        }
-
-        /// <summary>
-        /// Set ActiveCalories field
-        /// Units: kcal</summary>
-        /// <param name="activeCalories_">Nullable field value to be set</param>
-        public void SetActiveCalories(ushort? activeCalories_)
-        {
-            SetFieldValue(19, 0, activeCalories_, Fit.SubfieldIndexMainField);
-        }
-        
-        ///<summary>
-        /// Retrieves the CurrentActivityTypeIntensity field
-        /// Comment: Indicates single type / intensity for duration since last monitoring message.</summary>
-        /// <returns>Returns nullable byte representing the CurrentActivityTypeIntensity field</returns>
-        public byte? GetCurrentActivityTypeIntensity()
-        {
-            Object val = GetFieldValue(24, 0, Fit.SubfieldIndexMainField);
-            if(val == null)
-            {
-                return null;
-            }
-
-            return (Convert.ToByte(val));
-            
-        }
-
-        /// <summary>
-        /// Set CurrentActivityTypeIntensity field
-        /// Comment: Indicates single type / intensity for duration since last monitoring message.</summary>
-        /// <param name="currentActivityTypeIntensity_">Nullable field value to be set</param>
-        public void SetCurrentActivityTypeIntensity(byte? currentActivityTypeIntensity_)
-        {
-            SetFieldValue(24, 0, currentActivityTypeIntensity_, Fit.SubfieldIndexMainField);
-        }
-        
-        ///<summary>
-        /// Retrieves the TimestampMin8 field
-        /// Units: min</summary>
-        /// <returns>Returns nullable byte representing the TimestampMin8 field</returns>
-        public byte? GetTimestampMin8()
-        {
-            Object val = GetFieldValue(25, 0, Fit.SubfieldIndexMainField);
-            if(val == null)
-            {
-                return null;
-            }
-
-            return (Convert.ToByte(val));
-            
-        }
-
-        /// <summary>
-        /// Set TimestampMin8 field
-        /// Units: min</summary>
-        /// <param name="timestampMin8_">Nullable field value to be set</param>
-        public void SetTimestampMin8(byte? timestampMin8_)
-        {
-            SetFieldValue(25, 0, timestampMin8_, Fit.SubfieldIndexMainField);
-        }
-        
-        ///<summary>
-        /// Retrieves the Timestamp16 field
-        /// Units: s</summary>
-        /// <returns>Returns nullable ushort representing the Timestamp16 field</returns>
-        public ushort? GetTimestamp16()
-        {
-            Object val = GetFieldValue(26, 0, Fit.SubfieldIndexMainField);
-            if(val == null)
-            {
-                return null;
-            }
-
-            return (Convert.ToUInt16(val));
-            
-        }
-
-        /// <summary>
-        /// Set Timestamp16 field
-        /// Units: s</summary>
-        /// <param name="timestamp16_">Nullable field value to be set</param>
-        public void SetTimestamp16(ushort? timestamp16_)
-        {
-            SetFieldValue(26, 0, timestamp16_, Fit.SubfieldIndexMainField);
-        }
-        
-        ///<summary>
-        /// Retrieves the HeartRate field
-        /// Units: bpm</summary>
-        /// <returns>Returns nullable byte representing the HeartRate field</returns>
-        public byte? GetHeartRate()
-        {
-            Object val = GetFieldValue(27, 0, Fit.SubfieldIndexMainField);
-            if(val == null)
-            {
-                return null;
-            }
-
-            return (Convert.ToByte(val));
-            
-        }
-
-        /// <summary>
-        /// Set HeartRate field
-        /// Units: bpm</summary>
-        /// <param name="heartRate_">Nullable field value to be set</param>
-        public void SetHeartRate(byte? heartRate_)
-        {
-            SetFieldValue(27, 0, heartRate_, Fit.SubfieldIndexMainField);
-        }
-        
-        ///<summary>
-        /// Retrieves the Intensity field</summary>
-        /// <returns>Returns nullable float representing the Intensity field</returns>
-        public float? GetIntensity()
-        {
-            Object val = GetFieldValue(28, 0, Fit.SubfieldIndexMainField);
-            if(val == null)
-            {
-                return null;
-            }
-
-            return (Convert.ToSingle(val));
-            
-        }
-
-        /// <summary>
-        /// Set Intensity field</summary>
-        /// <param name="intensity_">Nullable field value to be set</param>
-        public void SetIntensity(float? intensity_)
-        {
-            SetFieldValue(28, 0, intensity_, Fit.SubfieldIndexMainField);
-        }
-        
-        ///<summary>
-        /// Retrieves the DurationMin field
-        /// Units: min</summary>
-        /// <returns>Returns nullable ushort representing the DurationMin field</returns>
-        public ushort? GetDurationMin()
-        {
-            Object val = GetFieldValue(29, 0, Fit.SubfieldIndexMainField);
-            if(val == null)
-            {
-                return null;
-            }
-
-            return (Convert.ToUInt16(val));
-            
-        }
-
-        /// <summary>
-        /// Set DurationMin field
-        /// Units: min</summary>
-        /// <param name="durationMin_">Nullable field value to be set</param>
-        public void SetDurationMin(ushort? durationMin_)
-        {
-            SetFieldValue(29, 0, durationMin_, Fit.SubfieldIndexMainField);
-        }
-        
-        ///<summary>
-        /// Retrieves the Duration field
-        /// Units: s</summary>
-        /// <returns>Returns nullable uint representing the Duration field</returns>
-        public uint? GetDuration()
-        {
-            Object val = GetFieldValue(30, 0, Fit.SubfieldIndexMainField);
-            if(val == null)
-            {
-                return null;
-            }
-
-            return (Convert.ToUInt32(val));
-            
-        }
-
-        /// <summary>
-        /// Set Duration field
-        /// Units: s</summary>
-        /// <param name="duration_">Nullable field value to be set</param>
-        public void SetDuration(uint? duration_)
-        {
-            SetFieldValue(30, 0, duration_, Fit.SubfieldIndexMainField);
-        }
-        
-        ///<summary>
-        /// Retrieves the Ascent field
-        /// Units: m</summary>
-        /// <returns>Returns nullable float representing the Ascent field</returns>
-        public float? GetAscent()
-        {
-            Object val = GetFieldValue(31, 0, Fit.SubfieldIndexMainField);
-            if(val == null)
-            {
-                return null;
-            }
-
-            return (Convert.ToSingle(val));
-            
-        }
-
-        /// <summary>
-        /// Set Ascent field
-        /// Units: m</summary>
-        /// <param name="ascent_">Nullable field value to be set</param>
-        public void SetAscent(float? ascent_)
-        {
-            SetFieldValue(31, 0, ascent_, Fit.SubfieldIndexMainField);
-        }
-        
-        ///<summary>
-        /// Retrieves the Descent field
-        /// Units: m</summary>
-        /// <returns>Returns nullable float representing the Descent field</returns>
-        public float? GetDescent()
-        {
-            Object val = GetFieldValue(32, 0, Fit.SubfieldIndexMainField);
-            if(val == null)
-            {
-                return null;
-            }
-
-            return (Convert.ToSingle(val));
-            
-        }
-
-        /// <summary>
-        /// Set Descent field
-        /// Units: m</summary>
-        /// <param name="descent_">Nullable field value to be set</param>
-        public void SetDescent(float? descent_)
-        {
-            SetFieldValue(32, 0, descent_, Fit.SubfieldIndexMainField);
-        }
-        
-        ///<summary>
-        /// Retrieves the ModerateActivityMinutes field
-        /// Units: minutes</summary>
-        /// <returns>Returns nullable ushort representing the ModerateActivityMinutes field</returns>
-        public ushort? GetModerateActivityMinutes()
-        {
-            Object val = GetFieldValue(33, 0, Fit.SubfieldIndexMainField);
-            if(val == null)
-            {
-                return null;
-            }
-
-            return (Convert.ToUInt16(val));
-            
-        }
-
-        /// <summary>
-        /// Set ModerateActivityMinutes field
-        /// Units: minutes</summary>
-        /// <param name="moderateActivityMinutes_">Nullable field value to be set</param>
-        public void SetModerateActivityMinutes(ushort? moderateActivityMinutes_)
-        {
-            SetFieldValue(33, 0, moderateActivityMinutes_, Fit.SubfieldIndexMainField);
-        }
-        
-        ///<summary>
-        /// Retrieves the VigorousActivityMinutes field
-        /// Units: minutes</summary>
-        /// <returns>Returns nullable ushort representing the VigorousActivityMinutes field</returns>
-        public ushort? GetVigorousActivityMinutes()
-        {
-            Object val = GetFieldValue(34, 0, Fit.SubfieldIndexMainField);
-            if(val == null)
-            {
-                return null;
-            }
-
-            return (Convert.ToUInt16(val));
-            
-        }
-
-        /// <summary>
-        /// Set VigorousActivityMinutes field
-        /// Units: minutes</summary>
-        /// <param name="vigorousActivityMinutes_">Nullable field value to be set</param>
-        public void SetVigorousActivityMinutes(ushort? vigorousActivityMinutes_)
-        {
-            SetFieldValue(34, 0, vigorousActivityMinutes_, Fit.SubfieldIndexMainField);
-        }
-        
-        #endregion // Methods
-    } // Class
+	/// <summary>
+	/// Implements the Monitoring profile message.
+	/// </summary>
+	public class MonitoringMesg : Mesg
+	{
+		#region Fields
+		static class CyclesSubfield
+		{
+			public static ushort Steps = 0;
+			public static ushort Strokes = 1;
+			public static ushort Subfields = 2;
+			public static ushort Active = Fit.SubfieldIndexActiveSubfield;
+			public static ushort MainField = Fit.SubfieldIndexMainField;
+		}
+		#endregion
+
+		/// <summary>
+		/// Field Numbers for <see cref="MonitoringMesg"/>
+		/// </summary>
+		public sealed class FieldDefNum
+		{
+			public const byte Timestamp = 253;
+			public const byte DeviceIndex = 0;
+			public const byte Calories = 1;
+			public const byte Distance = 2;
+			public const byte Cycles = 3;
+			public const byte ActiveTime = 4;
+			public const byte ActivityType = 5;
+			public const byte ActivitySubtype = 6;
+			public const byte ActivityLevel = 7;
+			public const byte Distance16 = 8;
+			public const byte Cycles16 = 9;
+			public const byte ActiveTime16 = 10;
+			public const byte LocalTimestamp = 11;
+			public const byte Temperature = 12;
+			public const byte TemperatureMin = 14;
+			public const byte TemperatureMax = 15;
+			public const byte ActivityTime = 16;
+			public const byte ActiveCalories = 19;
+			public const byte CurrentActivityTypeIntensity = 24;
+			public const byte TimestampMin8 = 25;
+			public const byte Timestamp16 = 26;
+			public const byte HeartRate = 27;
+			public const byte Intensity = 28;
+			public const byte DurationMin = 29;
+			public const byte Duration = 30;
+			public const byte Ascent = 31;
+			public const byte Descent = 32;
+			public const byte ModerateActivityMinutes = 33;
+			public const byte VigorousActivityMinutes = 34;
+			public const byte Invalid = Fit.FieldNumInvalid;
+		}
+
+		#region Constructors
+		public MonitoringMesg() : base(Profile.GetMesg(MesgNum.Monitoring))
+		{
+		}
+
+		public MonitoringMesg(Mesg mesg) : base(mesg)
+		{
+		}
+		#endregion // Constructors
+
+		#region Methods
+		///<summary>
+		/// Retrieves the Timestamp field
+		/// Units: s
+		/// Comment: Must align to logging interval, for example, time must be 00:00:00 for daily log.</summary>
+		/// <returns>Returns DateTime representing the Timestamp field</returns>
+		public DateTime Timestamp
+		{
+			get
+			{
+				Object val = GetFieldValue(253, 0, Fit.SubfieldIndexMainField);
+				if (val == null)
+				{
+					return null;
+				}
+
+				return TimestampToDateTime(Convert.ToUInt32(val));
+
+			}
+			set
+			{
+				SetFieldValue(253, 0, value.GetTimeStamp(), Fit.SubfieldIndexMainField);
+			}
+		}
+
+		///<summary>
+		/// Retrieves the DeviceIndex field
+		/// Comment: Associates this data to device_info message. Not required for file with single device (sensor).</summary>
+		/// <returns>Returns nullable byte representing the DeviceIndex field</returns>
+		public byte? DeviceIndex
+		{
+			get
+			{
+				Object val = GetFieldValue(0, 0, Fit.SubfieldIndexMainField);
+				if (val == null)
+				{
+					return null;
+				}
+
+				return (Convert.ToByte(val));
+
+			}
+			set
+			{
+				SetFieldValue(0, 0, value, Fit.SubfieldIndexMainField);
+			}
+		}
+
+		///<summary>
+		/// Retrieves the Calories field
+		/// Units: kcal
+		/// Comment: Accumulated total calories. Maintained by MonitoringReader for each activity_type. See SDK documentation</summary>
+		/// <returns>Returns nullable ushort representing the Calories field</returns>
+		public ushort? Calories
+		{
+			get
+			{
+				Object val = GetFieldValue(1, 0, Fit.SubfieldIndexMainField);
+				if (val == null)
+				{
+					return null;
+				}
+
+				return (Convert.ToUInt16(val));
+
+			}
+			set
+			{
+				SetFieldValue(1, 0, value, Fit.SubfieldIndexMainField);
+			}
+		}
+
+		///<summary>
+		/// Retrieves the Distance field
+		/// Units: m
+		/// Comment: Accumulated distance. Maintained by MonitoringReader for each activity_type. See SDK documentation.</summary>
+		/// <returns>Returns nullable float representing the Distance field</returns>
+		public float? Distance
+		{
+			get
+			{
+				Object val = GetFieldValue(2, 0, Fit.SubfieldIndexMainField);
+				if (val == null)
+				{
+					return null;
+				}
+
+				return (Convert.ToSingle(val));
+
+			}
+			set
+			{
+				SetFieldValue(2, 0, value, Fit.SubfieldIndexMainField);
+			}
+		}
+
+		///<summary>
+		/// Retrieves the Cycles field
+		/// Units: cycles
+		/// Comment: Accumulated cycles. Maintained by MonitoringReader for each activity_type. See SDK documentation.</summary>
+		/// <returns>Returns nullable float representing the Cycles field</returns>
+		public float? Cycles
+		{
+			get
+			{
+				Object val = GetFieldValue(3, 0, Fit.SubfieldIndexMainField);
+				if (val == null)
+				{
+					return null;
+				}
+
+				return (Convert.ToSingle(val));
+
+			}
+			set
+			{
+				SetFieldValue(3, 0, value, Fit.SubfieldIndexMainField);
+			}
+		}
+
+
+		/// <summary>
+		/// Retrieves the Steps subfield
+		/// Units: steps</summary>
+		/// <returns>Nullable uint representing the Steps subfield</returns>
+		public uint? Steps
+		{
+			get
+			{
+				Object val = GetFieldValue(3, 0, CyclesSubfield.Steps);
+				if (val == null)
+				{
+					return null;
+				}
+
+				return (Convert.ToUInt32(val));
+
+			}
+			set
+			{
+				SetFieldValue(3, 0, value, CyclesSubfield.Steps);
+			}
+		}
+
+		/// <summary>
+		/// Retrieves the Strokes subfield
+		/// Units: strokes</summary>
+		/// <returns>Nullable float representing the Strokes subfield</returns>
+		public float? Strokes
+		{
+			get
+			{
+				Object val = GetFieldValue(3, 0, CyclesSubfield.Strokes);
+				if (val == null)
+				{
+					return null;
+				}
+
+				return (Convert.ToSingle(val));
+
+			}
+			set
+			{
+				SetFieldValue(3, 0, value, CyclesSubfield.Strokes);
+			}
+		}
+		///<summary>
+		/// Retrieves the ActiveTime field
+		/// Units: s</summary>
+		/// <returns>Returns nullable float representing the ActiveTime field</returns>
+		public float? ActiveTime
+		{
+			get
+			{
+				Object val = GetFieldValue(4, 0, Fit.SubfieldIndexMainField);
+				if (val == null)
+				{
+					return null;
+				}
+
+				return (Convert.ToSingle(val));
+
+			}
+			set
+			{
+				SetFieldValue(4, 0, value, Fit.SubfieldIndexMainField);
+			}
+		}
+
+		///<summary>
+		/// Retrieves the ActivityType field</summary>
+		/// <returns>Returns nullable ActivityType enum representing the ActivityType field</returns>
+		public ActivityType? ActivityType
+		{
+			get
+			{
+				object obj = GetFieldValue(5, 0, Fit.SubfieldIndexMainField);
+				ActivityType? value = obj == null ? (ActivityType?)null : (ActivityType)obj;
+				return value;
+			}
+			set
+			{
+				SetFieldValue(5, 0, value, Fit.SubfieldIndexMainField);
+			}
+		}
+
+		///<summary>
+		/// Retrieves the ActivitySubtype field</summary>
+		/// <returns>Returns nullable ActivitySubtype enum representing the ActivitySubtype field</returns>
+		public ActivitySubtype? ActivitySubtype
+		{
+			get
+			{
+				object obj = GetFieldValue(6, 0, Fit.SubfieldIndexMainField);
+				ActivitySubtype? value = obj == null ? (ActivitySubtype?)null : (ActivitySubtype)obj;
+				return value;
+			}
+			set
+			{
+				SetFieldValue(6, 0, value, Fit.SubfieldIndexMainField);
+			}
+		}
+
+		///<summary>
+		/// Retrieves the ActivityLevel field</summary>
+		/// <returns>Returns nullable ActivityLevel enum representing the ActivityLevel field</returns>
+		public ActivityLevel? ActivityLevel
+		{
+			get
+			{
+				object obj = GetFieldValue(7, 0, Fit.SubfieldIndexMainField);
+				ActivityLevel? value = obj == null ? (ActivityLevel?)null : (ActivityLevel)obj;
+				return value;
+			}
+			set
+			{
+				SetFieldValue(7, 0, value, Fit.SubfieldIndexMainField);
+			}
+		}
+
+		///<summary>
+		/// Retrieves the Distance16 field
+		/// Units: 100 * m</summary>
+		/// <returns>Returns nullable ushort representing the Distance16 field</returns>
+		public ushort? Distance16
+		{
+			get
+			{
+				Object val = GetFieldValue(8, 0, Fit.SubfieldIndexMainField);
+				if (val == null)
+				{
+					return null;
+				}
+
+				return (Convert.ToUInt16(val));
+
+			}
+			set
+			{
+				SetFieldValue(8, 0, value, Fit.SubfieldIndexMainField);
+			}
+		}
+
+		///<summary>
+		/// Retrieves the Cycles16 field
+		/// Units: 2 * cycles (steps)</summary>
+		/// <returns>Returns nullable ushort representing the Cycles16 field</returns>
+		public ushort? Cycles16
+		{
+			get
+			{
+				Object val = GetFieldValue(9, 0, Fit.SubfieldIndexMainField);
+				if (val == null)
+				{
+					return null;
+				}
+
+				return (Convert.ToUInt16(val));
+
+			}
+			set
+			{
+				SetFieldValue(9, 0, value, Fit.SubfieldIndexMainField);
+			}
+		}
+
+		///<summary>
+		/// Retrieves the ActiveTime16 field
+		/// Units: s</summary>
+		/// <returns>Returns nullable ushort representing the ActiveTime16 field</returns>
+		public ushort? ActiveTime16
+		{
+			get
+			{
+				Object val = GetFieldValue(10, 0, Fit.SubfieldIndexMainField);
+				if (val == null)
+				{
+					return null;
+				}
+
+				return (Convert.ToUInt16(val));
+
+			}
+			set
+			{
+				SetFieldValue(10, 0, value, Fit.SubfieldIndexMainField);
+			}
+		}
+
+		///<summary>
+		/// Retrieves the LocalTimestamp field
+		/// Comment: Must align to logging interval, for example, time must be 00:00:00 for daily log.</summary>
+		/// <returns>Returns nullable uint representing the LocalTimestamp field</returns>
+		public uint? LocalTimestamp
+		{
+			get
+			{
+				Object val = GetFieldValue(11, 0, Fit.SubfieldIndexMainField);
+				if (val == null)
+				{
+					return null;
+				}
+
+				return (Convert.ToUInt32(val));
+
+			}
+			set
+			{
+				SetFieldValue(11, 0, value, Fit.SubfieldIndexMainField);
+			}
+		}
+
+		///<summary>
+		/// Retrieves the Temperature field
+		/// Units: C
+		/// Comment: Avg temperature during the logging interval ended at timestamp</summary>
+		/// <returns>Returns nullable float representing the Temperature field</returns>
+		public float? Temperature
+		{
+			get
+			{
+				Object val = GetFieldValue(12, 0, Fit.SubfieldIndexMainField);
+				if (val == null)
+				{
+					return null;
+				}
+
+				return (Convert.ToSingle(val));
+
+			}
+			set
+			{
+				SetFieldValue(12, 0, value, Fit.SubfieldIndexMainField);
+			}
+		}
+
+		///<summary>
+		/// Retrieves the TemperatureMin field
+		/// Units: C
+		/// Comment: Min temperature during the logging interval ended at timestamp</summary>
+		/// <returns>Returns nullable float representing the TemperatureMin field</returns>
+		public float? TemperatureMin
+		{
+			get
+			{
+				Object val = GetFieldValue(14, 0, Fit.SubfieldIndexMainField);
+				if (val == null)
+				{
+					return null;
+				}
+
+				return (Convert.ToSingle(val));
+
+			}
+			set
+			{
+				SetFieldValue(14, 0, value, Fit.SubfieldIndexMainField);
+			}
+		}
+
+		///<summary>
+		/// Retrieves the TemperatureMax field
+		/// Units: C
+		/// Comment: Max temperature during the logging interval ended at timestamp</summary>
+		/// <returns>Returns nullable float representing the TemperatureMax field</returns>
+		public float? TemperatureMax
+		{
+			get
+			{
+				Object val = GetFieldValue(15, 0, Fit.SubfieldIndexMainField);
+				if (val == null)
+				{
+					return null;
+				}
+
+				return (Convert.ToSingle(val));
+
+			}
+			set
+			{
+				SetFieldValue(15, 0, value, Fit.SubfieldIndexMainField);
+			}
+		}
+
+
+		/// <summary>
+		///
+		/// </summary>
+		/// <returns>returns number of elements in field ActivityTime</returns>
+		public int GetNumActivityTime()
+		{
+			return GetNumFieldValues(16, Fit.SubfieldIndexMainField);
+		}
+
+		///<summary>
+		/// Retrieves the ActivityTime field
+		/// Units: minutes
+		/// Comment: Indexed using minute_activity_level enum</summary>
+		/// <param name="index">0 based index of ActivityTime element to retrieve</param>
+		/// <returns>Returns nullable ushort representing the ActivityTime field</returns>
+		public ushort? GetActivityTime(int index)
+		{
+			Object val = GetFieldValue(16, index, Fit.SubfieldIndexMainField);
+			if (val == null)
+			{
+				return null;
+			}
+
+			return (Convert.ToUInt16(val));
+
+		}
+
+		/// <summary>
+		/// Set ActivityTime field
+		/// Units: minutes
+		/// Comment: Indexed using minute_activity_level enum</summary>
+		/// <param name="index">0 based index of activity_time</param>
+		/// <param name="activityTime_">Nullable field value to be set</param>
+		public void SetActivityTime(int index, ushort? activityTime_)
+		{
+			SetFieldValue(16, index, activityTime_, Fit.SubfieldIndexMainField);
+		}
+
+		///<summary>
+		/// Retrieves the ActiveCalories field
+		/// Units: kcal</summary>
+		/// <returns>Returns nullable ushort representing the ActiveCalories field</returns>
+		public ushort? ActiveCalories
+		{
+			get
+			{
+				Object val = GetFieldValue(19, 0, Fit.SubfieldIndexMainField);
+				if (val == null)
+				{
+					return null;
+				}
+
+				return (Convert.ToUInt16(val));
+
+			}
+			set
+			{
+				SetFieldValue(19, 0, value, Fit.SubfieldIndexMainField);
+			}
+		}
+
+		///<summary>
+		/// Retrieves the CurrentActivityTypeIntensity field
+		/// Comment: Indicates single type / intensity for duration since last monitoring message.</summary>
+		/// <returns>Returns nullable byte representing the CurrentActivityTypeIntensity field</returns>
+		public byte? CurrentActivityTypeIntensity
+		{
+			get
+			{
+				Object val = GetFieldValue(24, 0, Fit.SubfieldIndexMainField);
+				if (val == null)
+				{
+					return null;
+				}
+
+				return (Convert.ToByte(val));
+
+			}
+			set
+			{
+				SetFieldValue(24, 0, value, Fit.SubfieldIndexMainField);
+			}
+		}
+
+		///<summary>
+		/// Retrieves the TimestampMin8 field
+		/// Units: min</summary>
+		/// <returns>Returns nullable byte representing the TimestampMin8 field</returns>
+		public byte? TimestampMin8
+		{
+			get
+			{
+				Object val = GetFieldValue(25, 0, Fit.SubfieldIndexMainField);
+				if (val == null)
+				{
+					return null;
+				}
+
+				return (Convert.ToByte(val));
+
+			}
+			set
+			{
+				SetFieldValue(25, 0, value, Fit.SubfieldIndexMainField);
+			}
+		}
+
+		///<summary>
+		/// Retrieves the Timestamp16 field
+		/// Units: s</summary>
+		/// <returns>Returns nullable ushort representing the Timestamp16 field</returns>
+		public ushort? Timestamp16
+		{
+			get
+			{
+				Object val = GetFieldValue(26, 0, Fit.SubfieldIndexMainField);
+				if (val == null)
+				{
+					return null;
+				}
+
+				return (Convert.ToUInt16(val));
+
+			}
+			set
+			{
+				SetFieldValue(26, 0, value, Fit.SubfieldIndexMainField);
+			}
+		}
+
+		///<summary>
+		/// Retrieves the HeartRate field
+		/// Units: bpm</summary>
+		/// <returns>Returns nullable byte representing the HeartRate field</returns>
+		public byte? HeartRate
+		{
+			get
+			{
+				Object val = GetFieldValue(27, 0, Fit.SubfieldIndexMainField);
+				if (val == null)
+				{
+					return null;
+				}
+
+				return (Convert.ToByte(val));
+
+			}
+			set
+			{
+				SetFieldValue(27, 0, value, Fit.SubfieldIndexMainField);
+			}
+		}
+
+		///<summary>
+		/// Retrieves the Intensity field</summary>
+		/// <returns>Returns nullable float representing the Intensity field</returns>
+		public float? Intensity
+		{
+			get
+			{
+				Object val = GetFieldValue(28, 0, Fit.SubfieldIndexMainField);
+				if (val == null)
+				{
+					return null;
+				}
+
+				return (Convert.ToSingle(val));
+
+			}
+			set
+			{
+				SetFieldValue(28, 0, value, Fit.SubfieldIndexMainField);
+			}
+		}
+
+		///<summary>
+		/// Retrieves the DurationMin field
+		/// Units: min</summary>
+		/// <returns>Returns nullable ushort representing the DurationMin field</returns>
+		public ushort? DurationMin
+		{
+			get
+			{
+				Object val = GetFieldValue(29, 0, Fit.SubfieldIndexMainField);
+				if (val == null)
+				{
+					return null;
+				}
+
+				return (Convert.ToUInt16(val));
+
+			}
+			set
+			{
+				SetFieldValue(29, 0, value, Fit.SubfieldIndexMainField);
+			}
+		}
+
+		///<summary>
+		/// Retrieves the Duration field
+		/// Units: s</summary>
+		/// <returns>Returns nullable uint representing the Duration field</returns>
+		public uint? Duration
+		{
+			get
+			{
+				Object val = GetFieldValue(30, 0, Fit.SubfieldIndexMainField);
+				if (val == null)
+				{
+					return null;
+				}
+
+				return (Convert.ToUInt32(val));
+
+			}
+			set
+			{
+				SetFieldValue(30, 0, value, Fit.SubfieldIndexMainField);
+			}
+		}
+
+		///<summary>
+		/// Retrieves the Ascent field
+		/// Units: m</summary>
+		/// <returns>Returns nullable float representing the Ascent field</returns>
+		public float? Ascent
+		{
+			get
+			{
+				Object val = GetFieldValue(31, 0, Fit.SubfieldIndexMainField);
+				if (val == null)
+				{
+					return null;
+				}
+
+				return (Convert.ToSingle(val));
+
+			}
+			set
+			{
+				SetFieldValue(31, 0, value, Fit.SubfieldIndexMainField);
+			}
+		}
+
+		///<summary>
+		/// Retrieves the Descent field
+		/// Units: m</summary>
+		/// <returns>Returns nullable float representing the Descent field</returns>
+		public float? Descent
+		{
+			get
+			{
+				Object val = GetFieldValue(32, 0, Fit.SubfieldIndexMainField);
+				if (val == null)
+				{
+					return null;
+				}
+
+				return (Convert.ToSingle(val));
+
+			}
+			set
+			{
+				SetFieldValue(32, 0, value, Fit.SubfieldIndexMainField);
+			}
+		}
+
+		///<summary>
+		/// Retrieves the ModerateActivityMinutes field
+		/// Units: minutes</summary>
+		/// <returns>Returns nullable ushort representing the ModerateActivityMinutes field</returns>
+		public ushort? ModerateActivityMinutes
+		{
+			get
+			{
+				Object val = GetFieldValue(33, 0, Fit.SubfieldIndexMainField);
+				if (val == null)
+				{
+					return null;
+				}
+
+				return (Convert.ToUInt16(val));
+
+			}
+			set
+			{
+				SetFieldValue(33, 0, value, Fit.SubfieldIndexMainField);
+			}
+		}
+
+		///<summary>
+		/// Retrieves the VigorousActivityMinutes field
+		/// Units: minutes</summary>
+		/// <returns>Returns nullable ushort representing the VigorousActivityMinutes field</returns>
+		public ushort? VigorousActivityMinutes
+		{
+			get
+			{
+				Object val = GetFieldValue(34, 0, Fit.SubfieldIndexMainField);
+				if (val == null)
+				{
+					return null;
+				}
+
+				return (Convert.ToUInt16(val));
+
+			}
+			set
+			{
+				SetFieldValue(34, 0, value, Fit.SubfieldIndexMainField);
+			}
+		}
+
+		#endregion // Methods
+	} // Class
 } // namespace

--- a/Dynastream/Fit/Profile/Mesgs/NmeaSentenceMesg.cs
+++ b/Dynastream/Fit/Profile/Mesgs/NmeaSentenceMesg.cs
@@ -21,132 +21,123 @@ using System.Linq;
 
 namespace Dynastream.Fit
 {
-    /// <summary>
-    /// Implements the NmeaSentence profile message.
-    /// </summary>
-    public class NmeaSentenceMesg : Mesg
-    {
-        #region Fields
-        #endregion
+	/// <summary>
+	/// Implements the NmeaSentence profile message.
+	/// </summary>
+	public class NmeaSentenceMesg : Mesg
+	{
+		#region Fields
+		#endregion
 
-        /// <summary>
-        /// Field Numbers for <see cref="NmeaSentenceMesg"/>
-        /// </summary>
-        public sealed class FieldDefNum
-        {
-            public const byte Timestamp = 253;
-            public const byte TimestampMs = 0;
-            public const byte Sentence = 1;
-            public const byte Invalid = Fit.FieldNumInvalid;
-        }
+		/// <summary>
+		/// Field Numbers for <see cref="NmeaSentenceMesg"/>
+		/// </summary>
+		public sealed class FieldDefNum
+		{
+			public const byte Timestamp = 253;
+			public const byte TimestampMs = 0;
+			public const byte Sentence = 1;
+			public const byte Invalid = Fit.FieldNumInvalid;
+		}
 
-        #region Constructors
-        public NmeaSentenceMesg() : base(Profile.GetMesg(MesgNum.NmeaSentence))
-        {
-        }
+		#region Constructors
+		public NmeaSentenceMesg() : base(Profile.GetMesg(MesgNum.NmeaSentence))
+		{
+		}
 
-        public NmeaSentenceMesg(Mesg mesg) : base(mesg)
-        {
-        }
-        #endregion // Constructors
+		public NmeaSentenceMesg(Mesg mesg) : base(mesg)
+		{
+		}
+		#endregion // Constructors
 
-        #region Methods
-        ///<summary>
-        /// Retrieves the Timestamp field
-        /// Units: s
-        /// Comment: Timestamp message was output</summary>
-        /// <returns>Returns DateTime representing the Timestamp field</returns>
-        public DateTime GetTimestamp()
-        {
-            Object val = GetFieldValue(253, 0, Fit.SubfieldIndexMainField);
-            if(val == null)
-            {
-                return null;
-            }
+		#region Methods
+		///<summary>
+		/// Retrieves the Timestamp field
+		/// Units: s
+		/// Comment: Timestamp message was output</summary>
+		/// <returns>Returns DateTime representing the Timestamp field</returns>
+		public DateTime Timestamp
+		{
+			get
+			{
+				Object val = GetFieldValue(253, 0, Fit.SubfieldIndexMainField);
+				if (val == null)
+				{
+					return null;
+				}
 
-            return TimestampToDateTime(Convert.ToUInt32(val));
-            
-        }
+				return TimestampToDateTime(Convert.ToUInt32(val));
 
-        /// <summary>
-        /// Set Timestamp field
-        /// Units: s
-        /// Comment: Timestamp message was output</summary>
-        /// <param name="timestamp_">Nullable field value to be set</param>
-        public void SetTimestamp(DateTime timestamp_)
-        {
-            SetFieldValue(253, 0, timestamp_.GetTimeStamp(), Fit.SubfieldIndexMainField);
-        }
-        
-        ///<summary>
-        /// Retrieves the TimestampMs field
-        /// Units: ms
-        /// Comment: Fractional part of timestamp, added to timestamp</summary>
-        /// <returns>Returns nullable ushort representing the TimestampMs field</returns>
-        public ushort? GetTimestampMs()
-        {
-            Object val = GetFieldValue(0, 0, Fit.SubfieldIndexMainField);
-            if(val == null)
-            {
-                return null;
-            }
+			}
+			set
+			{
+				SetFieldValue(253, 0, value.GetTimeStamp(), Fit.SubfieldIndexMainField);
+			}
+		}
 
-            return (Convert.ToUInt16(val));
-            
-        }
+		///<summary>
+		/// Retrieves the TimestampMs field
+		/// Units: ms
+		/// Comment: Fractional part of timestamp, added to timestamp</summary>
+		/// <returns>Returns nullable ushort representing the TimestampMs field</returns>
+		public ushort? TimestampMs
+		{
+			get
+			{
+				Object val = GetFieldValue(0, 0, Fit.SubfieldIndexMainField);
+				if (val == null)
+				{
+					return null;
+				}
 
-        /// <summary>
-        /// Set TimestampMs field
-        /// Units: ms
-        /// Comment: Fractional part of timestamp, added to timestamp</summary>
-        /// <param name="timestampMs_">Nullable field value to be set</param>
-        public void SetTimestampMs(ushort? timestampMs_)
-        {
-            SetFieldValue(0, 0, timestampMs_, Fit.SubfieldIndexMainField);
-        }
-        
-        ///<summary>
-        /// Retrieves the Sentence field
-        /// Comment: NMEA sentence</summary>
-        /// <returns>Returns byte[] representing the Sentence field</returns>
-        public byte[] GetSentence()
-        {
-            byte[] data = (byte[])GetFieldValue(1, 0, Fit.SubfieldIndexMainField);
-            return data.Take(data.Length - 1).ToArray();
-        }
+				return (Convert.ToUInt16(val));
 
-        ///<summary>
-        /// Retrieves the Sentence field
-        /// Comment: NMEA sentence</summary>
-        /// <returns>Returns String representing the Sentence field</returns>
-        public String GetSentenceAsString()
-        {
-            byte[] data = (byte[])GetFieldValue(1, 0, Fit.SubfieldIndexMainField);
-            return data != null ? Encoding.UTF8.GetString(data, 0, data.Length - 1) : null;
-        }
+			}
+			set
+			{
+				SetFieldValue(0, 0, value, Fit.SubfieldIndexMainField);
+			}
+		}
 
-        ///<summary>
-        /// Set Sentence field
-        /// Comment: NMEA sentence</summary>
-        /// <param name="sentence_"> field value to be set</param>
-        public void SetSentence(String sentence_)
-        {
-            byte[] data = Encoding.UTF8.GetBytes(sentence_);
-            byte[] zdata = new byte[data.Length + 1];
-            data.CopyTo(zdata, 0);
-            SetFieldValue(1, 0, zdata, Fit.SubfieldIndexMainField);
-        }
+		///<summary>
+		/// Retrieves the Sentence field
+		/// Comment: NMEA sentence</summary>
+		/// <returns>Returns byte[] representing the Sentence field</returns>
+		public byte[] Sentence
+		{
+			get
+			{
+				byte[] data = (byte[])GetFieldValue(1, 0, Fit.SubfieldIndexMainField);
+				return data.Take(data.Length - 1).ToArray();
+			}
+			set
+			{
+				SetFieldValue(1, 0, value, Fit.SubfieldIndexMainField);
+			}
+		}
 
-        
-        /// <summary>
-        /// Set Sentence field
-        /// Comment: NMEA sentence</summary>
-        /// <param name="sentence_">field value to be set</param>
-        public void SetSentence(byte[] sentence_)
-        {
-            SetFieldValue(1, 0, sentence_, Fit.SubfieldIndexMainField);
-        }
-        
-        #endregion // Methods
-    } // Class
+		///<summary>
+		/// Retrieves the Sentence field
+		/// Comment: NMEA sentence</summary>
+		/// <returns>Returns String representing the Sentence field</returns>
+		public String GetSentenceAsString()
+		{
+			byte[] data = (byte[])GetFieldValue(1, 0, Fit.SubfieldIndexMainField);
+			return data != null ? Encoding.UTF8.GetString(data, 0, data.Length - 1) : null;
+		}
+
+		///<summary>
+		/// Set Sentence field
+		/// Comment: NMEA sentence</summary>
+		/// <param name="sentence_"> field value to be set</param>
+		public void SetSentence(String sentence_)
+		{
+			byte[] data = Encoding.UTF8.GetBytes(sentence_);
+			byte[] zdata = new byte[data.Length + 1];
+			data.CopyTo(zdata, 0);
+			SetFieldValue(1, 0, zdata, Fit.SubfieldIndexMainField);
+		}
+
+		#endregion // Methods
+	} // Class
 } // namespace

--- a/Dynastream/Fit/Profile/Mesgs/ObdiiDataMesg.cs
+++ b/Dynastream/Fit/Profile/Mesgs/ObdiiDataMesg.cs
@@ -21,323 +21,310 @@ using System.Linq;
 
 namespace Dynastream.Fit
 {
-    /// <summary>
-    /// Implements the ObdiiData profile message.
-    /// </summary>
-    public class ObdiiDataMesg : Mesg
-    {
-        #region Fields
-        #endregion
+	/// <summary>
+	/// Implements the ObdiiData profile message.
+	/// </summary>
+	public class ObdiiDataMesg : Mesg
+	{
+		#region Fields
+		#endregion
 
-        /// <summary>
-        /// Field Numbers for <see cref="ObdiiDataMesg"/>
-        /// </summary>
-        public sealed class FieldDefNum
-        {
-            public const byte Timestamp = 253;
-            public const byte TimestampMs = 0;
-            public const byte TimeOffset = 1;
-            public const byte Pid = 2;
-            public const byte RawData = 3;
-            public const byte PidDataSize = 4;
-            public const byte SystemTime = 5;
-            public const byte StartTimestamp = 6;
-            public const byte StartTimestampMs = 7;
-            public const byte Invalid = Fit.FieldNumInvalid;
-        }
+		/// <summary>
+		/// Field Numbers for <see cref="ObdiiDataMesg"/>
+		/// </summary>
+		public sealed class FieldDefNum
+		{
+			public const byte Timestamp = 253;
+			public const byte TimestampMs = 0;
+			public const byte TimeOffset = 1;
+			public const byte Pid = 2;
+			public const byte RawData = 3;
+			public const byte PidDataSize = 4;
+			public const byte SystemTime = 5;
+			public const byte StartTimestamp = 6;
+			public const byte StartTimestampMs = 7;
+			public const byte Invalid = Fit.FieldNumInvalid;
+		}
 
-        #region Constructors
-        public ObdiiDataMesg() : base(Profile.GetMesg(MesgNum.ObdiiData))
-        {
-        }
+		#region Constructors
+		public ObdiiDataMesg() : base(Profile.GetMesg(MesgNum.ObdiiData))
+		{
+		}
 
-        public ObdiiDataMesg(Mesg mesg) : base(mesg)
-        {
-        }
-        #endregion // Constructors
+		public ObdiiDataMesg(Mesg mesg) : base(mesg)
+		{
+		}
+		#endregion // Constructors
 
-        #region Methods
-        ///<summary>
-        /// Retrieves the Timestamp field
-        /// Units: s
-        /// Comment: Timestamp message was output</summary>
-        /// <returns>Returns DateTime representing the Timestamp field</returns>
-        public DateTime GetTimestamp()
-        {
-            Object val = GetFieldValue(253, 0, Fit.SubfieldIndexMainField);
-            if(val == null)
-            {
-                return null;
-            }
+		#region Methods
+		///<summary>
+		/// Retrieves the Timestamp field
+		/// Units: s
+		/// Comment: Timestamp message was output</summary>
+		/// <returns>Returns DateTime representing the Timestamp field</returns>
+		public DateTime Timestamp
+		{
+			get
+			{
+				Object val = GetFieldValue(253, 0, Fit.SubfieldIndexMainField);
+				if (val == null)
+				{
+					return null;
+				}
 
-            return TimestampToDateTime(Convert.ToUInt32(val));
-            
-        }
+				return TimestampToDateTime(Convert.ToUInt32(val));
 
-        /// <summary>
-        /// Set Timestamp field
-        /// Units: s
-        /// Comment: Timestamp message was output</summary>
-        /// <param name="timestamp_">Nullable field value to be set</param>
-        public void SetTimestamp(DateTime timestamp_)
-        {
-            SetFieldValue(253, 0, timestamp_.GetTimeStamp(), Fit.SubfieldIndexMainField);
-        }
-        
-        ///<summary>
-        /// Retrieves the TimestampMs field
-        /// Units: ms
-        /// Comment: Fractional part of timestamp, added to timestamp</summary>
-        /// <returns>Returns nullable ushort representing the TimestampMs field</returns>
-        public ushort? GetTimestampMs()
-        {
-            Object val = GetFieldValue(0, 0, Fit.SubfieldIndexMainField);
-            if(val == null)
-            {
-                return null;
-            }
+			}
+			set
+			{
+				SetFieldValue(253, 0, value.GetTimeStamp(), Fit.SubfieldIndexMainField);
+			}
+		}
 
-            return (Convert.ToUInt16(val));
-            
-        }
+		///<summary>
+		/// Retrieves the TimestampMs field
+		/// Units: ms
+		/// Comment: Fractional part of timestamp, added to timestamp</summary>
+		/// <returns>Returns nullable ushort representing the TimestampMs field</returns>
+		public ushort? TimestampMs
+		{
+			get
+			{
+				Object val = GetFieldValue(0, 0, Fit.SubfieldIndexMainField);
+				if (val == null)
+				{
+					return null;
+				}
 
-        /// <summary>
-        /// Set TimestampMs field
-        /// Units: ms
-        /// Comment: Fractional part of timestamp, added to timestamp</summary>
-        /// <param name="timestampMs_">Nullable field value to be set</param>
-        public void SetTimestampMs(ushort? timestampMs_)
-        {
-            SetFieldValue(0, 0, timestampMs_, Fit.SubfieldIndexMainField);
-        }
-        
-        
-        /// <summary>
-        ///
-        /// </summary>
-        /// <returns>returns number of elements in field TimeOffset</returns>
-        public int GetNumTimeOffset()
-        {
-            return GetNumFieldValues(1, Fit.SubfieldIndexMainField);
-        }
+				return (Convert.ToUInt16(val));
 
-        ///<summary>
-        /// Retrieves the TimeOffset field
-        /// Units: ms
-        /// Comment: Offset of PID reading [i] from start_timestamp+start_timestamp_ms. Readings may span accross seconds.</summary>
-        /// <param name="index">0 based index of TimeOffset element to retrieve</param>
-        /// <returns>Returns nullable ushort representing the TimeOffset field</returns>
-        public ushort? GetTimeOffset(int index)
-        {
-            Object val = GetFieldValue(1, index, Fit.SubfieldIndexMainField);
-            if(val == null)
-            {
-                return null;
-            }
+			}
+			set
+			{
+				SetFieldValue(0, 0, value, Fit.SubfieldIndexMainField);
+			}
+		}
 
-            return (Convert.ToUInt16(val));
-            
-        }
 
-        /// <summary>
-        /// Set TimeOffset field
-        /// Units: ms
-        /// Comment: Offset of PID reading [i] from start_timestamp+start_timestamp_ms. Readings may span accross seconds.</summary>
-        /// <param name="index">0 based index of time_offset</param>
-        /// <param name="timeOffset_">Nullable field value to be set</param>
-        public void SetTimeOffset(int index, ushort? timeOffset_)
-        {
-            SetFieldValue(1, index, timeOffset_, Fit.SubfieldIndexMainField);
-        }
-        
-        ///<summary>
-        /// Retrieves the Pid field
-        /// Comment: Parameter ID</summary>
-        /// <returns>Returns nullable byte representing the Pid field</returns>
-        public byte? GetPid()
-        {
-            Object val = GetFieldValue(2, 0, Fit.SubfieldIndexMainField);
-            if(val == null)
-            {
-                return null;
-            }
+		/// <summary>
+		///
+		/// </summary>
+		/// <returns>returns number of elements in field TimeOffset</returns>
+		public int GetNumTimeOffset()
+		{
+			return GetNumFieldValues(1, Fit.SubfieldIndexMainField);
+		}
 
-            return (Convert.ToByte(val));
-            
-        }
+		///<summary>
+		/// Retrieves the TimeOffset field
+		/// Units: ms
+		/// Comment: Offset of PID reading [i] from start_timestamp+start_timestamp_ms. Readings may span accross seconds.</summary>
+		/// <param name="index">0 based index of TimeOffset element to retrieve</param>
+		/// <returns>Returns nullable ushort representing the TimeOffset field</returns>
+		public ushort? GetTimeOffset(int index)
+		{
+			Object val = GetFieldValue(1, index, Fit.SubfieldIndexMainField);
+			if (val == null)
+			{
+				return null;
+			}
 
-        /// <summary>
-        /// Set Pid field
-        /// Comment: Parameter ID</summary>
-        /// <param name="pid_">Nullable field value to be set</param>
-        public void SetPid(byte? pid_)
-        {
-            SetFieldValue(2, 0, pid_, Fit.SubfieldIndexMainField);
-        }
-        
-        
-        /// <summary>
-        ///
-        /// </summary>
-        /// <returns>returns number of elements in field RawData</returns>
-        public int GetNumRawData()
-        {
-            return GetNumFieldValues(3, Fit.SubfieldIndexMainField);
-        }
+			return (Convert.ToUInt16(val));
 
-        ///<summary>
-        /// Retrieves the RawData field
-        /// Comment: Raw parameter data</summary>
-        /// <param name="index">0 based index of RawData element to retrieve</param>
-        /// <returns>Returns nullable byte representing the RawData field</returns>
-        public byte? GetRawData(int index)
-        {
-            Object val = GetFieldValue(3, index, Fit.SubfieldIndexMainField);
-            if(val == null)
-            {
-                return null;
-            }
+		}
 
-            return (Convert.ToByte(val));
-            
-        }
+		/// <summary>
+		/// Set TimeOffset field
+		/// Units: ms
+		/// Comment: Offset of PID reading [i] from start_timestamp+start_timestamp_ms. Readings may span accross seconds.</summary>
+		/// <param name="index">0 based index of time_offset</param>
+		/// <param name="timeOffset_">Nullable field value to be set</param>
+		public void SetTimeOffset(int index, ushort? timeOffset_)
+		{
+			SetFieldValue(1, index, timeOffset_, Fit.SubfieldIndexMainField);
+		}
 
-        /// <summary>
-        /// Set RawData field
-        /// Comment: Raw parameter data</summary>
-        /// <param name="index">0 based index of raw_data</param>
-        /// <param name="rawData_">Nullable field value to be set</param>
-        public void SetRawData(int index, byte? rawData_)
-        {
-            SetFieldValue(3, index, rawData_, Fit.SubfieldIndexMainField);
-        }
-        
-        
-        /// <summary>
-        ///
-        /// </summary>
-        /// <returns>returns number of elements in field PidDataSize</returns>
-        public int GetNumPidDataSize()
-        {
-            return GetNumFieldValues(4, Fit.SubfieldIndexMainField);
-        }
+		///<summary>
+		/// Retrieves the Pid field
+		/// Comment: Parameter ID</summary>
+		/// <returns>Returns nullable byte representing the Pid field</returns>
+		public byte? Pid
+		{
+			get
+			{
+				Object val = GetFieldValue(2, 0, Fit.SubfieldIndexMainField);
+				if (val == null)
+				{
+					return null;
+				}
 
-        ///<summary>
-        /// Retrieves the PidDataSize field
-        /// Comment: Optional, data size of PID[i]. If not specified refer to SAE J1979.</summary>
-        /// <param name="index">0 based index of PidDataSize element to retrieve</param>
-        /// <returns>Returns nullable byte representing the PidDataSize field</returns>
-        public byte? GetPidDataSize(int index)
-        {
-            Object val = GetFieldValue(4, index, Fit.SubfieldIndexMainField);
-            if(val == null)
-            {
-                return null;
-            }
+				return (Convert.ToByte(val));
 
-            return (Convert.ToByte(val));
-            
-        }
+			}
+			set
+			{
+				SetFieldValue(2, 0, value, Fit.SubfieldIndexMainField);
+			}
+		}
 
-        /// <summary>
-        /// Set PidDataSize field
-        /// Comment: Optional, data size of PID[i]. If not specified refer to SAE J1979.</summary>
-        /// <param name="index">0 based index of pid_data_size</param>
-        /// <param name="pidDataSize_">Nullable field value to be set</param>
-        public void SetPidDataSize(int index, byte? pidDataSize_)
-        {
-            SetFieldValue(4, index, pidDataSize_, Fit.SubfieldIndexMainField);
-        }
-        
-        
-        /// <summary>
-        ///
-        /// </summary>
-        /// <returns>returns number of elements in field SystemTime</returns>
-        public int GetNumSystemTime()
-        {
-            return GetNumFieldValues(5, Fit.SubfieldIndexMainField);
-        }
 
-        ///<summary>
-        /// Retrieves the SystemTime field
-        /// Comment: System time associated with sample expressed in ms, can be used instead of time_offset. There will be a system_time value for each raw_data element. For multibyte pids the system_time is repeated.</summary>
-        /// <param name="index">0 based index of SystemTime element to retrieve</param>
-        /// <returns>Returns nullable uint representing the SystemTime field</returns>
-        public uint? GetSystemTime(int index)
-        {
-            Object val = GetFieldValue(5, index, Fit.SubfieldIndexMainField);
-            if(val == null)
-            {
-                return null;
-            }
+		/// <summary>
+		///
+		/// </summary>
+		/// <returns>returns number of elements in field RawData</returns>
+		public int GetNumRawData()
+		{
+			return GetNumFieldValues(3, Fit.SubfieldIndexMainField);
+		}
 
-            return (Convert.ToUInt32(val));
-            
-        }
+		///<summary>
+		/// Retrieves the RawData field
+		/// Comment: Raw parameter data</summary>
+		/// <param name="index">0 based index of RawData element to retrieve</param>
+		/// <returns>Returns nullable byte representing the RawData field</returns>
+		public byte? GetRawData(int index)
+		{
+			Object val = GetFieldValue(3, index, Fit.SubfieldIndexMainField);
+			if (val == null)
+			{
+				return null;
+			}
 
-        /// <summary>
-        /// Set SystemTime field
-        /// Comment: System time associated with sample expressed in ms, can be used instead of time_offset. There will be a system_time value for each raw_data element. For multibyte pids the system_time is repeated.</summary>
-        /// <param name="index">0 based index of system_time</param>
-        /// <param name="systemTime_">Nullable field value to be set</param>
-        public void SetSystemTime(int index, uint? systemTime_)
-        {
-            SetFieldValue(5, index, systemTime_, Fit.SubfieldIndexMainField);
-        }
-        
-        ///<summary>
-        /// Retrieves the StartTimestamp field
-        /// Comment: Timestamp of first sample recorded in the message. Used with time_offset to generate time of each sample</summary>
-        /// <returns>Returns DateTime representing the StartTimestamp field</returns>
-        public DateTime GetStartTimestamp()
-        {
-            Object val = GetFieldValue(6, 0, Fit.SubfieldIndexMainField);
-            if(val == null)
-            {
-                return null;
-            }
+			return (Convert.ToByte(val));
 
-            return TimestampToDateTime(Convert.ToUInt32(val));
-            
-        }
+		}
 
-        /// <summary>
-        /// Set StartTimestamp field
-        /// Comment: Timestamp of first sample recorded in the message. Used with time_offset to generate time of each sample</summary>
-        /// <param name="startTimestamp_">Nullable field value to be set</param>
-        public void SetStartTimestamp(DateTime startTimestamp_)
-        {
-            SetFieldValue(6, 0, startTimestamp_.GetTimeStamp(), Fit.SubfieldIndexMainField);
-        }
-        
-        ///<summary>
-        /// Retrieves the StartTimestampMs field
-        /// Units: ms
-        /// Comment: Fractional part of start_timestamp</summary>
-        /// <returns>Returns nullable ushort representing the StartTimestampMs field</returns>
-        public ushort? GetStartTimestampMs()
-        {
-            Object val = GetFieldValue(7, 0, Fit.SubfieldIndexMainField);
-            if(val == null)
-            {
-                return null;
-            }
+		/// <summary>
+		/// Set RawData field
+		/// Comment: Raw parameter data</summary>
+		/// <param name="index">0 based index of raw_data</param>
+		/// <param name="rawData_">Nullable field value to be set</param>
+		public void SetRawData(int index, byte? rawData_)
+		{
+			SetFieldValue(3, index, rawData_, Fit.SubfieldIndexMainField);
+		}
 
-            return (Convert.ToUInt16(val));
-            
-        }
 
-        /// <summary>
-        /// Set StartTimestampMs field
-        /// Units: ms
-        /// Comment: Fractional part of start_timestamp</summary>
-        /// <param name="startTimestampMs_">Nullable field value to be set</param>
-        public void SetStartTimestampMs(ushort? startTimestampMs_)
-        {
-            SetFieldValue(7, 0, startTimestampMs_, Fit.SubfieldIndexMainField);
-        }
-        
-        #endregion // Methods
-    } // Class
+		/// <summary>
+		///
+		/// </summary>
+		/// <returns>returns number of elements in field PidDataSize</returns>
+		public int GetNumPidDataSize()
+		{
+			return GetNumFieldValues(4, Fit.SubfieldIndexMainField);
+		}
+
+		///<summary>
+		/// Retrieves the PidDataSize field
+		/// Comment: Optional, data size of PID[i]. If not specified refer to SAE J1979.</summary>
+		/// <param name="index">0 based index of PidDataSize element to retrieve</param>
+		/// <returns>Returns nullable byte representing the PidDataSize field</returns>
+		public byte? GetPidDataSize(int index)
+		{
+			Object val = GetFieldValue(4, index, Fit.SubfieldIndexMainField);
+			if (val == null)
+			{
+				return null;
+			}
+
+			return (Convert.ToByte(val));
+
+		}
+
+		/// <summary>
+		/// Set PidDataSize field
+		/// Comment: Optional, data size of PID[i]. If not specified refer to SAE J1979.</summary>
+		/// <param name="index">0 based index of pid_data_size</param>
+		/// <param name="pidDataSize_">Nullable field value to be set</param>
+		public void SetPidDataSize(int index, byte? pidDataSize_)
+		{
+			SetFieldValue(4, index, pidDataSize_, Fit.SubfieldIndexMainField);
+		}
+
+
+		/// <summary>
+		///
+		/// </summary>
+		/// <returns>returns number of elements in field SystemTime</returns>
+		public int GetNumSystemTime()
+		{
+			return GetNumFieldValues(5, Fit.SubfieldIndexMainField);
+		}
+
+		///<summary>
+		/// Retrieves the SystemTime field
+		/// Comment: System time associated with sample expressed in ms, can be used instead of time_offset. There will be a system_time value for each raw_data element. For multibyte pids the system_time is repeated.</summary>
+		/// <param name="index">0 based index of SystemTime element to retrieve</param>
+		/// <returns>Returns nullable uint representing the SystemTime field</returns>
+		public uint? GetSystemTime(int index)
+		{
+			Object val = GetFieldValue(5, index, Fit.SubfieldIndexMainField);
+			if (val == null)
+			{
+				return null;
+			}
+
+			return (Convert.ToUInt32(val));
+
+		}
+
+		/// <summary>
+		/// Set SystemTime field
+		/// Comment: System time associated with sample expressed in ms, can be used instead of time_offset. There will be a system_time value for each raw_data element. For multibyte pids the system_time is repeated.</summary>
+		/// <param name="index">0 based index of system_time</param>
+		/// <param name="systemTime_">Nullable field value to be set</param>
+		public void SetSystemTime(int index, uint? systemTime_)
+		{
+			SetFieldValue(5, index, systemTime_, Fit.SubfieldIndexMainField);
+		}
+
+		///<summary>
+		/// Retrieves the StartTimestamp field
+		/// Comment: Timestamp of first sample recorded in the message. Used with time_offset to generate time of each sample</summary>
+		/// <returns>Returns DateTime representing the StartTimestamp field</returns>
+		public DateTime StartTimestamp
+		{
+			get
+			{
+				Object val = GetFieldValue(6, 0, Fit.SubfieldIndexMainField);
+				if (val == null)
+				{
+					return null;
+				}
+
+				return TimestampToDateTime(Convert.ToUInt32(val));
+
+			}
+			set
+			{
+				SetFieldValue(6, 0, value.GetTimeStamp(), Fit.SubfieldIndexMainField);
+			}
+		}
+
+		///<summary>
+		/// Retrieves the StartTimestampMs field
+		/// Units: ms
+		/// Comment: Fractional part of start_timestamp</summary>
+		/// <returns>Returns nullable ushort representing the StartTimestampMs field</returns>
+		public ushort? StartTimestampMs
+		{
+			get
+			{
+				Object val = GetFieldValue(7, 0, Fit.SubfieldIndexMainField);
+				if (val == null)
+				{
+					return null;
+				}
+
+				return (Convert.ToUInt16(val));
+
+			}
+			set
+			{
+				SetFieldValue(7, 0, value, Fit.SubfieldIndexMainField);
+			}
+		}
+
+		#endregion // Methods
+	} // Class
 } // namespace

--- a/Dynastream/Fit/Profile/Mesgs/OhrSettingsMesg.cs
+++ b/Dynastream/Fit/Profile/Mesgs/OhrSettingsMesg.cs
@@ -21,78 +21,75 @@ using System.Linq;
 
 namespace Dynastream.Fit
 {
-    /// <summary>
-    /// Implements the OhrSettings profile message.
-    /// </summary>
-    public class OhrSettingsMesg : Mesg
-    {
-        #region Fields
-        #endregion
+	/// <summary>
+	/// Implements the OhrSettings profile message.
+	/// </summary>
+	public class OhrSettingsMesg : Mesg
+	{
+		#region Fields
+		#endregion
 
-        /// <summary>
-        /// Field Numbers for <see cref="OhrSettingsMesg"/>
-        /// </summary>
-        public sealed class FieldDefNum
-        {
-            public const byte Timestamp = 253;
-            public const byte Enabled = 0;
-            public const byte Invalid = Fit.FieldNumInvalid;
-        }
+		/// <summary>
+		/// Field Numbers for <see cref="OhrSettingsMesg"/>
+		/// </summary>
+		public sealed class FieldDefNum
+		{
+			public const byte Timestamp = 253;
+			public const byte Enabled = 0;
+			public const byte Invalid = Fit.FieldNumInvalid;
+		}
 
-        #region Constructors
-        public OhrSettingsMesg() : base(Profile.GetMesg(MesgNum.OhrSettings))
-        {
-        }
+		#region Constructors
+		public OhrSettingsMesg() : base(Profile.GetMesg(MesgNum.OhrSettings))
+		{
+		}
 
-        public OhrSettingsMesg(Mesg mesg) : base(mesg)
-        {
-        }
-        #endregion // Constructors
+		public OhrSettingsMesg(Mesg mesg) : base(mesg)
+		{
+		}
+		#endregion // Constructors
 
-        #region Methods
-        ///<summary>
-        /// Retrieves the Timestamp field
-        /// Units: s</summary>
-        /// <returns>Returns DateTime representing the Timestamp field</returns>
-        public DateTime GetTimestamp()
-        {
-            Object val = GetFieldValue(253, 0, Fit.SubfieldIndexMainField);
-            if(val == null)
-            {
-                return null;
-            }
+		#region Methods
+		///<summary>
+		/// Retrieves the Timestamp field
+		/// Units: s</summary>
+		/// <returns>Returns DateTime representing the Timestamp field</returns>
+		public DateTime Timestamp
+		{
+			get
+			{
+				Object val = GetFieldValue(253, 0, Fit.SubfieldIndexMainField);
+				if (val == null)
+				{
+					return null;
+				}
 
-            return TimestampToDateTime(Convert.ToUInt32(val));
-            
-        }
+				return TimestampToDateTime(Convert.ToUInt32(val));
 
-        /// <summary>
-        /// Set Timestamp field
-        /// Units: s</summary>
-        /// <param name="timestamp_">Nullable field value to be set</param>
-        public void SetTimestamp(DateTime timestamp_)
-        {
-            SetFieldValue(253, 0, timestamp_.GetTimeStamp(), Fit.SubfieldIndexMainField);
-        }
-        
-        ///<summary>
-        /// Retrieves the Enabled field</summary>
-        /// <returns>Returns nullable Switch enum representing the Enabled field</returns>
-        public Switch? GetEnabled()
-        {
-            object obj = GetFieldValue(0, 0, Fit.SubfieldIndexMainField);
-            Switch? value = obj == null ? (Switch?)null : (Switch)obj;
-            return value;
-        }
+			}
+			set
+			{
+				SetFieldValue(253, 0, value.GetTimeStamp(), Fit.SubfieldIndexMainField);
+			}
+		}
 
-        /// <summary>
-        /// Set Enabled field</summary>
-        /// <param name="enabled_">Nullable field value to be set</param>
-        public void SetEnabled(Switch? enabled_)
-        {
-            SetFieldValue(0, 0, enabled_, Fit.SubfieldIndexMainField);
-        }
-        
-        #endregion // Methods
-    } // Class
+		///<summary>
+		/// Retrieves the Enabled field</summary>
+		/// <returns>Returns nullable Switch enum representing the Enabled field</returns>
+		public Switch? Enabled
+		{
+			get
+			{
+				object obj = GetFieldValue(0, 0, Fit.SubfieldIndexMainField);
+				Switch? value = obj == null ? (Switch?)null : (Switch)obj;
+				return value;
+			}
+			set
+			{
+				SetFieldValue(0, 0, value, Fit.SubfieldIndexMainField);
+			}
+		}
+
+		#endregion // Methods
+	} // Class
 } // namespace

--- a/Dynastream/Fit/Profile/Mesgs/OneDSensorCalibrationMesg.cs
+++ b/Dynastream/Fit/Profile/Mesgs/OneDSensorCalibrationMesg.cs
@@ -21,223 +21,205 @@ using System.Linq;
 
 namespace Dynastream.Fit
 {
-    /// <summary>
-    /// Implements the OneDSensorCalibration profile message.
-    /// </summary>
-    public class OneDSensorCalibrationMesg : Mesg
-    {
-        #region Fields
-        static class CalibrationFactorSubfield
-        {
-            public static ushort BaroCalFactor = 0;
-            public static ushort Subfields = 1;
-            public static ushort Active = Fit.SubfieldIndexActiveSubfield;
-            public static ushort MainField = Fit.SubfieldIndexMainField;
-        }
-        #endregion
+	/// <summary>
+	/// Implements the OneDSensorCalibration profile message.
+	/// </summary>
+	public class OneDSensorCalibrationMesg : Mesg
+	{
+		#region Fields
+		static class CalibrationFactorSubfield
+		{
+			public static ushort BaroCalFactor = 0;
+			public static ushort Subfields = 1;
+			public static ushort Active = Fit.SubfieldIndexActiveSubfield;
+			public static ushort MainField = Fit.SubfieldIndexMainField;
+		}
+		#endregion
 
-        /// <summary>
-        /// Field Numbers for <see cref="OneDSensorCalibrationMesg"/>
-        /// </summary>
-        public sealed class FieldDefNum
-        {
-            public const byte Timestamp = 253;
-            public const byte SensorType = 0;
-            public const byte CalibrationFactor = 1;
-            public const byte CalibrationDivisor = 2;
-            public const byte LevelShift = 3;
-            public const byte OffsetCal = 4;
-            public const byte Invalid = Fit.FieldNumInvalid;
-        }
+		/// <summary>
+		/// Field Numbers for <see cref="OneDSensorCalibrationMesg"/>
+		/// </summary>
+		public sealed class FieldDefNum
+		{
+			public const byte Timestamp = 253;
+			public const byte SensorType = 0;
+			public const byte CalibrationFactor = 1;
+			public const byte CalibrationDivisor = 2;
+			public const byte LevelShift = 3;
+			public const byte OffsetCal = 4;
+			public const byte Invalid = Fit.FieldNumInvalid;
+		}
 
-        #region Constructors
-        public OneDSensorCalibrationMesg() : base(Profile.GetMesg(MesgNum.OneDSensorCalibration))
-        {
-        }
+		#region Constructors
+		public OneDSensorCalibrationMesg() : base(Profile.GetMesg(MesgNum.OneDSensorCalibration))
+		{
+		}
 
-        public OneDSensorCalibrationMesg(Mesg mesg) : base(mesg)
-        {
-        }
-        #endregion // Constructors
+		public OneDSensorCalibrationMesg(Mesg mesg) : base(mesg)
+		{
+		}
+		#endregion // Constructors
 
-        #region Methods
-        ///<summary>
-        /// Retrieves the Timestamp field
-        /// Units: s
-        /// Comment: Whole second part of the timestamp</summary>
-        /// <returns>Returns DateTime representing the Timestamp field</returns>
-        public DateTime GetTimestamp()
-        {
-            Object val = GetFieldValue(253, 0, Fit.SubfieldIndexMainField);
-            if(val == null)
-            {
-                return null;
-            }
+		#region Methods
+		///<summary>
+		/// Retrieves the Timestamp field
+		/// Units: s
+		/// Comment: Whole second part of the timestamp</summary>
+		/// <returns>Returns DateTime representing the Timestamp field</returns>
+		public DateTime Timestamp
+		{
+			get
+			{
+				Object val = GetFieldValue(253, 0, Fit.SubfieldIndexMainField);
+				if (val == null)
+				{
+					return null;
+				}
 
-            return TimestampToDateTime(Convert.ToUInt32(val));
-            
-        }
+				return TimestampToDateTime(Convert.ToUInt32(val));
 
-        /// <summary>
-        /// Set Timestamp field
-        /// Units: s
-        /// Comment: Whole second part of the timestamp</summary>
-        /// <param name="timestamp_">Nullable field value to be set</param>
-        public void SetTimestamp(DateTime timestamp_)
-        {
-            SetFieldValue(253, 0, timestamp_.GetTimeStamp(), Fit.SubfieldIndexMainField);
-        }
-        
-        ///<summary>
-        /// Retrieves the SensorType field
-        /// Comment: Indicates which sensor the calibration is for</summary>
-        /// <returns>Returns nullable SensorType enum representing the SensorType field</returns>
-        public SensorType? GetSensorType()
-        {
-            object obj = GetFieldValue(0, 0, Fit.SubfieldIndexMainField);
-            SensorType? value = obj == null ? (SensorType?)null : (SensorType)obj;
-            return value;
-        }
+			}
+			set
+			{
+				SetFieldValue(253, 0, value.GetTimeStamp(), Fit.SubfieldIndexMainField);
+			}
+		}
 
-        /// <summary>
-        /// Set SensorType field
-        /// Comment: Indicates which sensor the calibration is for</summary>
-        /// <param name="sensorType_">Nullable field value to be set</param>
-        public void SetSensorType(SensorType? sensorType_)
-        {
-            SetFieldValue(0, 0, sensorType_, Fit.SubfieldIndexMainField);
-        }
-        
-        ///<summary>
-        /// Retrieves the CalibrationFactor field
-        /// Comment: Calibration factor used to convert from raw ADC value to degrees, g, etc.</summary>
-        /// <returns>Returns nullable uint representing the CalibrationFactor field</returns>
-        public uint? GetCalibrationFactor()
-        {
-            Object val = GetFieldValue(1, 0, Fit.SubfieldIndexMainField);
-            if(val == null)
-            {
-                return null;
-            }
+		///<summary>
+		/// Retrieves the SensorType field
+		/// Comment: Indicates which sensor the calibration is for</summary>
+		/// <returns>Returns nullable SensorType enum representing the SensorType field</returns>
+		public SensorType? SensorType
+		{
+			get
+			{
+				object obj = GetFieldValue(0, 0, Fit.SubfieldIndexMainField);
+				SensorType? value = obj == null ? (SensorType?)null : (SensorType)obj;
+				return value;
+			}
+			set
+			{
+				SetFieldValue(0, 0, value, Fit.SubfieldIndexMainField);
+			}
+		}
 
-            return (Convert.ToUInt32(val));
-            
-        }
+		///<summary>
+		/// Retrieves the CalibrationFactor field
+		/// Comment: Calibration factor used to convert from raw ADC value to degrees, g, etc.</summary>
+		/// <returns>Returns nullable uint representing the CalibrationFactor field</returns>
+		public uint? CalibrationFactor
+		{
+			get
+			{
+				Object val = GetFieldValue(1, 0, Fit.SubfieldIndexMainField);
+				if (val == null)
+				{
+					return null;
+				}
 
-        /// <summary>
-        /// Set CalibrationFactor field
-        /// Comment: Calibration factor used to convert from raw ADC value to degrees, g, etc.</summary>
-        /// <param name="calibrationFactor_">Nullable field value to be set</param>
-        public void SetCalibrationFactor(uint? calibrationFactor_)
-        {
-            SetFieldValue(1, 0, calibrationFactor_, Fit.SubfieldIndexMainField);
-        }
-        
+				return (Convert.ToUInt32(val));
 
-        /// <summary>
-        /// Retrieves the BaroCalFactor subfield
-        /// Units: Pa
-        /// Comment: Barometer calibration factor</summary>
-        /// <returns>Nullable uint representing the BaroCalFactor subfield</returns>
-        public uint? GetBaroCalFactor()
-        {
-            Object val = GetFieldValue(1, 0, CalibrationFactorSubfield.BaroCalFactor);
-            if(val == null)
-            {
-                return null;
-            }
+			}
+			set
+			{
+				SetFieldValue(1, 0, value, Fit.SubfieldIndexMainField);
+			}
+		}
 
-            return (Convert.ToUInt32(val));
-            
-        }
 
-        /// <summary>
-        ///
-        /// Set BaroCalFactor subfield
-        /// Units: Pa
-        /// Comment: Barometer calibration factor</summary>
-        /// <param name="baroCalFactor">Subfield value to be set</param>
-        public void SetBaroCalFactor(uint? baroCalFactor)
-        {
-            SetFieldValue(1, 0, baroCalFactor, CalibrationFactorSubfield.BaroCalFactor);
-        }
-        ///<summary>
-        /// Retrieves the CalibrationDivisor field
-        /// Units: counts
-        /// Comment: Calibration factor divisor</summary>
-        /// <returns>Returns nullable uint representing the CalibrationDivisor field</returns>
-        public uint? GetCalibrationDivisor()
-        {
-            Object val = GetFieldValue(2, 0, Fit.SubfieldIndexMainField);
-            if(val == null)
-            {
-                return null;
-            }
+		/// <summary>
+		/// Retrieves the BaroCalFactor subfield
+		/// Units: Pa
+		/// Comment: Barometer calibration factor</summary>
+		/// <returns>Nullable uint representing the BaroCalFactor subfield</returns>
+		public uint? BaroCalFactor
+		{
+			get
+			{
+				Object val = GetFieldValue(1, 0, CalibrationFactorSubfield.BaroCalFactor);
+				if (val == null)
+				{
+					return null;
+				}
 
-            return (Convert.ToUInt32(val));
-            
-        }
+				return (Convert.ToUInt32(val));
 
-        /// <summary>
-        /// Set CalibrationDivisor field
-        /// Units: counts
-        /// Comment: Calibration factor divisor</summary>
-        /// <param name="calibrationDivisor_">Nullable field value to be set</param>
-        public void SetCalibrationDivisor(uint? calibrationDivisor_)
-        {
-            SetFieldValue(2, 0, calibrationDivisor_, Fit.SubfieldIndexMainField);
-        }
-        
-        ///<summary>
-        /// Retrieves the LevelShift field
-        /// Comment: Level shift value used to shift the ADC value back into range</summary>
-        /// <returns>Returns nullable uint representing the LevelShift field</returns>
-        public uint? GetLevelShift()
-        {
-            Object val = GetFieldValue(3, 0, Fit.SubfieldIndexMainField);
-            if(val == null)
-            {
-                return null;
-            }
+			}
+			set
+			{
+				SetFieldValue(1, 0, value, CalibrationFactorSubfield.BaroCalFactor);
+			}
+		}
+		///<summary>
+		/// Retrieves the CalibrationDivisor field
+		/// Units: counts
+		/// Comment: Calibration factor divisor</summary>
+		/// <returns>Returns nullable uint representing the CalibrationDivisor field</returns>
+		public uint? CalibrationDivisor
+		{
+			get
+			{
+				Object val = GetFieldValue(2, 0, Fit.SubfieldIndexMainField);
+				if (val == null)
+				{
+					return null;
+				}
 
-            return (Convert.ToUInt32(val));
-            
-        }
+				return (Convert.ToUInt32(val));
 
-        /// <summary>
-        /// Set LevelShift field
-        /// Comment: Level shift value used to shift the ADC value back into range</summary>
-        /// <param name="levelShift_">Nullable field value to be set</param>
-        public void SetLevelShift(uint? levelShift_)
-        {
-            SetFieldValue(3, 0, levelShift_, Fit.SubfieldIndexMainField);
-        }
-        
-        ///<summary>
-        /// Retrieves the OffsetCal field
-        /// Comment: Internal Calibration factor</summary>
-        /// <returns>Returns nullable int representing the OffsetCal field</returns>
-        public int? GetOffsetCal()
-        {
-            Object val = GetFieldValue(4, 0, Fit.SubfieldIndexMainField);
-            if(val == null)
-            {
-                return null;
-            }
+			}
+			set
+			{
+				SetFieldValue(2, 0, value, Fit.SubfieldIndexMainField);
+			}
+		}
 
-            return (Convert.ToInt32(val));
-            
-        }
+		///<summary>
+		/// Retrieves the LevelShift field
+		/// Comment: Level shift value used to shift the ADC value back into range</summary>
+		/// <returns>Returns nullable uint representing the LevelShift field</returns>
+		public uint? LevelShift
+		{
+			get
+			{
+				Object val = GetFieldValue(3, 0, Fit.SubfieldIndexMainField);
+				if (val == null)
+				{
+					return null;
+				}
 
-        /// <summary>
-        /// Set OffsetCal field
-        /// Comment: Internal Calibration factor</summary>
-        /// <param name="offsetCal_">Nullable field value to be set</param>
-        public void SetOffsetCal(int? offsetCal_)
-        {
-            SetFieldValue(4, 0, offsetCal_, Fit.SubfieldIndexMainField);
-        }
-        
-        #endregion // Methods
-    } // Class
+				return (Convert.ToUInt32(val));
+
+			}
+			set
+			{
+				SetFieldValue(3, 0, value, Fit.SubfieldIndexMainField);
+			}
+		}
+
+		///<summary>
+		/// Retrieves the OffsetCal field
+		/// Comment: Internal Calibration factor</summary>
+		/// <returns>Returns nullable int representing the OffsetCal field</returns>
+		public int? OffsetCal
+		{
+			get
+			{
+				Object val = GetFieldValue(4, 0, Fit.SubfieldIndexMainField);
+				if (val == null)
+				{
+					return null;
+				}
+
+				return (Convert.ToInt32(val));
+
+			}
+			set
+			{
+				SetFieldValue(4, 0, value, Fit.SubfieldIndexMainField);
+			}
+		}
+
+		#endregion // Methods
+	} // Class
 } // namespace

--- a/Dynastream/Fit/Profile/Mesgs/PadMesg.cs
+++ b/Dynastream/Fit/Profile/Mesgs/PadMesg.cs
@@ -21,33 +21,33 @@ using System.Linq;
 
 namespace Dynastream.Fit
 {
-    /// <summary>
-    /// Implements the Pad profile message.
-    /// </summary>
-    public class PadMesg : Mesg
-    {
-        #region Fields
-        #endregion
+	/// <summary>
+	/// Implements the Pad profile message.
+	/// </summary>
+	public class PadMesg : Mesg
+	{
+		#region Fields
+		#endregion
 
-        /// <summary>
-        /// Field Numbers for <see cref="PadMesg"/>
-        /// </summary>
-        public sealed class FieldDefNum
-        {
-            public const byte Invalid = Fit.FieldNumInvalid;
-        }
+		/// <summary>
+		/// Field Numbers for <see cref="PadMesg"/>
+		/// </summary>
+		public sealed class FieldDefNum
+		{
+			public const byte Invalid = Fit.FieldNumInvalid;
+		}
 
-        #region Constructors
-        public PadMesg() : base(Profile.GetMesg(MesgNum.Pad))
-        {
-        }
+		#region Constructors
+		public PadMesg() : base(Profile.GetMesg(MesgNum.Pad))
+		{
+		}
 
-        public PadMesg(Mesg mesg) : base(mesg)
-        {
-        }
-        #endregion // Constructors
+		public PadMesg(Mesg mesg) : base(mesg)
+		{
+		}
+		#endregion // Constructors
 
-        #region Methods
-        #endregion // Methods
-    } // Class
+		#region Methods
+		#endregion // Methods
+	} // Class
 } // namespace

--- a/Dynastream/Fit/Profile/Mesgs/PowerZoneMesg.cs
+++ b/Dynastream/Fit/Profile/Mesgs/PowerZoneMesg.cs
@@ -21,122 +21,117 @@ using System.Linq;
 
 namespace Dynastream.Fit
 {
-    /// <summary>
-    /// Implements the PowerZone profile message.
-    /// </summary>
-    public class PowerZoneMesg : Mesg
-    {
-        #region Fields
-        #endregion
+	/// <summary>
+	/// Implements the PowerZone profile message.
+	/// </summary>
+	public class PowerZoneMesg : Mesg
+	{
+		#region Fields
+		#endregion
 
-        /// <summary>
-        /// Field Numbers for <see cref="PowerZoneMesg"/>
-        /// </summary>
-        public sealed class FieldDefNum
-        {
-            public const byte MessageIndex = 254;
-            public const byte HighValue = 1;
-            public const byte Name = 2;
-            public const byte Invalid = Fit.FieldNumInvalid;
-        }
+		/// <summary>
+		/// Field Numbers for <see cref="PowerZoneMesg"/>
+		/// </summary>
+		public sealed class FieldDefNum
+		{
+			public const byte MessageIndex = 254;
+			public const byte HighValue = 1;
+			public const byte Name = 2;
+			public const byte Invalid = Fit.FieldNumInvalid;
+		}
 
-        #region Constructors
-        public PowerZoneMesg() : base(Profile.GetMesg(MesgNum.PowerZone))
-        {
-        }
+		#region Constructors
+		public PowerZoneMesg() : base(Profile.GetMesg(MesgNum.PowerZone))
+		{
+		}
 
-        public PowerZoneMesg(Mesg mesg) : base(mesg)
-        {
-        }
-        #endregion // Constructors
+		public PowerZoneMesg(Mesg mesg) : base(mesg)
+		{
+		}
+		#endregion // Constructors
 
-        #region Methods
-        ///<summary>
-        /// Retrieves the MessageIndex field</summary>
-        /// <returns>Returns nullable ushort representing the MessageIndex field</returns>
-        public ushort? GetMessageIndex()
-        {
-            Object val = GetFieldValue(254, 0, Fit.SubfieldIndexMainField);
-            if(val == null)
-            {
-                return null;
-            }
+		#region Methods
+		///<summary>
+		/// Retrieves the MessageIndex field</summary>
+		/// <returns>Returns nullable ushort representing the MessageIndex field</returns>
+		public ushort? MessageIndex
+		{
+			get
+			{
+				Object val = GetFieldValue(254, 0, Fit.SubfieldIndexMainField);
+				if (val == null)
+				{
+					return null;
+				}
 
-            return (Convert.ToUInt16(val));
-            
-        }
+				return (Convert.ToUInt16(val));
 
-        /// <summary>
-        /// Set MessageIndex field</summary>
-        /// <param name="messageIndex_">Nullable field value to be set</param>
-        public void SetMessageIndex(ushort? messageIndex_)
-        {
-            SetFieldValue(254, 0, messageIndex_, Fit.SubfieldIndexMainField);
-        }
-        
-        ///<summary>
-        /// Retrieves the HighValue field
-        /// Units: watts</summary>
-        /// <returns>Returns nullable ushort representing the HighValue field</returns>
-        public ushort? GetHighValue()
-        {
-            Object val = GetFieldValue(1, 0, Fit.SubfieldIndexMainField);
-            if(val == null)
-            {
-                return null;
-            }
+			}
+			set
+			{
+				SetFieldValue(254, 0, value, Fit.SubfieldIndexMainField);
+			}
+		}
 
-            return (Convert.ToUInt16(val));
-            
-        }
+		///<summary>
+		/// Retrieves the HighValue field
+		/// Units: watts</summary>
+		/// <returns>Returns nullable ushort representing the HighValue field</returns>
+		public ushort? HighValue
+		{
+			get
+			{
+				Object val = GetFieldValue(1, 0, Fit.SubfieldIndexMainField);
+				if (val == null)
+				{
+					return null;
+				}
 
-        /// <summary>
-        /// Set HighValue field
-        /// Units: watts</summary>
-        /// <param name="highValue_">Nullable field value to be set</param>
-        public void SetHighValue(ushort? highValue_)
-        {
-            SetFieldValue(1, 0, highValue_, Fit.SubfieldIndexMainField);
-        }
-        
-        ///<summary>
-        /// Retrieves the Name field</summary>
-        /// <returns>Returns byte[] representing the Name field</returns>
-        public byte[] GetName()
-        {
-            byte[] data = (byte[])GetFieldValue(2, 0, Fit.SubfieldIndexMainField);
-            return data.Take(data.Length - 1).ToArray();
-        }
+				return (Convert.ToUInt16(val));
 
-        ///<summary>
-        /// Retrieves the Name field</summary>
-        /// <returns>Returns String representing the Name field</returns>
-        public String GetNameAsString()
-        {
-            byte[] data = (byte[])GetFieldValue(2, 0, Fit.SubfieldIndexMainField);
-            return data != null ? Encoding.UTF8.GetString(data, 0, data.Length - 1) : null;
-        }
+			}
+			set
+			{
+				SetFieldValue(1, 0, value, Fit.SubfieldIndexMainField);
+			}
+		}
 
-        ///<summary>
-        /// Set Name field</summary>
-        /// <param name="name_"> field value to be set</param>
-        public void SetName(String name_)
-        {
-            byte[] data = Encoding.UTF8.GetBytes(name_);
-            byte[] zdata = new byte[data.Length + 1];
-            data.CopyTo(zdata, 0);
-            SetFieldValue(2, 0, zdata, Fit.SubfieldIndexMainField);
-        }
+		///<summary>
+		/// Retrieves the Name field</summary>
+		/// <returns>Returns byte[] representing the Name field</returns>
+		public byte[] Name
+		{
+			get
+			{
+				byte[] data = (byte[])GetFieldValue(2, 0, Fit.SubfieldIndexMainField);
+				return data.Take(data.Length - 1).ToArray();
+			}
+			set
+			{
+				SetFieldValue(2, 0, value, Fit.SubfieldIndexMainField);
+			}
+		}
 
-        
-        /// <summary>
-        /// Set Name field</summary>
-        /// <param name="name_">field value to be set</param>
-        public void SetName(byte[] name_)
-        {
-            SetFieldValue(2, 0, name_, Fit.SubfieldIndexMainField);
-        }
-        
-        #endregion // Methods
-    } // Class
+		///<summary>
+		/// Retrieves the Name field</summary>
+		/// <returns>Returns String representing the Name field</returns>
+		public String GetNameAsString()
+		{
+			byte[] data = (byte[])GetFieldValue(2, 0, Fit.SubfieldIndexMainField);
+			return data != null ? Encoding.UTF8.GetString(data, 0, data.Length - 1) : null;
+		}
+
+		///<summary>
+		/// Set Name field</summary>
+		/// <param name="name_"> field value to be set</param>
+		public void SetName(String name_)
+		{
+			byte[] data = Encoding.UTF8.GetBytes(name_);
+			byte[] zdata = new byte[data.Length + 1];
+			data.CopyTo(zdata, 0);
+			SetFieldValue(2, 0, zdata, Fit.SubfieldIndexMainField);
+		}
+
+		#endregion // Methods
+	} // Class
 } // namespace

--- a/Dynastream/Fit/Profile/Mesgs/RawBbiMesg.cs
+++ b/Dynastream/Fit/Profile/Mesgs/RawBbiMesg.cs
@@ -21,239 +21,235 @@ using System.Linq;
 
 namespace Dynastream.Fit
 {
-    /// <summary>
-    /// Implements the RawBbi profile message.
-    /// </summary>
-    public class RawBbiMesg : Mesg
-    {
-        #region Fields
-        #endregion
+	/// <summary>
+	/// Implements the RawBbi profile message.
+	/// </summary>
+	public class RawBbiMesg : Mesg
+	{
+		#region Fields
+		#endregion
 
-        /// <summary>
-        /// Field Numbers for <see cref="RawBbiMesg"/>
-        /// </summary>
-        public sealed class FieldDefNum
-        {
-            public const byte Timestamp = 253;
-            public const byte TimestampMs = 0;
-            public const byte Data = 1;
-            public const byte Time = 2;
-            public const byte Quality = 3;
-            public const byte Gap = 4;
-            public const byte Invalid = Fit.FieldNumInvalid;
-        }
+		/// <summary>
+		/// Field Numbers for <see cref="RawBbiMesg"/>
+		/// </summary>
+		public sealed class FieldDefNum
+		{
+			public const byte Timestamp = 253;
+			public const byte TimestampMs = 0;
+			public const byte Data = 1;
+			public const byte Time = 2;
+			public const byte Quality = 3;
+			public const byte Gap = 4;
+			public const byte Invalid = Fit.FieldNumInvalid;
+		}
 
-        #region Constructors
-        public RawBbiMesg() : base(Profile.GetMesg(MesgNum.RawBbi))
-        {
-        }
+		#region Constructors
+		public RawBbiMesg() : base(Profile.GetMesg(MesgNum.RawBbi))
+		{
+		}
 
-        public RawBbiMesg(Mesg mesg) : base(mesg)
-        {
-        }
-        #endregion // Constructors
+		public RawBbiMesg(Mesg mesg) : base(mesg)
+		{
+		}
+		#endregion // Constructors
 
-        #region Methods
-        ///<summary>
-        /// Retrieves the Timestamp field</summary>
-        /// <returns>Returns DateTime representing the Timestamp field</returns>
-        public DateTime GetTimestamp()
-        {
-            Object val = GetFieldValue(253, 0, Fit.SubfieldIndexMainField);
-            if(val == null)
-            {
-                return null;
-            }
+		#region Methods
+		///<summary>
+		/// Retrieves the Timestamp field</summary>
+		/// <returns>Returns DateTime representing the Timestamp field</returns>
+		public DateTime Timestamp
+		{
+			get
+			{
+				Object val = GetFieldValue(253, 0, Fit.SubfieldIndexMainField);
+				if (val == null)
+				{
+					return null;
+				}
 
-            return TimestampToDateTime(Convert.ToUInt32(val));
-            
-        }
+				return TimestampToDateTime(Convert.ToUInt32(val));
 
-        /// <summary>
-        /// Set Timestamp field</summary>
-        /// <param name="timestamp_">Nullable field value to be set</param>
-        public void SetTimestamp(DateTime timestamp_)
-        {
-            SetFieldValue(253, 0, timestamp_.GetTimeStamp(), Fit.SubfieldIndexMainField);
-        }
-        
-        ///<summary>
-        /// Retrieves the TimestampMs field
-        /// Units: ms
-        /// Comment: Millisecond resolution of the timestamp</summary>
-        /// <returns>Returns nullable ushort representing the TimestampMs field</returns>
-        public ushort? GetTimestampMs()
-        {
-            Object val = GetFieldValue(0, 0, Fit.SubfieldIndexMainField);
-            if(val == null)
-            {
-                return null;
-            }
+			}
+			set
+			{
+				SetFieldValue(253, 0, value.GetTimeStamp(), Fit.SubfieldIndexMainField);
+			}
+		}
 
-            return (Convert.ToUInt16(val));
-            
-        }
+		///<summary>
+		/// Retrieves the TimestampMs field
+		/// Units: ms
+		/// Comment: Millisecond resolution of the timestamp</summary>
+		/// <returns>Returns nullable ushort representing the TimestampMs field</returns>
+		public ushort? TimestampMs
+		{
+			get
+			{
+				Object val = GetFieldValue(0, 0, Fit.SubfieldIndexMainField);
+				if (val == null)
+				{
+					return null;
+				}
 
-        /// <summary>
-        /// Set TimestampMs field
-        /// Units: ms
-        /// Comment: Millisecond resolution of the timestamp</summary>
-        /// <param name="timestampMs_">Nullable field value to be set</param>
-        public void SetTimestampMs(ushort? timestampMs_)
-        {
-            SetFieldValue(0, 0, timestampMs_, Fit.SubfieldIndexMainField);
-        }
-        
-        
-        /// <summary>
-        ///
-        /// </summary>
-        /// <returns>returns number of elements in field Data</returns>
-        public int GetNumData()
-        {
-            return GetNumFieldValues(1, Fit.SubfieldIndexMainField);
-        }
+				return (Convert.ToUInt16(val));
 
-        ///<summary>
-        /// Retrieves the Data field
-        /// Comment: 1 bit for gap indicator, 1 bit for quality indicator, and 14 bits for Beat-to-Beat interval values in whole-integer millisecond resolution</summary>
-        /// <param name="index">0 based index of Data element to retrieve</param>
-        /// <returns>Returns nullable ushort representing the Data field</returns>
-        public ushort? GetData(int index)
-        {
-            Object val = GetFieldValue(1, index, Fit.SubfieldIndexMainField);
-            if(val == null)
-            {
-                return null;
-            }
+			}
+			set
+			{
+				SetFieldValue(0, 0, value, Fit.SubfieldIndexMainField);
+			}
+		}
 
-            return (Convert.ToUInt16(val));
-            
-        }
 
-        /// <summary>
-        /// Set Data field
-        /// Comment: 1 bit for gap indicator, 1 bit for quality indicator, and 14 bits for Beat-to-Beat interval values in whole-integer millisecond resolution</summary>
-        /// <param name="index">0 based index of data</param>
-        /// <param name="data_">Nullable field value to be set</param>
-        public void SetData(int index, ushort? data_)
-        {
-            SetFieldValue(1, index, data_, Fit.SubfieldIndexMainField);
-        }
-        
-        
-        /// <summary>
-        ///
-        /// </summary>
-        /// <returns>returns number of elements in field Time</returns>
-        public int GetNumTime()
-        {
-            return GetNumFieldValues(2, Fit.SubfieldIndexMainField);
-        }
+		/// <summary>
+		///
+		/// </summary>
+		/// <returns>returns number of elements in field Data</returns>
+		public int GetNumData()
+		{
+			return GetNumFieldValues(1, Fit.SubfieldIndexMainField);
+		}
 
-        ///<summary>
-        /// Retrieves the Time field
-        /// Units: ms
-        /// Comment: Array of millisecond times between beats</summary>
-        /// <param name="index">0 based index of Time element to retrieve</param>
-        /// <returns>Returns nullable ushort representing the Time field</returns>
-        public ushort? GetTime(int index)
-        {
-            Object val = GetFieldValue(2, index, Fit.SubfieldIndexMainField);
-            if(val == null)
-            {
-                return null;
-            }
+		///<summary>
+		/// Retrieves the Data field
+		/// Comment: 1 bit for gap indicator, 1 bit for quality indicator, and 14 bits for Beat-to-Beat interval values in whole-integer millisecond resolution</summary>
+		/// <param name="index">0 based index of Data element to retrieve</param>
+		/// <returns>Returns nullable ushort representing the Data field</returns>
+		public ushort? GetData(int index)
+		{
+			Object val = GetFieldValue(1, index, Fit.SubfieldIndexMainField);
+			if (val == null)
+			{
+				return null;
+			}
 
-            return (Convert.ToUInt16(val));
-            
-        }
+			return (Convert.ToUInt16(val));
 
-        /// <summary>
-        /// Set Time field
-        /// Units: ms
-        /// Comment: Array of millisecond times between beats</summary>
-        /// <param name="index">0 based index of time</param>
-        /// <param name="time_">Nullable field value to be set</param>
-        public void SetTime(int index, ushort? time_)
-        {
-            SetFieldValue(2, index, time_, Fit.SubfieldIndexMainField);
-        }
-        
-        
-        /// <summary>
-        ///
-        /// </summary>
-        /// <returns>returns number of elements in field Quality</returns>
-        public int GetNumQuality()
-        {
-            return GetNumFieldValues(3, Fit.SubfieldIndexMainField);
-        }
+		}
 
-        ///<summary>
-        /// Retrieves the Quality field
-        /// Comment: 1 = high confidence. 0 = low confidence. N/A when gap = 1</summary>
-        /// <param name="index">0 based index of Quality element to retrieve</param>
-        /// <returns>Returns nullable byte representing the Quality field</returns>
-        public byte? GetQuality(int index)
-        {
-            Object val = GetFieldValue(3, index, Fit.SubfieldIndexMainField);
-            if(val == null)
-            {
-                return null;
-            }
+		/// <summary>
+		/// Set Data field
+		/// Comment: 1 bit for gap indicator, 1 bit for quality indicator, and 14 bits for Beat-to-Beat interval values in whole-integer millisecond resolution</summary>
+		/// <param name="index">0 based index of data</param>
+		/// <param name="data_">Nullable field value to be set</param>
+		public void SetData(int index, ushort? data_)
+		{
+			SetFieldValue(1, index, data_, Fit.SubfieldIndexMainField);
+		}
 
-            return (Convert.ToByte(val));
-            
-        }
 
-        /// <summary>
-        /// Set Quality field
-        /// Comment: 1 = high confidence. 0 = low confidence. N/A when gap = 1</summary>
-        /// <param name="index">0 based index of quality</param>
-        /// <param name="quality_">Nullable field value to be set</param>
-        public void SetQuality(int index, byte? quality_)
-        {
-            SetFieldValue(3, index, quality_, Fit.SubfieldIndexMainField);
-        }
-        
-        
-        /// <summary>
-        ///
-        /// </summary>
-        /// <returns>returns number of elements in field Gap</returns>
-        public int GetNumGap()
-        {
-            return GetNumFieldValues(4, Fit.SubfieldIndexMainField);
-        }
+		/// <summary>
+		///
+		/// </summary>
+		/// <returns>returns number of elements in field Time</returns>
+		public int GetNumTime()
+		{
+			return GetNumFieldValues(2, Fit.SubfieldIndexMainField);
+		}
 
-        ///<summary>
-        /// Retrieves the Gap field
-        /// Comment: 1 = gap (time represents ms gap length). 0 = BBI data</summary>
-        /// <param name="index">0 based index of Gap element to retrieve</param>
-        /// <returns>Returns nullable byte representing the Gap field</returns>
-        public byte? GetGap(int index)
-        {
-            Object val = GetFieldValue(4, index, Fit.SubfieldIndexMainField);
-            if(val == null)
-            {
-                return null;
-            }
+		///<summary>
+		/// Retrieves the Time field
+		/// Units: ms
+		/// Comment: Array of millisecond times between beats</summary>
+		/// <param name="index">0 based index of Time element to retrieve</param>
+		/// <returns>Returns nullable ushort representing the Time field</returns>
+		public ushort? GetTime(int index)
+		{
+			Object val = GetFieldValue(2, index, Fit.SubfieldIndexMainField);
+			if (val == null)
+			{
+				return null;
+			}
 
-            return (Convert.ToByte(val));
-            
-        }
+			return (Convert.ToUInt16(val));
 
-        /// <summary>
-        /// Set Gap field
-        /// Comment: 1 = gap (time represents ms gap length). 0 = BBI data</summary>
-        /// <param name="index">0 based index of gap</param>
-        /// <param name="gap_">Nullable field value to be set</param>
-        public void SetGap(int index, byte? gap_)
-        {
-            SetFieldValue(4, index, gap_, Fit.SubfieldIndexMainField);
-        }
-        
-        #endregion // Methods
-    } // Class
+		}
+
+		/// <summary>
+		/// Set Time field
+		/// Units: ms
+		/// Comment: Array of millisecond times between beats</summary>
+		/// <param name="index">0 based index of time</param>
+		/// <param name="time_">Nullable field value to be set</param>
+		public void SetTime(int index, ushort? time_)
+		{
+			SetFieldValue(2, index, time_, Fit.SubfieldIndexMainField);
+		}
+
+
+		/// <summary>
+		///
+		/// </summary>
+		/// <returns>returns number of elements in field Quality</returns>
+		public int GetNumQuality()
+		{
+			return GetNumFieldValues(3, Fit.SubfieldIndexMainField);
+		}
+
+		///<summary>
+		/// Retrieves the Quality field
+		/// Comment: 1 = high confidence. 0 = low confidence. N/A when gap = 1</summary>
+		/// <param name="index">0 based index of Quality element to retrieve</param>
+		/// <returns>Returns nullable byte representing the Quality field</returns>
+		public byte? GetQuality(int index)
+		{
+			Object val = GetFieldValue(3, index, Fit.SubfieldIndexMainField);
+			if (val == null)
+			{
+				return null;
+			}
+
+			return (Convert.ToByte(val));
+
+		}
+
+		/// <summary>
+		/// Set Quality field
+		/// Comment: 1 = high confidence. 0 = low confidence. N/A when gap = 1</summary>
+		/// <param name="index">0 based index of quality</param>
+		/// <param name="quality_">Nullable field value to be set</param>
+		public void SetQuality(int index, byte? quality_)
+		{
+			SetFieldValue(3, index, quality_, Fit.SubfieldIndexMainField);
+		}
+
+
+		/// <summary>
+		///
+		/// </summary>
+		/// <returns>returns number of elements in field Gap</returns>
+		public int GetNumGap()
+		{
+			return GetNumFieldValues(4, Fit.SubfieldIndexMainField);
+		}
+
+		///<summary>
+		/// Retrieves the Gap field
+		/// Comment: 1 = gap (time represents ms gap length). 0 = BBI data</summary>
+		/// <param name="index">0 based index of Gap element to retrieve</param>
+		/// <returns>Returns nullable byte representing the Gap field</returns>
+		public byte? GetGap(int index)
+		{
+			Object val = GetFieldValue(4, index, Fit.SubfieldIndexMainField);
+			if (val == null)
+			{
+				return null;
+			}
+
+			return (Convert.ToByte(val));
+
+		}
+
+		/// <summary>
+		/// Set Gap field
+		/// Comment: 1 = gap (time represents ms gap length). 0 = BBI data</summary>
+		/// <param name="index">0 based index of gap</param>
+		/// <param name="gap_">Nullable field value to be set</param>
+		public void SetGap(int index, byte? gap_)
+		{
+			SetFieldValue(4, index, gap_, Fit.SubfieldIndexMainField);
+		}
+
+		#endregion // Methods
+	} // Class
 } // namespace

--- a/Dynastream/Fit/Profile/Mesgs/RecordMesg.cs
+++ b/Dynastream/Fit/Profile/Mesgs/RecordMesg.cs
@@ -21,2315 +21,2145 @@ using System.Linq;
 
 namespace Dynastream.Fit
 {
-    /// <summary>
-    /// Implements the Record profile message.
-    /// </summary>
-    public class RecordMesg : Mesg
-    {
-        #region Fields
-        #endregion
-
-        /// <summary>
-        /// Field Numbers for <see cref="RecordMesg"/>
-        /// </summary>
-        public sealed class FieldDefNum
-        {
-            public const byte Timestamp = 253;
-            public const byte PositionLat = 0;
-            public const byte PositionLong = 1;
-            public const byte Altitude = 2;
-            public const byte HeartRate = 3;
-            public const byte Cadence = 4;
-            public const byte Distance = 5;
-            public const byte Speed = 6;
-            public const byte Power = 7;
-            public const byte CompressedSpeedDistance = 8;
-            public const byte Grade = 9;
-            public const byte Resistance = 10;
-            public const byte TimeFromCourse = 11;
-            public const byte CycleLength = 12;
-            public const byte Temperature = 13;
-            public const byte Speed1s = 17;
-            public const byte Cycles = 18;
-            public const byte TotalCycles = 19;
-            public const byte CompressedAccumulatedPower = 28;
-            public const byte AccumulatedPower = 29;
-            public const byte LeftRightBalance = 30;
-            public const byte GpsAccuracy = 31;
-            public const byte VerticalSpeed = 32;
-            public const byte Calories = 33;
-            public const byte VerticalOscillation = 39;
-            public const byte StanceTimePercent = 40;
-            public const byte StanceTime = 41;
-            public const byte ActivityType = 42;
-            public const byte LeftTorqueEffectiveness = 43;
-            public const byte RightTorqueEffectiveness = 44;
-            public const byte LeftPedalSmoothness = 45;
-            public const byte RightPedalSmoothness = 46;
-            public const byte CombinedPedalSmoothness = 47;
-            public const byte Time128 = 48;
-            public const byte StrokeType = 49;
-            public const byte Zone = 50;
-            public const byte BallSpeed = 51;
-            public const byte Cadence256 = 52;
-            public const byte FractionalCadence = 53;
-            public const byte TotalHemoglobinConc = 54;
-            public const byte TotalHemoglobinConcMin = 55;
-            public const byte TotalHemoglobinConcMax = 56;
-            public const byte SaturatedHemoglobinPercent = 57;
-            public const byte SaturatedHemoglobinPercentMin = 58;
-            public const byte SaturatedHemoglobinPercentMax = 59;
-            public const byte DeviceIndex = 62;
-            public const byte LeftPco = 67;
-            public const byte RightPco = 68;
-            public const byte LeftPowerPhase = 69;
-            public const byte LeftPowerPhasePeak = 70;
-            public const byte RightPowerPhase = 71;
-            public const byte RightPowerPhasePeak = 72;
-            public const byte EnhancedSpeed = 73;
-            public const byte EnhancedAltitude = 78;
-            public const byte BatterySoc = 81;
-            public const byte MotorPower = 82;
-            public const byte VerticalRatio = 83;
-            public const byte StanceTimeBalance = 84;
-            public const byte StepLength = 85;
-            public const byte CycleLength16 = 87;
-            public const byte AbsolutePressure = 91;
-            public const byte Depth = 92;
-            public const byte NextStopDepth = 93;
-            public const byte NextStopTime = 94;
-            public const byte TimeToSurface = 95;
-            public const byte NdlTime = 96;
-            public const byte CnsLoad = 97;
-            public const byte N2Load = 98;
-            public const byte RespirationRate = 99;
-            public const byte EnhancedRespirationRate = 108;
-            public const byte Grit = 114;
-            public const byte Flow = 115;
-            public const byte CurrentStress = 116;
-            public const byte EbikeTravelRange = 117;
-            public const byte EbikeBatteryLevel = 118;
-            public const byte EbikeAssistMode = 119;
-            public const byte EbikeAssistLevelPercent = 120;
-            public const byte AirTimeRemaining = 123;
-            public const byte PressureSac = 124;
-            public const byte VolumeSac = 125;
-            public const byte Rmv = 126;
-            public const byte AscentRate = 127;
-            public const byte Po2 = 129;
-            public const byte CoreTemperature = 139;
-            public const byte Invalid = Fit.FieldNumInvalid;
-        }
-
-        #region Constructors
-        public RecordMesg() : base(Profile.GetMesg(MesgNum.Record))
-        {
-        }
-
-        public RecordMesg(Mesg mesg) : base(mesg)
-        {
-        }
-        #endregion // Constructors
-
-        #region Methods
-        ///<summary>
-        /// Retrieves the Timestamp field
-        /// Units: s</summary>
-        /// <returns>Returns DateTime representing the Timestamp field</returns>
-        public DateTime GetTimestamp()
-        {
-            Object val = GetFieldValue(253, 0, Fit.SubfieldIndexMainField);
-            if(val == null)
-            {
-                return null;
-            }
-
-            return TimestampToDateTime(Convert.ToUInt32(val));
-            
-        }
-
-        /// <summary>
-        /// Set Timestamp field
-        /// Units: s</summary>
-        /// <param name="timestamp_">Nullable field value to be set</param>
-        public void SetTimestamp(DateTime timestamp_)
-        {
-            SetFieldValue(253, 0, timestamp_.GetTimeStamp(), Fit.SubfieldIndexMainField);
-        }
-        
-        ///<summary>
-        /// Retrieves the PositionLat field
-        /// Units: semicircles</summary>
-        /// <returns>Returns nullable int representing the PositionLat field</returns>
-        public int? GetPositionLat()
-        {
-            Object val = GetFieldValue(0, 0, Fit.SubfieldIndexMainField);
-            if(val == null)
-            {
-                return null;
-            }
-
-            return (Convert.ToInt32(val));
-            
-        }
-
-        /// <summary>
-        /// Set PositionLat field
-        /// Units: semicircles</summary>
-        /// <param name="positionLat_">Nullable field value to be set</param>
-        public void SetPositionLat(int? positionLat_)
-        {
-            SetFieldValue(0, 0, positionLat_, Fit.SubfieldIndexMainField);
-        }
-        
-        ///<summary>
-        /// Retrieves the PositionLong field
-        /// Units: semicircles</summary>
-        /// <returns>Returns nullable int representing the PositionLong field</returns>
-        public int? GetPositionLong()
-        {
-            Object val = GetFieldValue(1, 0, Fit.SubfieldIndexMainField);
-            if(val == null)
-            {
-                return null;
-            }
-
-            return (Convert.ToInt32(val));
-            
-        }
-
-        /// <summary>
-        /// Set PositionLong field
-        /// Units: semicircles</summary>
-        /// <param name="positionLong_">Nullable field value to be set</param>
-        public void SetPositionLong(int? positionLong_)
-        {
-            SetFieldValue(1, 0, positionLong_, Fit.SubfieldIndexMainField);
-        }
-        
-        ///<summary>
-        /// Retrieves the Altitude field
-        /// Units: m</summary>
-        /// <returns>Returns nullable float representing the Altitude field</returns>
-        public float? GetAltitude()
-        {
-            Object val = GetFieldValue(2, 0, Fit.SubfieldIndexMainField);
-            if(val == null)
-            {
-                return null;
-            }
-
-            return (Convert.ToSingle(val));
-            
-        }
-
-        /// <summary>
-        /// Set Altitude field
-        /// Units: m</summary>
-        /// <param name="altitude_">Nullable field value to be set</param>
-        public void SetAltitude(float? altitude_)
-        {
-            SetFieldValue(2, 0, altitude_, Fit.SubfieldIndexMainField);
-        }
-        
-        ///<summary>
-        /// Retrieves the HeartRate field
-        /// Units: bpm</summary>
-        /// <returns>Returns nullable byte representing the HeartRate field</returns>
-        public byte? GetHeartRate()
-        {
-            Object val = GetFieldValue(3, 0, Fit.SubfieldIndexMainField);
-            if(val == null)
-            {
-                return null;
-            }
-
-            return (Convert.ToByte(val));
-            
-        }
-
-        /// <summary>
-        /// Set HeartRate field
-        /// Units: bpm</summary>
-        /// <param name="heartRate_">Nullable field value to be set</param>
-        public void SetHeartRate(byte? heartRate_)
-        {
-            SetFieldValue(3, 0, heartRate_, Fit.SubfieldIndexMainField);
-        }
-        
-        ///<summary>
-        /// Retrieves the Cadence field
-        /// Units: rpm</summary>
-        /// <returns>Returns nullable byte representing the Cadence field</returns>
-        public byte? GetCadence()
-        {
-            Object val = GetFieldValue(4, 0, Fit.SubfieldIndexMainField);
-            if(val == null)
-            {
-                return null;
-            }
-
-            return (Convert.ToByte(val));
-            
-        }
-
-        /// <summary>
-        /// Set Cadence field
-        /// Units: rpm</summary>
-        /// <param name="cadence_">Nullable field value to be set</param>
-        public void SetCadence(byte? cadence_)
-        {
-            SetFieldValue(4, 0, cadence_, Fit.SubfieldIndexMainField);
-        }
-        
-        ///<summary>
-        /// Retrieves the Distance field
-        /// Units: m</summary>
-        /// <returns>Returns nullable float representing the Distance field</returns>
-        public float? GetDistance()
-        {
-            Object val = GetFieldValue(5, 0, Fit.SubfieldIndexMainField);
-            if(val == null)
-            {
-                return null;
-            }
-
-            return (Convert.ToSingle(val));
-            
-        }
-
-        /// <summary>
-        /// Set Distance field
-        /// Units: m</summary>
-        /// <param name="distance_">Nullable field value to be set</param>
-        public void SetDistance(float? distance_)
-        {
-            SetFieldValue(5, 0, distance_, Fit.SubfieldIndexMainField);
-        }
-        
-        ///<summary>
-        /// Retrieves the Speed field
-        /// Units: m/s</summary>
-        /// <returns>Returns nullable float representing the Speed field</returns>
-        public float? GetSpeed()
-        {
-            Object val = GetFieldValue(6, 0, Fit.SubfieldIndexMainField);
-            if(val == null)
-            {
-                return null;
-            }
-
-            return (Convert.ToSingle(val));
-            
-        }
-
-        /// <summary>
-        /// Set Speed field
-        /// Units: m/s</summary>
-        /// <param name="speed_">Nullable field value to be set</param>
-        public void SetSpeed(float? speed_)
-        {
-            SetFieldValue(6, 0, speed_, Fit.SubfieldIndexMainField);
-        }
-        
-        ///<summary>
-        /// Retrieves the Power field
-        /// Units: watts</summary>
-        /// <returns>Returns nullable ushort representing the Power field</returns>
-        public ushort? GetPower()
-        {
-            Object val = GetFieldValue(7, 0, Fit.SubfieldIndexMainField);
-            if(val == null)
-            {
-                return null;
-            }
-
-            return (Convert.ToUInt16(val));
-            
-        }
-
-        /// <summary>
-        /// Set Power field
-        /// Units: watts</summary>
-        /// <param name="power_">Nullable field value to be set</param>
-        public void SetPower(ushort? power_)
-        {
-            SetFieldValue(7, 0, power_, Fit.SubfieldIndexMainField);
-        }
-        
-        
-        /// <summary>
-        ///
-        /// </summary>
-        /// <returns>returns number of elements in field CompressedSpeedDistance</returns>
-        public int GetNumCompressedSpeedDistance()
-        {
-            return GetNumFieldValues(8, Fit.SubfieldIndexMainField);
-        }
-
-        ///<summary>
-        /// Retrieves the CompressedSpeedDistance field</summary>
-        /// <param name="index">0 based index of CompressedSpeedDistance element to retrieve</param>
-        /// <returns>Returns nullable byte representing the CompressedSpeedDistance field</returns>
-        public byte? GetCompressedSpeedDistance(int index)
-        {
-            Object val = GetFieldValue(8, index, Fit.SubfieldIndexMainField);
-            if(val == null)
-            {
-                return null;
-            }
-
-            return (Convert.ToByte(val));
-            
-        }
-
-        /// <summary>
-        /// Set CompressedSpeedDistance field</summary>
-        /// <param name="index">0 based index of compressed_speed_distance</param>
-        /// <param name="compressedSpeedDistance_">Nullable field value to be set</param>
-        public void SetCompressedSpeedDistance(int index, byte? compressedSpeedDistance_)
-        {
-            SetFieldValue(8, index, compressedSpeedDistance_, Fit.SubfieldIndexMainField);
-        }
-        
-        ///<summary>
-        /// Retrieves the Grade field
-        /// Units: %</summary>
-        /// <returns>Returns nullable float representing the Grade field</returns>
-        public float? GetGrade()
-        {
-            Object val = GetFieldValue(9, 0, Fit.SubfieldIndexMainField);
-            if(val == null)
-            {
-                return null;
-            }
-
-            return (Convert.ToSingle(val));
-            
-        }
-
-        /// <summary>
-        /// Set Grade field
-        /// Units: %</summary>
-        /// <param name="grade_">Nullable field value to be set</param>
-        public void SetGrade(float? grade_)
-        {
-            SetFieldValue(9, 0, grade_, Fit.SubfieldIndexMainField);
-        }
-        
-        ///<summary>
-        /// Retrieves the Resistance field
-        /// Comment: Relative. 0 is none 254 is Max.</summary>
-        /// <returns>Returns nullable byte representing the Resistance field</returns>
-        public byte? GetResistance()
-        {
-            Object val = GetFieldValue(10, 0, Fit.SubfieldIndexMainField);
-            if(val == null)
-            {
-                return null;
-            }
-
-            return (Convert.ToByte(val));
-            
-        }
-
-        /// <summary>
-        /// Set Resistance field
-        /// Comment: Relative. 0 is none 254 is Max.</summary>
-        /// <param name="resistance_">Nullable field value to be set</param>
-        public void SetResistance(byte? resistance_)
-        {
-            SetFieldValue(10, 0, resistance_, Fit.SubfieldIndexMainField);
-        }
-        
-        ///<summary>
-        /// Retrieves the TimeFromCourse field
-        /// Units: s</summary>
-        /// <returns>Returns nullable float representing the TimeFromCourse field</returns>
-        public float? GetTimeFromCourse()
-        {
-            Object val = GetFieldValue(11, 0, Fit.SubfieldIndexMainField);
-            if(val == null)
-            {
-                return null;
-            }
-
-            return (Convert.ToSingle(val));
-            
-        }
-
-        /// <summary>
-        /// Set TimeFromCourse field
-        /// Units: s</summary>
-        /// <param name="timeFromCourse_">Nullable field value to be set</param>
-        public void SetTimeFromCourse(float? timeFromCourse_)
-        {
-            SetFieldValue(11, 0, timeFromCourse_, Fit.SubfieldIndexMainField);
-        }
-        
-        ///<summary>
-        /// Retrieves the CycleLength field
-        /// Units: m</summary>
-        /// <returns>Returns nullable float representing the CycleLength field</returns>
-        public float? GetCycleLength()
-        {
-            Object val = GetFieldValue(12, 0, Fit.SubfieldIndexMainField);
-            if(val == null)
-            {
-                return null;
-            }
-
-            return (Convert.ToSingle(val));
-            
-        }
-
-        /// <summary>
-        /// Set CycleLength field
-        /// Units: m</summary>
-        /// <param name="cycleLength_">Nullable field value to be set</param>
-        public void SetCycleLength(float? cycleLength_)
-        {
-            SetFieldValue(12, 0, cycleLength_, Fit.SubfieldIndexMainField);
-        }
-        
-        ///<summary>
-        /// Retrieves the Temperature field
-        /// Units: C</summary>
-        /// <returns>Returns nullable sbyte representing the Temperature field</returns>
-        public sbyte? GetTemperature()
-        {
-            Object val = GetFieldValue(13, 0, Fit.SubfieldIndexMainField);
-            if(val == null)
-            {
-                return null;
-            }
-
-            return (Convert.ToSByte(val));
-            
-        }
-
-        /// <summary>
-        /// Set Temperature field
-        /// Units: C</summary>
-        /// <param name="temperature_">Nullable field value to be set</param>
-        public void SetTemperature(sbyte? temperature_)
-        {
-            SetFieldValue(13, 0, temperature_, Fit.SubfieldIndexMainField);
-        }
-        
-        
-        /// <summary>
-        ///
-        /// </summary>
-        /// <returns>returns number of elements in field Speed1s</returns>
-        public int GetNumSpeed1s()
-        {
-            return GetNumFieldValues(17, Fit.SubfieldIndexMainField);
-        }
-
-        ///<summary>
-        /// Retrieves the Speed1s field
-        /// Units: m/s
-        /// Comment: Speed at 1s intervals. Timestamp field indicates time of last array element.</summary>
-        /// <param name="index">0 based index of Speed1s element to retrieve</param>
-        /// <returns>Returns nullable float representing the Speed1s field</returns>
-        public float? GetSpeed1s(int index)
-        {
-            Object val = GetFieldValue(17, index, Fit.SubfieldIndexMainField);
-            if(val == null)
-            {
-                return null;
-            }
-
-            return (Convert.ToSingle(val));
-            
-        }
-
-        /// <summary>
-        /// Set Speed1s field
-        /// Units: m/s
-        /// Comment: Speed at 1s intervals. Timestamp field indicates time of last array element.</summary>
-        /// <param name="index">0 based index of speed_1s</param>
-        /// <param name="speed1s_">Nullable field value to be set</param>
-        public void SetSpeed1s(int index, float? speed1s_)
-        {
-            SetFieldValue(17, index, speed1s_, Fit.SubfieldIndexMainField);
-        }
-        
-        ///<summary>
-        /// Retrieves the Cycles field
-        /// Units: cycles</summary>
-        /// <returns>Returns nullable byte representing the Cycles field</returns>
-        public byte? GetCycles()
-        {
-            Object val = GetFieldValue(18, 0, Fit.SubfieldIndexMainField);
-            if(val == null)
-            {
-                return null;
-            }
-
-            return (Convert.ToByte(val));
-            
-        }
-
-        /// <summary>
-        /// Set Cycles field
-        /// Units: cycles</summary>
-        /// <param name="cycles_">Nullable field value to be set</param>
-        public void SetCycles(byte? cycles_)
-        {
-            SetFieldValue(18, 0, cycles_, Fit.SubfieldIndexMainField);
-        }
-        
-        ///<summary>
-        /// Retrieves the TotalCycles field
-        /// Units: cycles</summary>
-        /// <returns>Returns nullable uint representing the TotalCycles field</returns>
-        public uint? GetTotalCycles()
-        {
-            Object val = GetFieldValue(19, 0, Fit.SubfieldIndexMainField);
-            if(val == null)
-            {
-                return null;
-            }
-
-            return (Convert.ToUInt32(val));
-            
-        }
-
-        /// <summary>
-        /// Set TotalCycles field
-        /// Units: cycles</summary>
-        /// <param name="totalCycles_">Nullable field value to be set</param>
-        public void SetTotalCycles(uint? totalCycles_)
-        {
-            SetFieldValue(19, 0, totalCycles_, Fit.SubfieldIndexMainField);
-        }
-        
-        ///<summary>
-        /// Retrieves the CompressedAccumulatedPower field
-        /// Units: watts</summary>
-        /// <returns>Returns nullable ushort representing the CompressedAccumulatedPower field</returns>
-        public ushort? GetCompressedAccumulatedPower()
-        {
-            Object val = GetFieldValue(28, 0, Fit.SubfieldIndexMainField);
-            if(val == null)
-            {
-                return null;
-            }
-
-            return (Convert.ToUInt16(val));
-            
-        }
-
-        /// <summary>
-        /// Set CompressedAccumulatedPower field
-        /// Units: watts</summary>
-        /// <param name="compressedAccumulatedPower_">Nullable field value to be set</param>
-        public void SetCompressedAccumulatedPower(ushort? compressedAccumulatedPower_)
-        {
-            SetFieldValue(28, 0, compressedAccumulatedPower_, Fit.SubfieldIndexMainField);
-        }
-        
-        ///<summary>
-        /// Retrieves the AccumulatedPower field
-        /// Units: watts</summary>
-        /// <returns>Returns nullable uint representing the AccumulatedPower field</returns>
-        public uint? GetAccumulatedPower()
-        {
-            Object val = GetFieldValue(29, 0, Fit.SubfieldIndexMainField);
-            if(val == null)
-            {
-                return null;
-            }
-
-            return (Convert.ToUInt32(val));
-            
-        }
-
-        /// <summary>
-        /// Set AccumulatedPower field
-        /// Units: watts</summary>
-        /// <param name="accumulatedPower_">Nullable field value to be set</param>
-        public void SetAccumulatedPower(uint? accumulatedPower_)
-        {
-            SetFieldValue(29, 0, accumulatedPower_, Fit.SubfieldIndexMainField);
-        }
-        
-        ///<summary>
-        /// Retrieves the LeftRightBalance field</summary>
-        /// <returns>Returns nullable byte representing the LeftRightBalance field</returns>
-        public byte? GetLeftRightBalance()
-        {
-            Object val = GetFieldValue(30, 0, Fit.SubfieldIndexMainField);
-            if(val == null)
-            {
-                return null;
-            }
-
-            return (Convert.ToByte(val));
-            
-        }
-
-        /// <summary>
-        /// Set LeftRightBalance field</summary>
-        /// <param name="leftRightBalance_">Nullable field value to be set</param>
-        public void SetLeftRightBalance(byte? leftRightBalance_)
-        {
-            SetFieldValue(30, 0, leftRightBalance_, Fit.SubfieldIndexMainField);
-        }
-        
-        ///<summary>
-        /// Retrieves the GpsAccuracy field
-        /// Units: m</summary>
-        /// <returns>Returns nullable byte representing the GpsAccuracy field</returns>
-        public byte? GetGpsAccuracy()
-        {
-            Object val = GetFieldValue(31, 0, Fit.SubfieldIndexMainField);
-            if(val == null)
-            {
-                return null;
-            }
-
-            return (Convert.ToByte(val));
-            
-        }
-
-        /// <summary>
-        /// Set GpsAccuracy field
-        /// Units: m</summary>
-        /// <param name="gpsAccuracy_">Nullable field value to be set</param>
-        public void SetGpsAccuracy(byte? gpsAccuracy_)
-        {
-            SetFieldValue(31, 0, gpsAccuracy_, Fit.SubfieldIndexMainField);
-        }
-        
-        ///<summary>
-        /// Retrieves the VerticalSpeed field
-        /// Units: m/s</summary>
-        /// <returns>Returns nullable float representing the VerticalSpeed field</returns>
-        public float? GetVerticalSpeed()
-        {
-            Object val = GetFieldValue(32, 0, Fit.SubfieldIndexMainField);
-            if(val == null)
-            {
-                return null;
-            }
-
-            return (Convert.ToSingle(val));
-            
-        }
-
-        /// <summary>
-        /// Set VerticalSpeed field
-        /// Units: m/s</summary>
-        /// <param name="verticalSpeed_">Nullable field value to be set</param>
-        public void SetVerticalSpeed(float? verticalSpeed_)
-        {
-            SetFieldValue(32, 0, verticalSpeed_, Fit.SubfieldIndexMainField);
-        }
-        
-        ///<summary>
-        /// Retrieves the Calories field
-        /// Units: kcal</summary>
-        /// <returns>Returns nullable ushort representing the Calories field</returns>
-        public ushort? GetCalories()
-        {
-            Object val = GetFieldValue(33, 0, Fit.SubfieldIndexMainField);
-            if(val == null)
-            {
-                return null;
-            }
-
-            return (Convert.ToUInt16(val));
-            
-        }
-
-        /// <summary>
-        /// Set Calories field
-        /// Units: kcal</summary>
-        /// <param name="calories_">Nullable field value to be set</param>
-        public void SetCalories(ushort? calories_)
-        {
-            SetFieldValue(33, 0, calories_, Fit.SubfieldIndexMainField);
-        }
-        
-        ///<summary>
-        /// Retrieves the VerticalOscillation field
-        /// Units: mm</summary>
-        /// <returns>Returns nullable float representing the VerticalOscillation field</returns>
-        public float? GetVerticalOscillation()
-        {
-            Object val = GetFieldValue(39, 0, Fit.SubfieldIndexMainField);
-            if(val == null)
-            {
-                return null;
-            }
-
-            return (Convert.ToSingle(val));
-            
-        }
-
-        /// <summary>
-        /// Set VerticalOscillation field
-        /// Units: mm</summary>
-        /// <param name="verticalOscillation_">Nullable field value to be set</param>
-        public void SetVerticalOscillation(float? verticalOscillation_)
-        {
-            SetFieldValue(39, 0, verticalOscillation_, Fit.SubfieldIndexMainField);
-        }
-        
-        ///<summary>
-        /// Retrieves the StanceTimePercent field
-        /// Units: percent</summary>
-        /// <returns>Returns nullable float representing the StanceTimePercent field</returns>
-        public float? GetStanceTimePercent()
-        {
-            Object val = GetFieldValue(40, 0, Fit.SubfieldIndexMainField);
-            if(val == null)
-            {
-                return null;
-            }
-
-            return (Convert.ToSingle(val));
-            
-        }
-
-        /// <summary>
-        /// Set StanceTimePercent field
-        /// Units: percent</summary>
-        /// <param name="stanceTimePercent_">Nullable field value to be set</param>
-        public void SetStanceTimePercent(float? stanceTimePercent_)
-        {
-            SetFieldValue(40, 0, stanceTimePercent_, Fit.SubfieldIndexMainField);
-        }
-        
-        ///<summary>
-        /// Retrieves the StanceTime field
-        /// Units: ms</summary>
-        /// <returns>Returns nullable float representing the StanceTime field</returns>
-        public float? GetStanceTime()
-        {
-            Object val = GetFieldValue(41, 0, Fit.SubfieldIndexMainField);
-            if(val == null)
-            {
-                return null;
-            }
-
-            return (Convert.ToSingle(val));
-            
-        }
-
-        /// <summary>
-        /// Set StanceTime field
-        /// Units: ms</summary>
-        /// <param name="stanceTime_">Nullable field value to be set</param>
-        public void SetStanceTime(float? stanceTime_)
-        {
-            SetFieldValue(41, 0, stanceTime_, Fit.SubfieldIndexMainField);
-        }
-        
-        ///<summary>
-        /// Retrieves the ActivityType field</summary>
-        /// <returns>Returns nullable ActivityType enum representing the ActivityType field</returns>
-        public ActivityType? GetActivityType()
-        {
-            object obj = GetFieldValue(42, 0, Fit.SubfieldIndexMainField);
-            ActivityType? value = obj == null ? (ActivityType?)null : (ActivityType)obj;
-            return value;
-        }
-
-        /// <summary>
-        /// Set ActivityType field</summary>
-        /// <param name="activityType_">Nullable field value to be set</param>
-        public void SetActivityType(ActivityType? activityType_)
-        {
-            SetFieldValue(42, 0, activityType_, Fit.SubfieldIndexMainField);
-        }
-        
-        ///<summary>
-        /// Retrieves the LeftTorqueEffectiveness field
-        /// Units: percent</summary>
-        /// <returns>Returns nullable float representing the LeftTorqueEffectiveness field</returns>
-        public float? GetLeftTorqueEffectiveness()
-        {
-            Object val = GetFieldValue(43, 0, Fit.SubfieldIndexMainField);
-            if(val == null)
-            {
-                return null;
-            }
-
-            return (Convert.ToSingle(val));
-            
-        }
-
-        /// <summary>
-        /// Set LeftTorqueEffectiveness field
-        /// Units: percent</summary>
-        /// <param name="leftTorqueEffectiveness_">Nullable field value to be set</param>
-        public void SetLeftTorqueEffectiveness(float? leftTorqueEffectiveness_)
-        {
-            SetFieldValue(43, 0, leftTorqueEffectiveness_, Fit.SubfieldIndexMainField);
-        }
-        
-        ///<summary>
-        /// Retrieves the RightTorqueEffectiveness field
-        /// Units: percent</summary>
-        /// <returns>Returns nullable float representing the RightTorqueEffectiveness field</returns>
-        public float? GetRightTorqueEffectiveness()
-        {
-            Object val = GetFieldValue(44, 0, Fit.SubfieldIndexMainField);
-            if(val == null)
-            {
-                return null;
-            }
-
-            return (Convert.ToSingle(val));
-            
-        }
-
-        /// <summary>
-        /// Set RightTorqueEffectiveness field
-        /// Units: percent</summary>
-        /// <param name="rightTorqueEffectiveness_">Nullable field value to be set</param>
-        public void SetRightTorqueEffectiveness(float? rightTorqueEffectiveness_)
-        {
-            SetFieldValue(44, 0, rightTorqueEffectiveness_, Fit.SubfieldIndexMainField);
-        }
-        
-        ///<summary>
-        /// Retrieves the LeftPedalSmoothness field
-        /// Units: percent</summary>
-        /// <returns>Returns nullable float representing the LeftPedalSmoothness field</returns>
-        public float? GetLeftPedalSmoothness()
-        {
-            Object val = GetFieldValue(45, 0, Fit.SubfieldIndexMainField);
-            if(val == null)
-            {
-                return null;
-            }
-
-            return (Convert.ToSingle(val));
-            
-        }
-
-        /// <summary>
-        /// Set LeftPedalSmoothness field
-        /// Units: percent</summary>
-        /// <param name="leftPedalSmoothness_">Nullable field value to be set</param>
-        public void SetLeftPedalSmoothness(float? leftPedalSmoothness_)
-        {
-            SetFieldValue(45, 0, leftPedalSmoothness_, Fit.SubfieldIndexMainField);
-        }
-        
-        ///<summary>
-        /// Retrieves the RightPedalSmoothness field
-        /// Units: percent</summary>
-        /// <returns>Returns nullable float representing the RightPedalSmoothness field</returns>
-        public float? GetRightPedalSmoothness()
-        {
-            Object val = GetFieldValue(46, 0, Fit.SubfieldIndexMainField);
-            if(val == null)
-            {
-                return null;
-            }
-
-            return (Convert.ToSingle(val));
-            
-        }
-
-        /// <summary>
-        /// Set RightPedalSmoothness field
-        /// Units: percent</summary>
-        /// <param name="rightPedalSmoothness_">Nullable field value to be set</param>
-        public void SetRightPedalSmoothness(float? rightPedalSmoothness_)
-        {
-            SetFieldValue(46, 0, rightPedalSmoothness_, Fit.SubfieldIndexMainField);
-        }
-        
-        ///<summary>
-        /// Retrieves the CombinedPedalSmoothness field
-        /// Units: percent</summary>
-        /// <returns>Returns nullable float representing the CombinedPedalSmoothness field</returns>
-        public float? GetCombinedPedalSmoothness()
-        {
-            Object val = GetFieldValue(47, 0, Fit.SubfieldIndexMainField);
-            if(val == null)
-            {
-                return null;
-            }
-
-            return (Convert.ToSingle(val));
-            
-        }
-
-        /// <summary>
-        /// Set CombinedPedalSmoothness field
-        /// Units: percent</summary>
-        /// <param name="combinedPedalSmoothness_">Nullable field value to be set</param>
-        public void SetCombinedPedalSmoothness(float? combinedPedalSmoothness_)
-        {
-            SetFieldValue(47, 0, combinedPedalSmoothness_, Fit.SubfieldIndexMainField);
-        }
-        
-        ///<summary>
-        /// Retrieves the Time128 field
-        /// Units: s</summary>
-        /// <returns>Returns nullable float representing the Time128 field</returns>
-        public float? GetTime128()
-        {
-            Object val = GetFieldValue(48, 0, Fit.SubfieldIndexMainField);
-            if(val == null)
-            {
-                return null;
-            }
-
-            return (Convert.ToSingle(val));
-            
-        }
-
-        /// <summary>
-        /// Set Time128 field
-        /// Units: s</summary>
-        /// <param name="time128_">Nullable field value to be set</param>
-        public void SetTime128(float? time128_)
-        {
-            SetFieldValue(48, 0, time128_, Fit.SubfieldIndexMainField);
-        }
-        
-        ///<summary>
-        /// Retrieves the StrokeType field</summary>
-        /// <returns>Returns nullable StrokeType enum representing the StrokeType field</returns>
-        public StrokeType? GetStrokeType()
-        {
-            object obj = GetFieldValue(49, 0, Fit.SubfieldIndexMainField);
-            StrokeType? value = obj == null ? (StrokeType?)null : (StrokeType)obj;
-            return value;
-        }
-
-        /// <summary>
-        /// Set StrokeType field</summary>
-        /// <param name="strokeType_">Nullable field value to be set</param>
-        public void SetStrokeType(StrokeType? strokeType_)
-        {
-            SetFieldValue(49, 0, strokeType_, Fit.SubfieldIndexMainField);
-        }
-        
-        ///<summary>
-        /// Retrieves the Zone field</summary>
-        /// <returns>Returns nullable byte representing the Zone field</returns>
-        public byte? GetZone()
-        {
-            Object val = GetFieldValue(50, 0, Fit.SubfieldIndexMainField);
-            if(val == null)
-            {
-                return null;
-            }
-
-            return (Convert.ToByte(val));
-            
-        }
-
-        /// <summary>
-        /// Set Zone field</summary>
-        /// <param name="zone_">Nullable field value to be set</param>
-        public void SetZone(byte? zone_)
-        {
-            SetFieldValue(50, 0, zone_, Fit.SubfieldIndexMainField);
-        }
-        
-        ///<summary>
-        /// Retrieves the BallSpeed field
-        /// Units: m/s</summary>
-        /// <returns>Returns nullable float representing the BallSpeed field</returns>
-        public float? GetBallSpeed()
-        {
-            Object val = GetFieldValue(51, 0, Fit.SubfieldIndexMainField);
-            if(val == null)
-            {
-                return null;
-            }
-
-            return (Convert.ToSingle(val));
-            
-        }
-
-        /// <summary>
-        /// Set BallSpeed field
-        /// Units: m/s</summary>
-        /// <param name="ballSpeed_">Nullable field value to be set</param>
-        public void SetBallSpeed(float? ballSpeed_)
-        {
-            SetFieldValue(51, 0, ballSpeed_, Fit.SubfieldIndexMainField);
-        }
-        
-        ///<summary>
-        /// Retrieves the Cadence256 field
-        /// Units: rpm
-        /// Comment: Log cadence and fractional cadence for backwards compatability</summary>
-        /// <returns>Returns nullable float representing the Cadence256 field</returns>
-        public float? GetCadence256()
-        {
-            Object val = GetFieldValue(52, 0, Fit.SubfieldIndexMainField);
-            if(val == null)
-            {
-                return null;
-            }
-
-            return (Convert.ToSingle(val));
-            
-        }
-
-        /// <summary>
-        /// Set Cadence256 field
-        /// Units: rpm
-        /// Comment: Log cadence and fractional cadence for backwards compatability</summary>
-        /// <param name="cadence256_">Nullable field value to be set</param>
-        public void SetCadence256(float? cadence256_)
-        {
-            SetFieldValue(52, 0, cadence256_, Fit.SubfieldIndexMainField);
-        }
-        
-        ///<summary>
-        /// Retrieves the FractionalCadence field
-        /// Units: rpm</summary>
-        /// <returns>Returns nullable float representing the FractionalCadence field</returns>
-        public float? GetFractionalCadence()
-        {
-            Object val = GetFieldValue(53, 0, Fit.SubfieldIndexMainField);
-            if(val == null)
-            {
-                return null;
-            }
-
-            return (Convert.ToSingle(val));
-            
-        }
-
-        /// <summary>
-        /// Set FractionalCadence field
-        /// Units: rpm</summary>
-        /// <param name="fractionalCadence_">Nullable field value to be set</param>
-        public void SetFractionalCadence(float? fractionalCadence_)
-        {
-            SetFieldValue(53, 0, fractionalCadence_, Fit.SubfieldIndexMainField);
-        }
-        
-        ///<summary>
-        /// Retrieves the TotalHemoglobinConc field
-        /// Units: g/dL
-        /// Comment: Total saturated and unsaturated hemoglobin</summary>
-        /// <returns>Returns nullable float representing the TotalHemoglobinConc field</returns>
-        public float? GetTotalHemoglobinConc()
-        {
-            Object val = GetFieldValue(54, 0, Fit.SubfieldIndexMainField);
-            if(val == null)
-            {
-                return null;
-            }
-
-            return (Convert.ToSingle(val));
-            
-        }
-
-        /// <summary>
-        /// Set TotalHemoglobinConc field
-        /// Units: g/dL
-        /// Comment: Total saturated and unsaturated hemoglobin</summary>
-        /// <param name="totalHemoglobinConc_">Nullable field value to be set</param>
-        public void SetTotalHemoglobinConc(float? totalHemoglobinConc_)
-        {
-            SetFieldValue(54, 0, totalHemoglobinConc_, Fit.SubfieldIndexMainField);
-        }
-        
-        ///<summary>
-        /// Retrieves the TotalHemoglobinConcMin field
-        /// Units: g/dL
-        /// Comment: Min saturated and unsaturated hemoglobin</summary>
-        /// <returns>Returns nullable float representing the TotalHemoglobinConcMin field</returns>
-        public float? GetTotalHemoglobinConcMin()
-        {
-            Object val = GetFieldValue(55, 0, Fit.SubfieldIndexMainField);
-            if(val == null)
-            {
-                return null;
-            }
-
-            return (Convert.ToSingle(val));
-            
-        }
-
-        /// <summary>
-        /// Set TotalHemoglobinConcMin field
-        /// Units: g/dL
-        /// Comment: Min saturated and unsaturated hemoglobin</summary>
-        /// <param name="totalHemoglobinConcMin_">Nullable field value to be set</param>
-        public void SetTotalHemoglobinConcMin(float? totalHemoglobinConcMin_)
-        {
-            SetFieldValue(55, 0, totalHemoglobinConcMin_, Fit.SubfieldIndexMainField);
-        }
-        
-        ///<summary>
-        /// Retrieves the TotalHemoglobinConcMax field
-        /// Units: g/dL
-        /// Comment: Max saturated and unsaturated hemoglobin</summary>
-        /// <returns>Returns nullable float representing the TotalHemoglobinConcMax field</returns>
-        public float? GetTotalHemoglobinConcMax()
-        {
-            Object val = GetFieldValue(56, 0, Fit.SubfieldIndexMainField);
-            if(val == null)
-            {
-                return null;
-            }
-
-            return (Convert.ToSingle(val));
-            
-        }
-
-        /// <summary>
-        /// Set TotalHemoglobinConcMax field
-        /// Units: g/dL
-        /// Comment: Max saturated and unsaturated hemoglobin</summary>
-        /// <param name="totalHemoglobinConcMax_">Nullable field value to be set</param>
-        public void SetTotalHemoglobinConcMax(float? totalHemoglobinConcMax_)
-        {
-            SetFieldValue(56, 0, totalHemoglobinConcMax_, Fit.SubfieldIndexMainField);
-        }
-        
-        ///<summary>
-        /// Retrieves the SaturatedHemoglobinPercent field
-        /// Units: %
-        /// Comment: Percentage of hemoglobin saturated with oxygen</summary>
-        /// <returns>Returns nullable float representing the SaturatedHemoglobinPercent field</returns>
-        public float? GetSaturatedHemoglobinPercent()
-        {
-            Object val = GetFieldValue(57, 0, Fit.SubfieldIndexMainField);
-            if(val == null)
-            {
-                return null;
-            }
-
-            return (Convert.ToSingle(val));
-            
-        }
-
-        /// <summary>
-        /// Set SaturatedHemoglobinPercent field
-        /// Units: %
-        /// Comment: Percentage of hemoglobin saturated with oxygen</summary>
-        /// <param name="saturatedHemoglobinPercent_">Nullable field value to be set</param>
-        public void SetSaturatedHemoglobinPercent(float? saturatedHemoglobinPercent_)
-        {
-            SetFieldValue(57, 0, saturatedHemoglobinPercent_, Fit.SubfieldIndexMainField);
-        }
-        
-        ///<summary>
-        /// Retrieves the SaturatedHemoglobinPercentMin field
-        /// Units: %
-        /// Comment: Min percentage of hemoglobin saturated with oxygen</summary>
-        /// <returns>Returns nullable float representing the SaturatedHemoglobinPercentMin field</returns>
-        public float? GetSaturatedHemoglobinPercentMin()
-        {
-            Object val = GetFieldValue(58, 0, Fit.SubfieldIndexMainField);
-            if(val == null)
-            {
-                return null;
-            }
-
-            return (Convert.ToSingle(val));
-            
-        }
-
-        /// <summary>
-        /// Set SaturatedHemoglobinPercentMin field
-        /// Units: %
-        /// Comment: Min percentage of hemoglobin saturated with oxygen</summary>
-        /// <param name="saturatedHemoglobinPercentMin_">Nullable field value to be set</param>
-        public void SetSaturatedHemoglobinPercentMin(float? saturatedHemoglobinPercentMin_)
-        {
-            SetFieldValue(58, 0, saturatedHemoglobinPercentMin_, Fit.SubfieldIndexMainField);
-        }
-        
-        ///<summary>
-        /// Retrieves the SaturatedHemoglobinPercentMax field
-        /// Units: %
-        /// Comment: Max percentage of hemoglobin saturated with oxygen</summary>
-        /// <returns>Returns nullable float representing the SaturatedHemoglobinPercentMax field</returns>
-        public float? GetSaturatedHemoglobinPercentMax()
-        {
-            Object val = GetFieldValue(59, 0, Fit.SubfieldIndexMainField);
-            if(val == null)
-            {
-                return null;
-            }
-
-            return (Convert.ToSingle(val));
-            
-        }
-
-        /// <summary>
-        /// Set SaturatedHemoglobinPercentMax field
-        /// Units: %
-        /// Comment: Max percentage of hemoglobin saturated with oxygen</summary>
-        /// <param name="saturatedHemoglobinPercentMax_">Nullable field value to be set</param>
-        public void SetSaturatedHemoglobinPercentMax(float? saturatedHemoglobinPercentMax_)
-        {
-            SetFieldValue(59, 0, saturatedHemoglobinPercentMax_, Fit.SubfieldIndexMainField);
-        }
-        
-        ///<summary>
-        /// Retrieves the DeviceIndex field</summary>
-        /// <returns>Returns nullable byte representing the DeviceIndex field</returns>
-        public byte? GetDeviceIndex()
-        {
-            Object val = GetFieldValue(62, 0, Fit.SubfieldIndexMainField);
-            if(val == null)
-            {
-                return null;
-            }
-
-            return (Convert.ToByte(val));
-            
-        }
-
-        /// <summary>
-        /// Set DeviceIndex field</summary>
-        /// <param name="deviceIndex_">Nullable field value to be set</param>
-        public void SetDeviceIndex(byte? deviceIndex_)
-        {
-            SetFieldValue(62, 0, deviceIndex_, Fit.SubfieldIndexMainField);
-        }
-        
-        ///<summary>
-        /// Retrieves the LeftPco field
-        /// Units: mm
-        /// Comment: Left platform center offset</summary>
-        /// <returns>Returns nullable sbyte representing the LeftPco field</returns>
-        public sbyte? GetLeftPco()
-        {
-            Object val = GetFieldValue(67, 0, Fit.SubfieldIndexMainField);
-            if(val == null)
-            {
-                return null;
-            }
-
-            return (Convert.ToSByte(val));
-            
-        }
-
-        /// <summary>
-        /// Set LeftPco field
-        /// Units: mm
-        /// Comment: Left platform center offset</summary>
-        /// <param name="leftPco_">Nullable field value to be set</param>
-        public void SetLeftPco(sbyte? leftPco_)
-        {
-            SetFieldValue(67, 0, leftPco_, Fit.SubfieldIndexMainField);
-        }
-        
-        ///<summary>
-        /// Retrieves the RightPco field
-        /// Units: mm
-        /// Comment: Right platform center offset</summary>
-        /// <returns>Returns nullable sbyte representing the RightPco field</returns>
-        public sbyte? GetRightPco()
-        {
-            Object val = GetFieldValue(68, 0, Fit.SubfieldIndexMainField);
-            if(val == null)
-            {
-                return null;
-            }
-
-            return (Convert.ToSByte(val));
-            
-        }
-
-        /// <summary>
-        /// Set RightPco field
-        /// Units: mm
-        /// Comment: Right platform center offset</summary>
-        /// <param name="rightPco_">Nullable field value to be set</param>
-        public void SetRightPco(sbyte? rightPco_)
-        {
-            SetFieldValue(68, 0, rightPco_, Fit.SubfieldIndexMainField);
-        }
-        
-        
-        /// <summary>
-        ///
-        /// </summary>
-        /// <returns>returns number of elements in field LeftPowerPhase</returns>
-        public int GetNumLeftPowerPhase()
-        {
-            return GetNumFieldValues(69, Fit.SubfieldIndexMainField);
-        }
-
-        ///<summary>
-        /// Retrieves the LeftPowerPhase field
-        /// Units: degrees
-        /// Comment: Left power phase angles. Data value indexes defined by power_phase_type.</summary>
-        /// <param name="index">0 based index of LeftPowerPhase element to retrieve</param>
-        /// <returns>Returns nullable float representing the LeftPowerPhase field</returns>
-        public float? GetLeftPowerPhase(int index)
-        {
-            Object val = GetFieldValue(69, index, Fit.SubfieldIndexMainField);
-            if(val == null)
-            {
-                return null;
-            }
-
-            return (Convert.ToSingle(val));
-            
-        }
-
-        /// <summary>
-        /// Set LeftPowerPhase field
-        /// Units: degrees
-        /// Comment: Left power phase angles. Data value indexes defined by power_phase_type.</summary>
-        /// <param name="index">0 based index of left_power_phase</param>
-        /// <param name="leftPowerPhase_">Nullable field value to be set</param>
-        public void SetLeftPowerPhase(int index, float? leftPowerPhase_)
-        {
-            SetFieldValue(69, index, leftPowerPhase_, Fit.SubfieldIndexMainField);
-        }
-        
-        
-        /// <summary>
-        ///
-        /// </summary>
-        /// <returns>returns number of elements in field LeftPowerPhasePeak</returns>
-        public int GetNumLeftPowerPhasePeak()
-        {
-            return GetNumFieldValues(70, Fit.SubfieldIndexMainField);
-        }
-
-        ///<summary>
-        /// Retrieves the LeftPowerPhasePeak field
-        /// Units: degrees
-        /// Comment: Left power phase peak angles. Data value indexes defined by power_phase_type.</summary>
-        /// <param name="index">0 based index of LeftPowerPhasePeak element to retrieve</param>
-        /// <returns>Returns nullable float representing the LeftPowerPhasePeak field</returns>
-        public float? GetLeftPowerPhasePeak(int index)
-        {
-            Object val = GetFieldValue(70, index, Fit.SubfieldIndexMainField);
-            if(val == null)
-            {
-                return null;
-            }
-
-            return (Convert.ToSingle(val));
-            
-        }
-
-        /// <summary>
-        /// Set LeftPowerPhasePeak field
-        /// Units: degrees
-        /// Comment: Left power phase peak angles. Data value indexes defined by power_phase_type.</summary>
-        /// <param name="index">0 based index of left_power_phase_peak</param>
-        /// <param name="leftPowerPhasePeak_">Nullable field value to be set</param>
-        public void SetLeftPowerPhasePeak(int index, float? leftPowerPhasePeak_)
-        {
-            SetFieldValue(70, index, leftPowerPhasePeak_, Fit.SubfieldIndexMainField);
-        }
-        
-        
-        /// <summary>
-        ///
-        /// </summary>
-        /// <returns>returns number of elements in field RightPowerPhase</returns>
-        public int GetNumRightPowerPhase()
-        {
-            return GetNumFieldValues(71, Fit.SubfieldIndexMainField);
-        }
-
-        ///<summary>
-        /// Retrieves the RightPowerPhase field
-        /// Units: degrees
-        /// Comment: Right power phase angles. Data value indexes defined by power_phase_type.</summary>
-        /// <param name="index">0 based index of RightPowerPhase element to retrieve</param>
-        /// <returns>Returns nullable float representing the RightPowerPhase field</returns>
-        public float? GetRightPowerPhase(int index)
-        {
-            Object val = GetFieldValue(71, index, Fit.SubfieldIndexMainField);
-            if(val == null)
-            {
-                return null;
-            }
-
-            return (Convert.ToSingle(val));
-            
-        }
-
-        /// <summary>
-        /// Set RightPowerPhase field
-        /// Units: degrees
-        /// Comment: Right power phase angles. Data value indexes defined by power_phase_type.</summary>
-        /// <param name="index">0 based index of right_power_phase</param>
-        /// <param name="rightPowerPhase_">Nullable field value to be set</param>
-        public void SetRightPowerPhase(int index, float? rightPowerPhase_)
-        {
-            SetFieldValue(71, index, rightPowerPhase_, Fit.SubfieldIndexMainField);
-        }
-        
-        
-        /// <summary>
-        ///
-        /// </summary>
-        /// <returns>returns number of elements in field RightPowerPhasePeak</returns>
-        public int GetNumRightPowerPhasePeak()
-        {
-            return GetNumFieldValues(72, Fit.SubfieldIndexMainField);
-        }
-
-        ///<summary>
-        /// Retrieves the RightPowerPhasePeak field
-        /// Units: degrees
-        /// Comment: Right power phase peak angles. Data value indexes defined by power_phase_type.</summary>
-        /// <param name="index">0 based index of RightPowerPhasePeak element to retrieve</param>
-        /// <returns>Returns nullable float representing the RightPowerPhasePeak field</returns>
-        public float? GetRightPowerPhasePeak(int index)
-        {
-            Object val = GetFieldValue(72, index, Fit.SubfieldIndexMainField);
-            if(val == null)
-            {
-                return null;
-            }
-
-            return (Convert.ToSingle(val));
-            
-        }
-
-        /// <summary>
-        /// Set RightPowerPhasePeak field
-        /// Units: degrees
-        /// Comment: Right power phase peak angles. Data value indexes defined by power_phase_type.</summary>
-        /// <param name="index">0 based index of right_power_phase_peak</param>
-        /// <param name="rightPowerPhasePeak_">Nullable field value to be set</param>
-        public void SetRightPowerPhasePeak(int index, float? rightPowerPhasePeak_)
-        {
-            SetFieldValue(72, index, rightPowerPhasePeak_, Fit.SubfieldIndexMainField);
-        }
-        
-        ///<summary>
-        /// Retrieves the EnhancedSpeed field
-        /// Units: m/s</summary>
-        /// <returns>Returns nullable float representing the EnhancedSpeed field</returns>
-        public float? GetEnhancedSpeed()
-        {
-            Object val = GetFieldValue(73, 0, Fit.SubfieldIndexMainField);
-            if(val == null)
-            {
-                return null;
-            }
-
-            return (Convert.ToSingle(val));
-            
-        }
-
-        /// <summary>
-        /// Set EnhancedSpeed field
-        /// Units: m/s</summary>
-        /// <param name="enhancedSpeed_">Nullable field value to be set</param>
-        public void SetEnhancedSpeed(float? enhancedSpeed_)
-        {
-            SetFieldValue(73, 0, enhancedSpeed_, Fit.SubfieldIndexMainField);
-        }
-        
-        ///<summary>
-        /// Retrieves the EnhancedAltitude field
-        /// Units: m</summary>
-        /// <returns>Returns nullable float representing the EnhancedAltitude field</returns>
-        public float? GetEnhancedAltitude()
-        {
-            Object val = GetFieldValue(78, 0, Fit.SubfieldIndexMainField);
-            if(val == null)
-            {
-                return null;
-            }
-
-            return (Convert.ToSingle(val));
-            
-        }
-
-        /// <summary>
-        /// Set EnhancedAltitude field
-        /// Units: m</summary>
-        /// <param name="enhancedAltitude_">Nullable field value to be set</param>
-        public void SetEnhancedAltitude(float? enhancedAltitude_)
-        {
-            SetFieldValue(78, 0, enhancedAltitude_, Fit.SubfieldIndexMainField);
-        }
-        
-        ///<summary>
-        /// Retrieves the BatterySoc field
-        /// Units: percent
-        /// Comment: lev battery state of charge</summary>
-        /// <returns>Returns nullable float representing the BatterySoc field</returns>
-        public float? GetBatterySoc()
-        {
-            Object val = GetFieldValue(81, 0, Fit.SubfieldIndexMainField);
-            if(val == null)
-            {
-                return null;
-            }
-
-            return (Convert.ToSingle(val));
-            
-        }
-
-        /// <summary>
-        /// Set BatterySoc field
-        /// Units: percent
-        /// Comment: lev battery state of charge</summary>
-        /// <param name="batterySoc_">Nullable field value to be set</param>
-        public void SetBatterySoc(float? batterySoc_)
-        {
-            SetFieldValue(81, 0, batterySoc_, Fit.SubfieldIndexMainField);
-        }
-        
-        ///<summary>
-        /// Retrieves the MotorPower field
-        /// Units: watts
-        /// Comment: lev motor power</summary>
-        /// <returns>Returns nullable ushort representing the MotorPower field</returns>
-        public ushort? GetMotorPower()
-        {
-            Object val = GetFieldValue(82, 0, Fit.SubfieldIndexMainField);
-            if(val == null)
-            {
-                return null;
-            }
-
-            return (Convert.ToUInt16(val));
-            
-        }
-
-        /// <summary>
-        /// Set MotorPower field
-        /// Units: watts
-        /// Comment: lev motor power</summary>
-        /// <param name="motorPower_">Nullable field value to be set</param>
-        public void SetMotorPower(ushort? motorPower_)
-        {
-            SetFieldValue(82, 0, motorPower_, Fit.SubfieldIndexMainField);
-        }
-        
-        ///<summary>
-        /// Retrieves the VerticalRatio field
-        /// Units: percent</summary>
-        /// <returns>Returns nullable float representing the VerticalRatio field</returns>
-        public float? GetVerticalRatio()
-        {
-            Object val = GetFieldValue(83, 0, Fit.SubfieldIndexMainField);
-            if(val == null)
-            {
-                return null;
-            }
-
-            return (Convert.ToSingle(val));
-            
-        }
-
-        /// <summary>
-        /// Set VerticalRatio field
-        /// Units: percent</summary>
-        /// <param name="verticalRatio_">Nullable field value to be set</param>
-        public void SetVerticalRatio(float? verticalRatio_)
-        {
-            SetFieldValue(83, 0, verticalRatio_, Fit.SubfieldIndexMainField);
-        }
-        
-        ///<summary>
-        /// Retrieves the StanceTimeBalance field
-        /// Units: percent</summary>
-        /// <returns>Returns nullable float representing the StanceTimeBalance field</returns>
-        public float? GetStanceTimeBalance()
-        {
-            Object val = GetFieldValue(84, 0, Fit.SubfieldIndexMainField);
-            if(val == null)
-            {
-                return null;
-            }
-
-            return (Convert.ToSingle(val));
-            
-        }
-
-        /// <summary>
-        /// Set StanceTimeBalance field
-        /// Units: percent</summary>
-        /// <param name="stanceTimeBalance_">Nullable field value to be set</param>
-        public void SetStanceTimeBalance(float? stanceTimeBalance_)
-        {
-            SetFieldValue(84, 0, stanceTimeBalance_, Fit.SubfieldIndexMainField);
-        }
-        
-        ///<summary>
-        /// Retrieves the StepLength field
-        /// Units: mm</summary>
-        /// <returns>Returns nullable float representing the StepLength field</returns>
-        public float? GetStepLength()
-        {
-            Object val = GetFieldValue(85, 0, Fit.SubfieldIndexMainField);
-            if(val == null)
-            {
-                return null;
-            }
-
-            return (Convert.ToSingle(val));
-            
-        }
-
-        /// <summary>
-        /// Set StepLength field
-        /// Units: mm</summary>
-        /// <param name="stepLength_">Nullable field value to be set</param>
-        public void SetStepLength(float? stepLength_)
-        {
-            SetFieldValue(85, 0, stepLength_, Fit.SubfieldIndexMainField);
-        }
-        
-        ///<summary>
-        /// Retrieves the CycleLength16 field
-        /// Units: m
-        /// Comment: Supports larger cycle sizes needed for paddlesports. Max cycle size: 655.35</summary>
-        /// <returns>Returns nullable float representing the CycleLength16 field</returns>
-        public float? GetCycleLength16()
-        {
-            Object val = GetFieldValue(87, 0, Fit.SubfieldIndexMainField);
-            if(val == null)
-            {
-                return null;
-            }
-
-            return (Convert.ToSingle(val));
-            
-        }
-
-        /// <summary>
-        /// Set CycleLength16 field
-        /// Units: m
-        /// Comment: Supports larger cycle sizes needed for paddlesports. Max cycle size: 655.35</summary>
-        /// <param name="cycleLength16_">Nullable field value to be set</param>
-        public void SetCycleLength16(float? cycleLength16_)
-        {
-            SetFieldValue(87, 0, cycleLength16_, Fit.SubfieldIndexMainField);
-        }
-        
-        ///<summary>
-        /// Retrieves the AbsolutePressure field
-        /// Units: Pa
-        /// Comment: Includes atmospheric pressure</summary>
-        /// <returns>Returns nullable uint representing the AbsolutePressure field</returns>
-        public uint? GetAbsolutePressure()
-        {
-            Object val = GetFieldValue(91, 0, Fit.SubfieldIndexMainField);
-            if(val == null)
-            {
-                return null;
-            }
-
-            return (Convert.ToUInt32(val));
-            
-        }
-
-        /// <summary>
-        /// Set AbsolutePressure field
-        /// Units: Pa
-        /// Comment: Includes atmospheric pressure</summary>
-        /// <param name="absolutePressure_">Nullable field value to be set</param>
-        public void SetAbsolutePressure(uint? absolutePressure_)
-        {
-            SetFieldValue(91, 0, absolutePressure_, Fit.SubfieldIndexMainField);
-        }
-        
-        ///<summary>
-        /// Retrieves the Depth field
-        /// Units: m
-        /// Comment: 0 if above water</summary>
-        /// <returns>Returns nullable float representing the Depth field</returns>
-        public float? GetDepth()
-        {
-            Object val = GetFieldValue(92, 0, Fit.SubfieldIndexMainField);
-            if(val == null)
-            {
-                return null;
-            }
-
-            return (Convert.ToSingle(val));
-            
-        }
-
-        /// <summary>
-        /// Set Depth field
-        /// Units: m
-        /// Comment: 0 if above water</summary>
-        /// <param name="depth_">Nullable field value to be set</param>
-        public void SetDepth(float? depth_)
-        {
-            SetFieldValue(92, 0, depth_, Fit.SubfieldIndexMainField);
-        }
-        
-        ///<summary>
-        /// Retrieves the NextStopDepth field
-        /// Units: m
-        /// Comment: 0 if above water</summary>
-        /// <returns>Returns nullable float representing the NextStopDepth field</returns>
-        public float? GetNextStopDepth()
-        {
-            Object val = GetFieldValue(93, 0, Fit.SubfieldIndexMainField);
-            if(val == null)
-            {
-                return null;
-            }
-
-            return (Convert.ToSingle(val));
-            
-        }
-
-        /// <summary>
-        /// Set NextStopDepth field
-        /// Units: m
-        /// Comment: 0 if above water</summary>
-        /// <param name="nextStopDepth_">Nullable field value to be set</param>
-        public void SetNextStopDepth(float? nextStopDepth_)
-        {
-            SetFieldValue(93, 0, nextStopDepth_, Fit.SubfieldIndexMainField);
-        }
-        
-        ///<summary>
-        /// Retrieves the NextStopTime field
-        /// Units: s</summary>
-        /// <returns>Returns nullable uint representing the NextStopTime field</returns>
-        public uint? GetNextStopTime()
-        {
-            Object val = GetFieldValue(94, 0, Fit.SubfieldIndexMainField);
-            if(val == null)
-            {
-                return null;
-            }
-
-            return (Convert.ToUInt32(val));
-            
-        }
-
-        /// <summary>
-        /// Set NextStopTime field
-        /// Units: s</summary>
-        /// <param name="nextStopTime_">Nullable field value to be set</param>
-        public void SetNextStopTime(uint? nextStopTime_)
-        {
-            SetFieldValue(94, 0, nextStopTime_, Fit.SubfieldIndexMainField);
-        }
-        
-        ///<summary>
-        /// Retrieves the TimeToSurface field
-        /// Units: s</summary>
-        /// <returns>Returns nullable uint representing the TimeToSurface field</returns>
-        public uint? GetTimeToSurface()
-        {
-            Object val = GetFieldValue(95, 0, Fit.SubfieldIndexMainField);
-            if(val == null)
-            {
-                return null;
-            }
-
-            return (Convert.ToUInt32(val));
-            
-        }
-
-        /// <summary>
-        /// Set TimeToSurface field
-        /// Units: s</summary>
-        /// <param name="timeToSurface_">Nullable field value to be set</param>
-        public void SetTimeToSurface(uint? timeToSurface_)
-        {
-            SetFieldValue(95, 0, timeToSurface_, Fit.SubfieldIndexMainField);
-        }
-        
-        ///<summary>
-        /// Retrieves the NdlTime field
-        /// Units: s</summary>
-        /// <returns>Returns nullable uint representing the NdlTime field</returns>
-        public uint? GetNdlTime()
-        {
-            Object val = GetFieldValue(96, 0, Fit.SubfieldIndexMainField);
-            if(val == null)
-            {
-                return null;
-            }
-
-            return (Convert.ToUInt32(val));
-            
-        }
-
-        /// <summary>
-        /// Set NdlTime field
-        /// Units: s</summary>
-        /// <param name="ndlTime_">Nullable field value to be set</param>
-        public void SetNdlTime(uint? ndlTime_)
-        {
-            SetFieldValue(96, 0, ndlTime_, Fit.SubfieldIndexMainField);
-        }
-        
-        ///<summary>
-        /// Retrieves the CnsLoad field
-        /// Units: percent</summary>
-        /// <returns>Returns nullable byte representing the CnsLoad field</returns>
-        public byte? GetCnsLoad()
-        {
-            Object val = GetFieldValue(97, 0, Fit.SubfieldIndexMainField);
-            if(val == null)
-            {
-                return null;
-            }
-
-            return (Convert.ToByte(val));
-            
-        }
-
-        /// <summary>
-        /// Set CnsLoad field
-        /// Units: percent</summary>
-        /// <param name="cnsLoad_">Nullable field value to be set</param>
-        public void SetCnsLoad(byte? cnsLoad_)
-        {
-            SetFieldValue(97, 0, cnsLoad_, Fit.SubfieldIndexMainField);
-        }
-        
-        ///<summary>
-        /// Retrieves the N2Load field
-        /// Units: percent</summary>
-        /// <returns>Returns nullable ushort representing the N2Load field</returns>
-        public ushort? GetN2Load()
-        {
-            Object val = GetFieldValue(98, 0, Fit.SubfieldIndexMainField);
-            if(val == null)
-            {
-                return null;
-            }
-
-            return (Convert.ToUInt16(val));
-            
-        }
-
-        /// <summary>
-        /// Set N2Load field
-        /// Units: percent</summary>
-        /// <param name="n2Load_">Nullable field value to be set</param>
-        public void SetN2Load(ushort? n2Load_)
-        {
-            SetFieldValue(98, 0, n2Load_, Fit.SubfieldIndexMainField);
-        }
-        
-        ///<summary>
-        /// Retrieves the RespirationRate field
-        /// Units: s</summary>
-        /// <returns>Returns nullable byte representing the RespirationRate field</returns>
-        public byte? GetRespirationRate()
-        {
-            Object val = GetFieldValue(99, 0, Fit.SubfieldIndexMainField);
-            if(val == null)
-            {
-                return null;
-            }
-
-            return (Convert.ToByte(val));
-            
-        }
-
-        /// <summary>
-        /// Set RespirationRate field
-        /// Units: s</summary>
-        /// <param name="respirationRate_">Nullable field value to be set</param>
-        public void SetRespirationRate(byte? respirationRate_)
-        {
-            SetFieldValue(99, 0, respirationRate_, Fit.SubfieldIndexMainField);
-        }
-        
-        ///<summary>
-        /// Retrieves the EnhancedRespirationRate field
-        /// Units: Breaths/min</summary>
-        /// <returns>Returns nullable float representing the EnhancedRespirationRate field</returns>
-        public float? GetEnhancedRespirationRate()
-        {
-            Object val = GetFieldValue(108, 0, Fit.SubfieldIndexMainField);
-            if(val == null)
-            {
-                return null;
-            }
-
-            return (Convert.ToSingle(val));
-            
-        }
-
-        /// <summary>
-        /// Set EnhancedRespirationRate field
-        /// Units: Breaths/min</summary>
-        /// <param name="enhancedRespirationRate_">Nullable field value to be set</param>
-        public void SetEnhancedRespirationRate(float? enhancedRespirationRate_)
-        {
-            SetFieldValue(108, 0, enhancedRespirationRate_, Fit.SubfieldIndexMainField);
-        }
-        
-        ///<summary>
-        /// Retrieves the Grit field
-        /// Comment: The grit score estimates how challenging a route could be for a cyclist in terms of time spent going over sharp turns or large grade slopes.</summary>
-        /// <returns>Returns nullable float representing the Grit field</returns>
-        public float? GetGrit()
-        {
-            Object val = GetFieldValue(114, 0, Fit.SubfieldIndexMainField);
-            if(val == null)
-            {
-                return null;
-            }
-
-            return (Convert.ToSingle(val));
-            
-        }
-
-        /// <summary>
-        /// Set Grit field
-        /// Comment: The grit score estimates how challenging a route could be for a cyclist in terms of time spent going over sharp turns or large grade slopes.</summary>
-        /// <param name="grit_">Nullable field value to be set</param>
-        public void SetGrit(float? grit_)
-        {
-            SetFieldValue(114, 0, grit_, Fit.SubfieldIndexMainField);
-        }
-        
-        ///<summary>
-        /// Retrieves the Flow field
-        /// Comment: The flow score estimates how long distance wise a cyclist deaccelerates over intervals where deacceleration is unnecessary such as smooth turns or small grade angle intervals.</summary>
-        /// <returns>Returns nullable float representing the Flow field</returns>
-        public float? GetFlow()
-        {
-            Object val = GetFieldValue(115, 0, Fit.SubfieldIndexMainField);
-            if(val == null)
-            {
-                return null;
-            }
-
-            return (Convert.ToSingle(val));
-            
-        }
-
-        /// <summary>
-        /// Set Flow field
-        /// Comment: The flow score estimates how long distance wise a cyclist deaccelerates over intervals where deacceleration is unnecessary such as smooth turns or small grade angle intervals.</summary>
-        /// <param name="flow_">Nullable field value to be set</param>
-        public void SetFlow(float? flow_)
-        {
-            SetFieldValue(115, 0, flow_, Fit.SubfieldIndexMainField);
-        }
-        
-        ///<summary>
-        /// Retrieves the CurrentStress field
-        /// Comment: Current Stress value</summary>
-        /// <returns>Returns nullable float representing the CurrentStress field</returns>
-        public float? GetCurrentStress()
-        {
-            Object val = GetFieldValue(116, 0, Fit.SubfieldIndexMainField);
-            if(val == null)
-            {
-                return null;
-            }
-
-            return (Convert.ToSingle(val));
-            
-        }
-
-        /// <summary>
-        /// Set CurrentStress field
-        /// Comment: Current Stress value</summary>
-        /// <param name="currentStress_">Nullable field value to be set</param>
-        public void SetCurrentStress(float? currentStress_)
-        {
-            SetFieldValue(116, 0, currentStress_, Fit.SubfieldIndexMainField);
-        }
-        
-        ///<summary>
-        /// Retrieves the EbikeTravelRange field
-        /// Units: km</summary>
-        /// <returns>Returns nullable ushort representing the EbikeTravelRange field</returns>
-        public ushort? GetEbikeTravelRange()
-        {
-            Object val = GetFieldValue(117, 0, Fit.SubfieldIndexMainField);
-            if(val == null)
-            {
-                return null;
-            }
-
-            return (Convert.ToUInt16(val));
-            
-        }
-
-        /// <summary>
-        /// Set EbikeTravelRange field
-        /// Units: km</summary>
-        /// <param name="ebikeTravelRange_">Nullable field value to be set</param>
-        public void SetEbikeTravelRange(ushort? ebikeTravelRange_)
-        {
-            SetFieldValue(117, 0, ebikeTravelRange_, Fit.SubfieldIndexMainField);
-        }
-        
-        ///<summary>
-        /// Retrieves the EbikeBatteryLevel field
-        /// Units: percent</summary>
-        /// <returns>Returns nullable byte representing the EbikeBatteryLevel field</returns>
-        public byte? GetEbikeBatteryLevel()
-        {
-            Object val = GetFieldValue(118, 0, Fit.SubfieldIndexMainField);
-            if(val == null)
-            {
-                return null;
-            }
-
-            return (Convert.ToByte(val));
-            
-        }
-
-        /// <summary>
-        /// Set EbikeBatteryLevel field
-        /// Units: percent</summary>
-        /// <param name="ebikeBatteryLevel_">Nullable field value to be set</param>
-        public void SetEbikeBatteryLevel(byte? ebikeBatteryLevel_)
-        {
-            SetFieldValue(118, 0, ebikeBatteryLevel_, Fit.SubfieldIndexMainField);
-        }
-        
-        ///<summary>
-        /// Retrieves the EbikeAssistMode field
-        /// Units: depends on sensor</summary>
-        /// <returns>Returns nullable byte representing the EbikeAssistMode field</returns>
-        public byte? GetEbikeAssistMode()
-        {
-            Object val = GetFieldValue(119, 0, Fit.SubfieldIndexMainField);
-            if(val == null)
-            {
-                return null;
-            }
-
-            return (Convert.ToByte(val));
-            
-        }
-
-        /// <summary>
-        /// Set EbikeAssistMode field
-        /// Units: depends on sensor</summary>
-        /// <param name="ebikeAssistMode_">Nullable field value to be set</param>
-        public void SetEbikeAssistMode(byte? ebikeAssistMode_)
-        {
-            SetFieldValue(119, 0, ebikeAssistMode_, Fit.SubfieldIndexMainField);
-        }
-        
-        ///<summary>
-        /// Retrieves the EbikeAssistLevelPercent field
-        /// Units: percent</summary>
-        /// <returns>Returns nullable byte representing the EbikeAssistLevelPercent field</returns>
-        public byte? GetEbikeAssistLevelPercent()
-        {
-            Object val = GetFieldValue(120, 0, Fit.SubfieldIndexMainField);
-            if(val == null)
-            {
-                return null;
-            }
-
-            return (Convert.ToByte(val));
-            
-        }
-
-        /// <summary>
-        /// Set EbikeAssistLevelPercent field
-        /// Units: percent</summary>
-        /// <param name="ebikeAssistLevelPercent_">Nullable field value to be set</param>
-        public void SetEbikeAssistLevelPercent(byte? ebikeAssistLevelPercent_)
-        {
-            SetFieldValue(120, 0, ebikeAssistLevelPercent_, Fit.SubfieldIndexMainField);
-        }
-        
-        ///<summary>
-        /// Retrieves the AirTimeRemaining field
-        /// Units: s</summary>
-        /// <returns>Returns nullable uint representing the AirTimeRemaining field</returns>
-        public uint? GetAirTimeRemaining()
-        {
-            Object val = GetFieldValue(123, 0, Fit.SubfieldIndexMainField);
-            if(val == null)
-            {
-                return null;
-            }
-
-            return (Convert.ToUInt32(val));
-            
-        }
-
-        /// <summary>
-        /// Set AirTimeRemaining field
-        /// Units: s</summary>
-        /// <param name="airTimeRemaining_">Nullable field value to be set</param>
-        public void SetAirTimeRemaining(uint? airTimeRemaining_)
-        {
-            SetFieldValue(123, 0, airTimeRemaining_, Fit.SubfieldIndexMainField);
-        }
-        
-        ///<summary>
-        /// Retrieves the PressureSac field
-        /// Units: bar/min
-        /// Comment: Pressure-based surface air consumption</summary>
-        /// <returns>Returns nullable float representing the PressureSac field</returns>
-        public float? GetPressureSac()
-        {
-            Object val = GetFieldValue(124, 0, Fit.SubfieldIndexMainField);
-            if(val == null)
-            {
-                return null;
-            }
-
-            return (Convert.ToSingle(val));
-            
-        }
-
-        /// <summary>
-        /// Set PressureSac field
-        /// Units: bar/min
-        /// Comment: Pressure-based surface air consumption</summary>
-        /// <param name="pressureSac_">Nullable field value to be set</param>
-        public void SetPressureSac(float? pressureSac_)
-        {
-            SetFieldValue(124, 0, pressureSac_, Fit.SubfieldIndexMainField);
-        }
-        
-        ///<summary>
-        /// Retrieves the VolumeSac field
-        /// Units: L/min
-        /// Comment: Volumetric surface air consumption</summary>
-        /// <returns>Returns nullable float representing the VolumeSac field</returns>
-        public float? GetVolumeSac()
-        {
-            Object val = GetFieldValue(125, 0, Fit.SubfieldIndexMainField);
-            if(val == null)
-            {
-                return null;
-            }
-
-            return (Convert.ToSingle(val));
-            
-        }
-
-        /// <summary>
-        /// Set VolumeSac field
-        /// Units: L/min
-        /// Comment: Volumetric surface air consumption</summary>
-        /// <param name="volumeSac_">Nullable field value to be set</param>
-        public void SetVolumeSac(float? volumeSac_)
-        {
-            SetFieldValue(125, 0, volumeSac_, Fit.SubfieldIndexMainField);
-        }
-        
-        ///<summary>
-        /// Retrieves the Rmv field
-        /// Units: L/min
-        /// Comment: Respiratory minute volume</summary>
-        /// <returns>Returns nullable float representing the Rmv field</returns>
-        public float? GetRmv()
-        {
-            Object val = GetFieldValue(126, 0, Fit.SubfieldIndexMainField);
-            if(val == null)
-            {
-                return null;
-            }
-
-            return (Convert.ToSingle(val));
-            
-        }
-
-        /// <summary>
-        /// Set Rmv field
-        /// Units: L/min
-        /// Comment: Respiratory minute volume</summary>
-        /// <param name="rmv_">Nullable field value to be set</param>
-        public void SetRmv(float? rmv_)
-        {
-            SetFieldValue(126, 0, rmv_, Fit.SubfieldIndexMainField);
-        }
-        
-        ///<summary>
-        /// Retrieves the AscentRate field
-        /// Units: m/s</summary>
-        /// <returns>Returns nullable float representing the AscentRate field</returns>
-        public float? GetAscentRate()
-        {
-            Object val = GetFieldValue(127, 0, Fit.SubfieldIndexMainField);
-            if(val == null)
-            {
-                return null;
-            }
-
-            return (Convert.ToSingle(val));
-            
-        }
-
-        /// <summary>
-        /// Set AscentRate field
-        /// Units: m/s</summary>
-        /// <param name="ascentRate_">Nullable field value to be set</param>
-        public void SetAscentRate(float? ascentRate_)
-        {
-            SetFieldValue(127, 0, ascentRate_, Fit.SubfieldIndexMainField);
-        }
-        
-        ///<summary>
-        /// Retrieves the Po2 field
-        /// Units: percent
-        /// Comment: Current partial pressure of oxygen</summary>
-        /// <returns>Returns nullable float representing the Po2 field</returns>
-        public float? GetPo2()
-        {
-            Object val = GetFieldValue(129, 0, Fit.SubfieldIndexMainField);
-            if(val == null)
-            {
-                return null;
-            }
-
-            return (Convert.ToSingle(val));
-            
-        }
-
-        /// <summary>
-        /// Set Po2 field
-        /// Units: percent
-        /// Comment: Current partial pressure of oxygen</summary>
-        /// <param name="po2_">Nullable field value to be set</param>
-        public void SetPo2(float? po2_)
-        {
-            SetFieldValue(129, 0, po2_, Fit.SubfieldIndexMainField);
-        }
-        
-        ///<summary>
-        /// Retrieves the CoreTemperature field
-        /// Units: C</summary>
-        /// <returns>Returns nullable float representing the CoreTemperature field</returns>
-        public float? GetCoreTemperature()
-        {
-            Object val = GetFieldValue(139, 0, Fit.SubfieldIndexMainField);
-            if(val == null)
-            {
-                return null;
-            }
-
-            return (Convert.ToSingle(val));
-            
-        }
-
-        /// <summary>
-        /// Set CoreTemperature field
-        /// Units: C</summary>
-        /// <param name="coreTemperature_">Nullable field value to be set</param>
-        public void SetCoreTemperature(float? coreTemperature_)
-        {
-            SetFieldValue(139, 0, coreTemperature_, Fit.SubfieldIndexMainField);
-        }
-        
-        #endregion // Methods
-    } // Class
+	/// <summary>
+	/// Implements the Record profile message.
+	/// </summary>
+	public class RecordMesg : Mesg
+	{
+		#region Fields
+		#endregion
+
+		/// <summary>
+		/// Field Numbers for <see cref="RecordMesg"/>
+		/// </summary>
+		public sealed class FieldDefNum
+		{
+			public const byte Timestamp = 253;
+			public const byte PositionLat = 0;
+			public const byte PositionLong = 1;
+			public const byte Altitude = 2;
+			public const byte HeartRate = 3;
+			public const byte Cadence = 4;
+			public const byte Distance = 5;
+			public const byte Speed = 6;
+			public const byte Power = 7;
+			public const byte CompressedSpeedDistance = 8;
+			public const byte Grade = 9;
+			public const byte Resistance = 10;
+			public const byte TimeFromCourse = 11;
+			public const byte CycleLength = 12;
+			public const byte Temperature = 13;
+			public const byte Speed1s = 17;
+			public const byte Cycles = 18;
+			public const byte TotalCycles = 19;
+			public const byte CompressedAccumulatedPower = 28;
+			public const byte AccumulatedPower = 29;
+			public const byte LeftRightBalance = 30;
+			public const byte GpsAccuracy = 31;
+			public const byte VerticalSpeed = 32;
+			public const byte Calories = 33;
+			public const byte VerticalOscillation = 39;
+			public const byte StanceTimePercent = 40;
+			public const byte StanceTime = 41;
+			public const byte ActivityType = 42;
+			public const byte LeftTorqueEffectiveness = 43;
+			public const byte RightTorqueEffectiveness = 44;
+			public const byte LeftPedalSmoothness = 45;
+			public const byte RightPedalSmoothness = 46;
+			public const byte CombinedPedalSmoothness = 47;
+			public const byte Time128 = 48;
+			public const byte StrokeType = 49;
+			public const byte Zone = 50;
+			public const byte BallSpeed = 51;
+			public const byte Cadence256 = 52;
+			public const byte FractionalCadence = 53;
+			public const byte TotalHemoglobinConc = 54;
+			public const byte TotalHemoglobinConcMin = 55;
+			public const byte TotalHemoglobinConcMax = 56;
+			public const byte SaturatedHemoglobinPercent = 57;
+			public const byte SaturatedHemoglobinPercentMin = 58;
+			public const byte SaturatedHemoglobinPercentMax = 59;
+			public const byte DeviceIndex = 62;
+			public const byte LeftPco = 67;
+			public const byte RightPco = 68;
+			public const byte LeftPowerPhase = 69;
+			public const byte LeftPowerPhasePeak = 70;
+			public const byte RightPowerPhase = 71;
+			public const byte RightPowerPhasePeak = 72;
+			public const byte EnhancedSpeed = 73;
+			public const byte EnhancedAltitude = 78;
+			public const byte BatterySoc = 81;
+			public const byte MotorPower = 82;
+			public const byte VerticalRatio = 83;
+			public const byte StanceTimeBalance = 84;
+			public const byte StepLength = 85;
+			public const byte CycleLength16 = 87;
+			public const byte AbsolutePressure = 91;
+			public const byte Depth = 92;
+			public const byte NextStopDepth = 93;
+			public const byte NextStopTime = 94;
+			public const byte TimeToSurface = 95;
+			public const byte NdlTime = 96;
+			public const byte CnsLoad = 97;
+			public const byte N2Load = 98;
+			public const byte RespirationRate = 99;
+			public const byte EnhancedRespirationRate = 108;
+			public const byte Grit = 114;
+			public const byte Flow = 115;
+			public const byte CurrentStress = 116;
+			public const byte EbikeTravelRange = 117;
+			public const byte EbikeBatteryLevel = 118;
+			public const byte EbikeAssistMode = 119;
+			public const byte EbikeAssistLevelPercent = 120;
+			public const byte AirTimeRemaining = 123;
+			public const byte PressureSac = 124;
+			public const byte VolumeSac = 125;
+			public const byte Rmv = 126;
+			public const byte AscentRate = 127;
+			public const byte Po2 = 129;
+			public const byte CoreTemperature = 139;
+			public const byte Invalid = Fit.FieldNumInvalid;
+		}
+
+		#region Constructors
+		public RecordMesg() : base(Profile.GetMesg(MesgNum.Record))
+		{
+		}
+
+		public RecordMesg(Mesg mesg) : base(mesg)
+		{
+		}
+		#endregion // Constructors
+
+		#region Methods
+		///<summary>
+		/// Retrieves the Timestamp field
+		/// Units: s</summary>
+		/// <returns>Returns DateTime representing the Timestamp field</returns>
+		public DateTime Timestamp
+		{
+			get
+			{
+				Object val = GetFieldValue(253, 0, Fit.SubfieldIndexMainField);
+				if (val == null)
+				{
+					return null;
+				}
+
+				return TimestampToDateTime(Convert.ToUInt32(val));
+
+			}
+			set
+			{
+				SetFieldValue(253, 0, value.GetTimeStamp(), Fit.SubfieldIndexMainField);
+			}
+		}
+
+		///<summary>
+		/// Retrieves the PositionLat field
+		/// Units: semicircles</summary>
+		/// <returns>Returns nullable int representing the PositionLat field</returns>
+		public int? PositionLat
+		{
+			get
+			{
+				Object val = GetFieldValue(0, 0, Fit.SubfieldIndexMainField);
+				if (val == null)
+				{
+					return null;
+				}
+
+				return (Convert.ToInt32(val));
+
+			}
+			set
+			{
+				SetFieldValue(0, 0, value, Fit.SubfieldIndexMainField);
+			}
+		}
+
+		///<summary>
+		/// Retrieves the PositionLong field
+		/// Units: semicircles</summary>
+		/// <returns>Returns nullable int representing the PositionLong field</returns>
+		public int? PositionLong
+		{
+			get
+			{
+				Object val = GetFieldValue(1, 0, Fit.SubfieldIndexMainField);
+				if (val == null)
+				{
+					return null;
+				}
+
+				return (Convert.ToInt32(val));
+
+			}
+			set
+			{
+				SetFieldValue(1, 0, value, Fit.SubfieldIndexMainField);
+			}
+		}
+
+		///<summary>
+		/// Retrieves the Altitude field
+		/// Units: m</summary>
+		/// <returns>Returns nullable float representing the Altitude field</returns>
+		public float? Altitude
+		{
+			get
+			{
+				Object val = GetFieldValue(2, 0, Fit.SubfieldIndexMainField);
+				if (val == null)
+				{
+					return null;
+				}
+
+				return (Convert.ToSingle(val));
+
+			}
+			set
+			{
+				SetFieldValue(2, 0, value, Fit.SubfieldIndexMainField);
+			}
+		}
+
+		///<summary>
+		/// Retrieves the HeartRate field
+		/// Units: bpm</summary>
+		/// <returns>Returns nullable byte representing the HeartRate field</returns>
+		public byte? HeartRate
+		{
+			get
+			{
+				Object val = GetFieldValue(3, 0, Fit.SubfieldIndexMainField);
+				if (val == null)
+				{
+					return null;
+				}
+
+				return (Convert.ToByte(val));
+
+			}
+			set
+			{
+				SetFieldValue(3, 0, value, Fit.SubfieldIndexMainField);
+			}
+		}
+
+		///<summary>
+		/// Retrieves the Cadence field
+		/// Units: rpm</summary>
+		/// <returns>Returns nullable byte representing the Cadence field</returns>
+		public byte? Cadence
+		{
+			get
+			{
+				Object val = GetFieldValue(4, 0, Fit.SubfieldIndexMainField);
+				if (val == null)
+				{
+					return null;
+				}
+
+				return (Convert.ToByte(val));
+
+			}
+			set
+			{
+				SetFieldValue(4, 0, value, Fit.SubfieldIndexMainField);
+			}
+		}
+
+		///<summary>
+		/// Retrieves the Distance field
+		/// Units: m</summary>
+		/// <returns>Returns nullable float representing the Distance field</returns>
+		public float? Distance
+		{
+			get
+			{
+				Object val = GetFieldValue(5, 0, Fit.SubfieldIndexMainField);
+				if (val == null)
+				{
+					return null;
+				}
+
+				return (Convert.ToSingle(val));
+
+			}
+			set
+			{
+				SetFieldValue(5, 0, value, Fit.SubfieldIndexMainField);
+			}
+		}
+
+		///<summary>
+		/// Retrieves the Speed field
+		/// Units: m/s</summary>
+		/// <returns>Returns nullable float representing the Speed field</returns>
+		public float? Speed
+		{
+			get
+			{
+				Object val = GetFieldValue(6, 0, Fit.SubfieldIndexMainField);
+				if (val == null)
+				{
+					return null;
+				}
+
+				return (Convert.ToSingle(val));
+
+			}
+			set
+			{
+				SetFieldValue(6, 0, value, Fit.SubfieldIndexMainField);
+			}
+		}
+
+		///<summary>
+		/// Retrieves the Power field
+		/// Units: watts</summary>
+		/// <returns>Returns nullable ushort representing the Power field</returns>
+		public ushort? Power
+		{
+			get
+			{
+				Object val = GetFieldValue(7, 0, Fit.SubfieldIndexMainField);
+				if (val == null)
+				{
+					return null;
+				}
+
+				return (Convert.ToUInt16(val));
+
+			}
+			set
+			{
+				SetFieldValue(7, 0, value, Fit.SubfieldIndexMainField);
+			}
+		}
+
+
+		/// <summary>
+		///
+		/// </summary>
+		/// <returns>returns number of elements in field CompressedSpeedDistance</returns>
+		public int GetNumCompressedSpeedDistance()
+		{
+			return GetNumFieldValues(8, Fit.SubfieldIndexMainField);
+		}
+
+		///<summary>
+		/// Retrieves the CompressedSpeedDistance field</summary>
+		/// <param name="index">0 based index of CompressedSpeedDistance element to retrieve</param>
+		/// <returns>Returns nullable byte representing the CompressedSpeedDistance field</returns>
+		public byte? GetCompressedSpeedDistance(int index)
+		{
+			Object val = GetFieldValue(8, index, Fit.SubfieldIndexMainField);
+			if (val == null)
+			{
+				return null;
+			}
+
+			return (Convert.ToByte(val));
+
+		}
+
+		/// <summary>
+		/// Set CompressedSpeedDistance field</summary>
+		/// <param name="index">0 based index of compressed_speed_distance</param>
+		/// <param name="compressedSpeedDistance_">Nullable field value to be set</param>
+		public void SetCompressedSpeedDistance(int index, byte? compressedSpeedDistance_)
+		{
+			SetFieldValue(8, index, compressedSpeedDistance_, Fit.SubfieldIndexMainField);
+		}
+
+		///<summary>
+		/// Retrieves the Grade field
+		/// Units: %</summary>
+		/// <returns>Returns nullable float representing the Grade field</returns>
+		public float? Grade
+		{
+			get
+			{
+				Object val = GetFieldValue(9, 0, Fit.SubfieldIndexMainField);
+				if (val == null)
+				{
+					return null;
+				}
+
+				return (Convert.ToSingle(val));
+
+			}
+			set
+			{
+				SetFieldValue(9, 0, value, Fit.SubfieldIndexMainField);
+			}
+		}
+
+		///<summary>
+		/// Retrieves the Resistance field
+		/// Comment: Relative. 0 is none 254 is Max.</summary>
+		/// <returns>Returns nullable byte representing the Resistance field</returns>
+		public byte? Resistance
+		{
+			get
+			{
+				Object val = GetFieldValue(10, 0, Fit.SubfieldIndexMainField);
+				if (val == null)
+				{
+					return null;
+				}
+
+				return (Convert.ToByte(val));
+
+			}
+			set
+			{
+				SetFieldValue(10, 0, value, Fit.SubfieldIndexMainField);
+			}
+		}
+
+		///<summary>
+		/// Retrieves the TimeFromCourse field
+		/// Units: s</summary>
+		/// <returns>Returns nullable float representing the TimeFromCourse field</returns>
+		public float? TimeFromCourse
+		{
+			get
+			{
+				Object val = GetFieldValue(11, 0, Fit.SubfieldIndexMainField);
+				if (val == null)
+				{
+					return null;
+				}
+
+				return (Convert.ToSingle(val));
+
+			}
+			set
+			{
+				SetFieldValue(11, 0, value, Fit.SubfieldIndexMainField);
+			}
+		}
+
+		///<summary>
+		/// Retrieves the CycleLength field
+		/// Units: m</summary>
+		/// <returns>Returns nullable float representing the CycleLength field</returns>
+		public float? CycleLength
+		{
+			get
+			{
+				Object val = GetFieldValue(12, 0, Fit.SubfieldIndexMainField);
+				if (val == null)
+				{
+					return null;
+				}
+
+				return (Convert.ToSingle(val));
+
+			}
+			set
+			{
+				SetFieldValue(12, 0, value, Fit.SubfieldIndexMainField);
+			}
+		}
+
+		///<summary>
+		/// Retrieves the Temperature field
+		/// Units: C</summary>
+		/// <returns>Returns nullable sbyte representing the Temperature field</returns>
+		public sbyte? Temperature
+		{
+			get
+			{
+				Object val = GetFieldValue(13, 0, Fit.SubfieldIndexMainField);
+				if (val == null)
+				{
+					return null;
+				}
+
+				return (Convert.ToSByte(val));
+
+			}
+			set
+			{
+				SetFieldValue(13, 0, value, Fit.SubfieldIndexMainField);
+			}
+		}
+
+
+		/// <summary>
+		///
+		/// </summary>
+		/// <returns>returns number of elements in field Speed1s</returns>
+		public int GetNumSpeed1s()
+		{
+			return GetNumFieldValues(17, Fit.SubfieldIndexMainField);
+		}
+
+		///<summary>
+		/// Retrieves the Speed1s field
+		/// Units: m/s
+		/// Comment: Speed at 1s intervals. Timestamp field indicates time of last array element.</summary>
+		/// <param name="index">0 based index of Speed1s element to retrieve</param>
+		/// <returns>Returns nullable float representing the Speed1s field</returns>
+		public float? GetSpeed1s(int index)
+		{
+			Object val = GetFieldValue(17, index, Fit.SubfieldIndexMainField);
+			if (val == null)
+			{
+				return null;
+			}
+
+			return (Convert.ToSingle(val));
+
+		}
+
+		/// <summary>
+		/// Set Speed1s field
+		/// Units: m/s
+		/// Comment: Speed at 1s intervals. Timestamp field indicates time of last array element.</summary>
+		/// <param name="index">0 based index of speed_1s</param>
+		/// <param name="speed1s_">Nullable field value to be set</param>
+		public void SetSpeed1s(int index, float? speed1s_)
+		{
+			SetFieldValue(17, index, speed1s_, Fit.SubfieldIndexMainField);
+		}
+
+		///<summary>
+		/// Retrieves the Cycles field
+		/// Units: cycles</summary>
+		/// <returns>Returns nullable byte representing the Cycles field</returns>
+		public byte? Cycles
+		{
+			get
+			{
+				Object val = GetFieldValue(18, 0, Fit.SubfieldIndexMainField);
+				if (val == null)
+				{
+					return null;
+				}
+
+				return (Convert.ToByte(val));
+
+			}
+			set
+			{
+				SetFieldValue(18, 0, value, Fit.SubfieldIndexMainField);
+			}
+		}
+
+		///<summary>
+		/// Retrieves the TotalCycles field
+		/// Units: cycles</summary>
+		/// <returns>Returns nullable uint representing the TotalCycles field</returns>
+		public uint? TotalCycles
+		{
+			get
+			{
+				Object val = GetFieldValue(19, 0, Fit.SubfieldIndexMainField);
+				if (val == null)
+				{
+					return null;
+				}
+
+				return (Convert.ToUInt32(val));
+
+			}
+			set
+			{
+				SetFieldValue(19, 0, value, Fit.SubfieldIndexMainField);
+			}
+		}
+
+		///<summary>
+		/// Retrieves the CompressedAccumulatedPower field
+		/// Units: watts</summary>
+		/// <returns>Returns nullable ushort representing the CompressedAccumulatedPower field</returns>
+		public ushort? CompressedAccumulatedPower
+		{
+			get
+			{
+				Object val = GetFieldValue(28, 0, Fit.SubfieldIndexMainField);
+				if (val == null)
+				{
+					return null;
+				}
+
+				return (Convert.ToUInt16(val));
+
+			}
+			set
+			{
+				SetFieldValue(28, 0, value, Fit.SubfieldIndexMainField);
+			}
+		}
+
+		///<summary>
+		/// Retrieves the AccumulatedPower field
+		/// Units: watts</summary>
+		/// <returns>Returns nullable uint representing the AccumulatedPower field</returns>
+		public uint? AccumulatedPower
+		{
+			get
+			{
+				Object val = GetFieldValue(29, 0, Fit.SubfieldIndexMainField);
+				if (val == null)
+				{
+					return null;
+				}
+
+				return (Convert.ToUInt32(val));
+
+			}
+			set
+			{
+				SetFieldValue(29, 0, value, Fit.SubfieldIndexMainField);
+			}
+		}
+
+		///<summary>
+		/// Retrieves the LeftRightBalance field</summary>
+		/// <returns>Returns nullable byte representing the LeftRightBalance field</returns>
+		public byte? LeftRightBalance
+		{
+			get
+			{
+				Object val = GetFieldValue(30, 0, Fit.SubfieldIndexMainField);
+				if (val == null)
+				{
+					return null;
+				}
+
+				return (Convert.ToByte(val));
+
+			}
+			set
+			{
+				SetFieldValue(30, 0, value, Fit.SubfieldIndexMainField);
+			}
+		}
+
+		///<summary>
+		/// Retrieves the GpsAccuracy field
+		/// Units: m</summary>
+		/// <returns>Returns nullable byte representing the GpsAccuracy field</returns>
+		public byte? GpsAccuracy
+		{
+			get
+			{
+				Object val = GetFieldValue(31, 0, Fit.SubfieldIndexMainField);
+				if (val == null)
+				{
+					return null;
+				}
+
+				return (Convert.ToByte(val));
+
+			}
+			set
+			{
+				SetFieldValue(31, 0, value, Fit.SubfieldIndexMainField);
+			}
+		}
+
+		///<summary>
+		/// Retrieves the VerticalSpeed field
+		/// Units: m/s</summary>
+		/// <returns>Returns nullable float representing the VerticalSpeed field</returns>
+		public float? VerticalSpeed
+		{
+			get
+			{
+				Object val = GetFieldValue(32, 0, Fit.SubfieldIndexMainField);
+				if (val == null)
+				{
+					return null;
+				}
+
+				return (Convert.ToSingle(val));
+
+			}
+			set
+			{
+				SetFieldValue(32, 0, value, Fit.SubfieldIndexMainField);
+			}
+		}
+
+		///<summary>
+		/// Retrieves the Calories field
+		/// Units: kcal</summary>
+		/// <returns>Returns nullable ushort representing the Calories field</returns>
+		public ushort? Calories
+		{
+			get
+			{
+				Object val = GetFieldValue(33, 0, Fit.SubfieldIndexMainField);
+				if (val == null)
+				{
+					return null;
+				}
+
+				return (Convert.ToUInt16(val));
+
+			}
+			set
+			{
+				SetFieldValue(33, 0, value, Fit.SubfieldIndexMainField);
+			}
+		}
+
+		///<summary>
+		/// Retrieves the VerticalOscillation field
+		/// Units: mm</summary>
+		/// <returns>Returns nullable float representing the VerticalOscillation field</returns>
+		public float? VerticalOscillation
+		{
+			get
+			{
+				Object val = GetFieldValue(39, 0, Fit.SubfieldIndexMainField);
+				if (val == null)
+				{
+					return null;
+				}
+
+				return (Convert.ToSingle(val));
+
+			}
+			set
+			{
+				SetFieldValue(39, 0, value, Fit.SubfieldIndexMainField);
+			}
+		}
+
+		///<summary>
+		/// Retrieves the StanceTimePercent field
+		/// Units: percent</summary>
+		/// <returns>Returns nullable float representing the StanceTimePercent field</returns>
+		public float? StanceTimePercent
+		{
+			get
+			{
+				Object val = GetFieldValue(40, 0, Fit.SubfieldIndexMainField);
+				if (val == null)
+				{
+					return null;
+				}
+
+				return (Convert.ToSingle(val));
+
+			}
+			set
+			{
+				SetFieldValue(40, 0, value, Fit.SubfieldIndexMainField);
+			}
+		}
+
+		///<summary>
+		/// Retrieves the StanceTime field
+		/// Units: ms</summary>
+		/// <returns>Returns nullable float representing the StanceTime field</returns>
+		public float? StanceTime
+		{
+			get
+			{
+				Object val = GetFieldValue(41, 0, Fit.SubfieldIndexMainField);
+				if (val == null)
+				{
+					return null;
+				}
+
+				return (Convert.ToSingle(val));
+
+			}
+			set
+			{
+				SetFieldValue(41, 0, value, Fit.SubfieldIndexMainField);
+			}
+		}
+
+		///<summary>
+		/// Retrieves the ActivityType field</summary>
+		/// <returns>Returns nullable ActivityType enum representing the ActivityType field</returns>
+		public ActivityType? ActivityType
+		{
+			get
+			{
+				object obj = GetFieldValue(42, 0, Fit.SubfieldIndexMainField);
+				ActivityType? value = obj == null ? (ActivityType?)null : (ActivityType)obj;
+				return value;
+			}
+			set
+			{
+				SetFieldValue(42, 0, value, Fit.SubfieldIndexMainField);
+			}
+		}
+
+		///<summary>
+		/// Retrieves the LeftTorqueEffectiveness field
+		/// Units: percent</summary>
+		/// <returns>Returns nullable float representing the LeftTorqueEffectiveness field</returns>
+		public float? LeftTorqueEffectiveness
+		{
+			get
+			{
+				Object val = GetFieldValue(43, 0, Fit.SubfieldIndexMainField);
+				if (val == null)
+				{
+					return null;
+				}
+
+				return (Convert.ToSingle(val));
+
+			}
+			set
+			{
+				SetFieldValue(43, 0, value, Fit.SubfieldIndexMainField);
+			}
+		}
+
+		///<summary>
+		/// Retrieves the RightTorqueEffectiveness field
+		/// Units: percent</summary>
+		/// <returns>Returns nullable float representing the RightTorqueEffectiveness field</returns>
+		public float? RightTorqueEffectiveness
+		{
+			get
+			{
+				Object val = GetFieldValue(44, 0, Fit.SubfieldIndexMainField);
+				if (val == null)
+				{
+					return null;
+				}
+
+				return (Convert.ToSingle(val));
+
+			}
+			set
+			{
+				SetFieldValue(44, 0, value, Fit.SubfieldIndexMainField);
+			}
+		}
+
+		///<summary>
+		/// Retrieves the LeftPedalSmoothness field
+		/// Units: percent</summary>
+		/// <returns>Returns nullable float representing the LeftPedalSmoothness field</returns>
+		public float? LeftPedalSmoothness
+		{
+			get
+			{
+				Object val = GetFieldValue(45, 0, Fit.SubfieldIndexMainField);
+				if (val == null)
+				{
+					return null;
+				}
+
+				return (Convert.ToSingle(val));
+
+			}
+			set
+			{
+				SetFieldValue(45, 0, value, Fit.SubfieldIndexMainField);
+			}
+		}
+
+		///<summary>
+		/// Retrieves the RightPedalSmoothness field
+		/// Units: percent</summary>
+		/// <returns>Returns nullable float representing the RightPedalSmoothness field</returns>
+		public float? RightPedalSmoothness
+		{
+			get
+			{
+				Object val = GetFieldValue(46, 0, Fit.SubfieldIndexMainField);
+				if (val == null)
+				{
+					return null;
+				}
+
+				return (Convert.ToSingle(val));
+
+			}
+			set
+			{
+				SetFieldValue(46, 0, value, Fit.SubfieldIndexMainField);
+			}
+		}
+
+		///<summary>
+		/// Retrieves the CombinedPedalSmoothness field
+		/// Units: percent</summary>
+		/// <returns>Returns nullable float representing the CombinedPedalSmoothness field</returns>
+		public float? CombinedPedalSmoothness
+		{
+			get
+			{
+				Object val = GetFieldValue(47, 0, Fit.SubfieldIndexMainField);
+				if (val == null)
+				{
+					return null;
+				}
+
+				return (Convert.ToSingle(val));
+
+			}
+			set
+			{
+				SetFieldValue(47, 0, value, Fit.SubfieldIndexMainField);
+			}
+		}
+
+		///<summary>
+		/// Retrieves the Time128 field
+		/// Units: s</summary>
+		/// <returns>Returns nullable float representing the Time128 field</returns>
+		public float? Time128
+		{
+			get
+			{
+				Object val = GetFieldValue(48, 0, Fit.SubfieldIndexMainField);
+				if (val == null)
+				{
+					return null;
+				}
+
+				return (Convert.ToSingle(val));
+
+			}
+			set
+			{
+				SetFieldValue(48, 0, value, Fit.SubfieldIndexMainField);
+			}
+		}
+
+		///<summary>
+		/// Retrieves the StrokeType field</summary>
+		/// <returns>Returns nullable StrokeType enum representing the StrokeType field</returns>
+		public StrokeType? StrokeType
+		{
+			get
+			{
+				object obj = GetFieldValue(49, 0, Fit.SubfieldIndexMainField);
+				StrokeType? value = obj == null ? (StrokeType?)null : (StrokeType)obj;
+				return value;
+			}
+			set
+			{
+				SetFieldValue(49, 0, value, Fit.SubfieldIndexMainField);
+			}
+		}
+
+		///<summary>
+		/// Retrieves the Zone field</summary>
+		/// <returns>Returns nullable byte representing the Zone field</returns>
+		public byte? Zone
+		{
+			get
+			{
+				Object val = GetFieldValue(50, 0, Fit.SubfieldIndexMainField);
+				if (val == null)
+				{
+					return null;
+				}
+
+				return (Convert.ToByte(val));
+
+			}
+			set
+			{
+				SetFieldValue(50, 0, value, Fit.SubfieldIndexMainField);
+			}
+		}
+
+		///<summary>
+		/// Retrieves the BallSpeed field
+		/// Units: m/s</summary>
+		/// <returns>Returns nullable float representing the BallSpeed field</returns>
+		public float? BallSpeed
+		{
+			get
+			{
+				Object val = GetFieldValue(51, 0, Fit.SubfieldIndexMainField);
+				if (val == null)
+				{
+					return null;
+				}
+
+				return (Convert.ToSingle(val));
+
+			}
+			set
+			{
+				SetFieldValue(51, 0, value, Fit.SubfieldIndexMainField);
+			}
+		}
+
+		///<summary>
+		/// Retrieves the Cadence256 field
+		/// Units: rpm
+		/// Comment: Log cadence and fractional cadence for backwards compatability</summary>
+		/// <returns>Returns nullable float representing the Cadence256 field</returns>
+		public float? Cadence256
+		{
+			get
+			{
+				Object val = GetFieldValue(52, 0, Fit.SubfieldIndexMainField);
+				if (val == null)
+				{
+					return null;
+				}
+
+				return (Convert.ToSingle(val));
+
+			}
+			set
+			{
+				SetFieldValue(52, 0, value, Fit.SubfieldIndexMainField);
+			}
+		}
+
+		///<summary>
+		/// Retrieves the FractionalCadence field
+		/// Units: rpm</summary>
+		/// <returns>Returns nullable float representing the FractionalCadence field</returns>
+		public float? FractionalCadence
+		{
+			get
+			{
+				Object val = GetFieldValue(53, 0, Fit.SubfieldIndexMainField);
+				if (val == null)
+				{
+					return null;
+				}
+
+				return (Convert.ToSingle(val));
+
+			}
+			set
+			{
+				SetFieldValue(53, 0, value, Fit.SubfieldIndexMainField);
+			}
+		}
+
+		///<summary>
+		/// Retrieves the TotalHemoglobinConc field
+		/// Units: g/dL
+		/// Comment: Total saturated and unsaturated hemoglobin</summary>
+		/// <returns>Returns nullable float representing the TotalHemoglobinConc field</returns>
+		public float? TotalHemoglobinConc
+		{
+			get
+			{
+				Object val = GetFieldValue(54, 0, Fit.SubfieldIndexMainField);
+				if (val == null)
+				{
+					return null;
+				}
+
+				return (Convert.ToSingle(val));
+
+			}
+			set
+			{
+				SetFieldValue(54, 0, value, Fit.SubfieldIndexMainField);
+			}
+		}
+
+		///<summary>
+		/// Retrieves the TotalHemoglobinConcMin field
+		/// Units: g/dL
+		/// Comment: Min saturated and unsaturated hemoglobin</summary>
+		/// <returns>Returns nullable float representing the TotalHemoglobinConcMin field</returns>
+		public float? TotalHemoglobinConcMin
+		{
+			get
+			{
+				Object val = GetFieldValue(55, 0, Fit.SubfieldIndexMainField);
+				if (val == null)
+				{
+					return null;
+				}
+
+				return (Convert.ToSingle(val));
+
+			}
+			set
+			{
+				SetFieldValue(55, 0, value, Fit.SubfieldIndexMainField);
+			}
+		}
+
+		///<summary>
+		/// Retrieves the TotalHemoglobinConcMax field
+		/// Units: g/dL
+		/// Comment: Max saturated and unsaturated hemoglobin</summary>
+		/// <returns>Returns nullable float representing the TotalHemoglobinConcMax field</returns>
+		public float? TotalHemoglobinConcMax
+		{
+			get
+			{
+				Object val = GetFieldValue(56, 0, Fit.SubfieldIndexMainField);
+				if (val == null)
+				{
+					return null;
+				}
+
+				return (Convert.ToSingle(val));
+
+			}
+			set
+			{
+				SetFieldValue(56, 0, value, Fit.SubfieldIndexMainField);
+			}
+		}
+
+		///<summary>
+		/// Retrieves the SaturatedHemoglobinPercent field
+		/// Units: %
+		/// Comment: Percentage of hemoglobin saturated with oxygen</summary>
+		/// <returns>Returns nullable float representing the SaturatedHemoglobinPercent field</returns>
+		public float? SaturatedHemoglobinPercent
+		{
+			get
+			{
+				Object val = GetFieldValue(57, 0, Fit.SubfieldIndexMainField);
+				if (val == null)
+				{
+					return null;
+				}
+
+				return (Convert.ToSingle(val));
+
+			}
+			set
+			{
+				SetFieldValue(57, 0, value, Fit.SubfieldIndexMainField);
+			}
+		}
+
+		///<summary>
+		/// Retrieves the SaturatedHemoglobinPercentMin field
+		/// Units: %
+		/// Comment: Min percentage of hemoglobin saturated with oxygen</summary>
+		/// <returns>Returns nullable float representing the SaturatedHemoglobinPercentMin field</returns>
+		public float? SaturatedHemoglobinPercentMin
+		{
+			get
+			{
+				Object val = GetFieldValue(58, 0, Fit.SubfieldIndexMainField);
+				if (val == null)
+				{
+					return null;
+				}
+
+				return (Convert.ToSingle(val));
+
+			}
+			set
+			{
+				SetFieldValue(58, 0, value, Fit.SubfieldIndexMainField);
+			}
+		}
+
+		///<summary>
+		/// Retrieves the SaturatedHemoglobinPercentMax field
+		/// Units: %
+		/// Comment: Max percentage of hemoglobin saturated with oxygen</summary>
+		/// <returns>Returns nullable float representing the SaturatedHemoglobinPercentMax field</returns>
+		public float? SaturatedHemoglobinPercentMax
+		{
+			get
+			{
+				Object val = GetFieldValue(59, 0, Fit.SubfieldIndexMainField);
+				if (val == null)
+				{
+					return null;
+				}
+
+				return (Convert.ToSingle(val));
+
+			}
+			set
+			{
+				SetFieldValue(59, 0, value, Fit.SubfieldIndexMainField);
+			}
+		}
+
+		///<summary>
+		/// Retrieves the DeviceIndex field</summary>
+		/// <returns>Returns nullable byte representing the DeviceIndex field</returns>
+		public byte? DeviceIndex
+		{
+			get
+			{
+				Object val = GetFieldValue(62, 0, Fit.SubfieldIndexMainField);
+				if (val == null)
+				{
+					return null;
+				}
+
+				return (Convert.ToByte(val));
+
+			}
+			set
+			{
+				SetFieldValue(62, 0, value, Fit.SubfieldIndexMainField);
+			}
+		}
+
+		///<summary>
+		/// Retrieves the LeftPco field
+		/// Units: mm
+		/// Comment: Left platform center offset</summary>
+		/// <returns>Returns nullable sbyte representing the LeftPco field</returns>
+		public sbyte? LeftPco
+		{
+			get
+			{
+				Object val = GetFieldValue(67, 0, Fit.SubfieldIndexMainField);
+				if (val == null)
+				{
+					return null;
+				}
+
+				return (Convert.ToSByte(val));
+
+			}
+			set
+			{
+				SetFieldValue(67, 0, value, Fit.SubfieldIndexMainField);
+			}
+		}
+
+		///<summary>
+		/// Retrieves the RightPco field
+		/// Units: mm
+		/// Comment: Right platform center offset</summary>
+		/// <returns>Returns nullable sbyte representing the RightPco field</returns>
+		public sbyte? RightPco
+		{
+			get
+			{
+				Object val = GetFieldValue(68, 0, Fit.SubfieldIndexMainField);
+				if (val == null)
+				{
+					return null;
+				}
+
+				return (Convert.ToSByte(val));
+
+			}
+			set
+			{
+				SetFieldValue(68, 0, value, Fit.SubfieldIndexMainField);
+			}
+		}
+
+
+		/// <summary>
+		///
+		/// </summary>
+		/// <returns>returns number of elements in field LeftPowerPhase</returns>
+		public int GetNumLeftPowerPhase()
+		{
+			return GetNumFieldValues(69, Fit.SubfieldIndexMainField);
+		}
+
+		///<summary>
+		/// Retrieves the LeftPowerPhase field
+		/// Units: degrees
+		/// Comment: Left power phase angles. Data value indexes defined by power_phase_type.</summary>
+		/// <param name="index">0 based index of LeftPowerPhase element to retrieve</param>
+		/// <returns>Returns nullable float representing the LeftPowerPhase field</returns>
+		public float? GetLeftPowerPhase(int index)
+		{
+			Object val = GetFieldValue(69, index, Fit.SubfieldIndexMainField);
+			if (val == null)
+			{
+				return null;
+			}
+
+			return (Convert.ToSingle(val));
+
+		}
+
+		/// <summary>
+		/// Set LeftPowerPhase field
+		/// Units: degrees
+		/// Comment: Left power phase angles. Data value indexes defined by power_phase_type.</summary>
+		/// <param name="index">0 based index of left_power_phase</param>
+		/// <param name="leftPowerPhase_">Nullable field value to be set</param>
+		public void SetLeftPowerPhase(int index, float? leftPowerPhase_)
+		{
+			SetFieldValue(69, index, leftPowerPhase_, Fit.SubfieldIndexMainField);
+		}
+
+
+		/// <summary>
+		///
+		/// </summary>
+		/// <returns>returns number of elements in field LeftPowerPhasePeak</returns>
+		public int GetNumLeftPowerPhasePeak()
+		{
+			return GetNumFieldValues(70, Fit.SubfieldIndexMainField);
+		}
+
+		///<summary>
+		/// Retrieves the LeftPowerPhasePeak field
+		/// Units: degrees
+		/// Comment: Left power phase peak angles. Data value indexes defined by power_phase_type.</summary>
+		/// <param name="index">0 based index of LeftPowerPhasePeak element to retrieve</param>
+		/// <returns>Returns nullable float representing the LeftPowerPhasePeak field</returns>
+		public float? GetLeftPowerPhasePeak(int index)
+		{
+			Object val = GetFieldValue(70, index, Fit.SubfieldIndexMainField);
+			if (val == null)
+			{
+				return null;
+			}
+
+			return (Convert.ToSingle(val));
+
+		}
+
+		/// <summary>
+		/// Set LeftPowerPhasePeak field
+		/// Units: degrees
+		/// Comment: Left power phase peak angles. Data value indexes defined by power_phase_type.</summary>
+		/// <param name="index">0 based index of left_power_phase_peak</param>
+		/// <param name="leftPowerPhasePeak_">Nullable field value to be set</param>
+		public void SetLeftPowerPhasePeak(int index, float? leftPowerPhasePeak_)
+		{
+			SetFieldValue(70, index, leftPowerPhasePeak_, Fit.SubfieldIndexMainField);
+		}
+
+
+		/// <summary>
+		///
+		/// </summary>
+		/// <returns>returns number of elements in field RightPowerPhase</returns>
+		public int GetNumRightPowerPhase()
+		{
+			return GetNumFieldValues(71, Fit.SubfieldIndexMainField);
+		}
+
+		///<summary>
+		/// Retrieves the RightPowerPhase field
+		/// Units: degrees
+		/// Comment: Right power phase angles. Data value indexes defined by power_phase_type.</summary>
+		/// <param name="index">0 based index of RightPowerPhase element to retrieve</param>
+		/// <returns>Returns nullable float representing the RightPowerPhase field</returns>
+		public float? GetRightPowerPhase(int index)
+		{
+			Object val = GetFieldValue(71, index, Fit.SubfieldIndexMainField);
+			if (val == null)
+			{
+				return null;
+			}
+
+			return (Convert.ToSingle(val));
+
+		}
+
+		/// <summary>
+		/// Set RightPowerPhase field
+		/// Units: degrees
+		/// Comment: Right power phase angles. Data value indexes defined by power_phase_type.</summary>
+		/// <param name="index">0 based index of right_power_phase</param>
+		/// <param name="rightPowerPhase_">Nullable field value to be set</param>
+		public void SetRightPowerPhase(int index, float? rightPowerPhase_)
+		{
+			SetFieldValue(71, index, rightPowerPhase_, Fit.SubfieldIndexMainField);
+		}
+
+
+		/// <summary>
+		///
+		/// </summary>
+		/// <returns>returns number of elements in field RightPowerPhasePeak</returns>
+		public int GetNumRightPowerPhasePeak()
+		{
+			return GetNumFieldValues(72, Fit.SubfieldIndexMainField);
+		}
+
+		///<summary>
+		/// Retrieves the RightPowerPhasePeak field
+		/// Units: degrees
+		/// Comment: Right power phase peak angles. Data value indexes defined by power_phase_type.</summary>
+		/// <param name="index">0 based index of RightPowerPhasePeak element to retrieve</param>
+		/// <returns>Returns nullable float representing the RightPowerPhasePeak field</returns>
+		public float? GetRightPowerPhasePeak(int index)
+		{
+			Object val = GetFieldValue(72, index, Fit.SubfieldIndexMainField);
+			if (val == null)
+			{
+				return null;
+			}
+
+			return (Convert.ToSingle(val));
+
+		}
+
+		/// <summary>
+		/// Set RightPowerPhasePeak field
+		/// Units: degrees
+		/// Comment: Right power phase peak angles. Data value indexes defined by power_phase_type.</summary>
+		/// <param name="index">0 based index of right_power_phase_peak</param>
+		/// <param name="rightPowerPhasePeak_">Nullable field value to be set</param>
+		public void SetRightPowerPhasePeak(int index, float? rightPowerPhasePeak_)
+		{
+			SetFieldValue(72, index, rightPowerPhasePeak_, Fit.SubfieldIndexMainField);
+		}
+
+		///<summary>
+		/// Retrieves the EnhancedSpeed field
+		/// Units: m/s</summary>
+		/// <returns>Returns nullable float representing the EnhancedSpeed field</returns>
+		public float? EnhancedSpeed
+		{
+			get
+			{
+				Object val = GetFieldValue(73, 0, Fit.SubfieldIndexMainField);
+				if (val == null)
+				{
+					return null;
+				}
+
+				return (Convert.ToSingle(val));
+
+			}
+			set
+			{
+				SetFieldValue(73, 0, value, Fit.SubfieldIndexMainField);
+			}
+		}
+
+		///<summary>
+		/// Retrieves the EnhancedAltitude field
+		/// Units: m</summary>
+		/// <returns>Returns nullable float representing the EnhancedAltitude field</returns>
+		public float? EnhancedAltitude
+		{
+			get
+			{
+				Object val = GetFieldValue(78, 0, Fit.SubfieldIndexMainField);
+				if (val == null)
+				{
+					return null;
+				}
+
+				return (Convert.ToSingle(val));
+
+			}
+			set
+			{
+				SetFieldValue(78, 0, value, Fit.SubfieldIndexMainField);
+			}
+		}
+
+		///<summary>
+		/// Retrieves the BatterySoc field
+		/// Units: percent
+		/// Comment: lev battery state of charge</summary>
+		/// <returns>Returns nullable float representing the BatterySoc field</returns>
+		public float? BatterySoc
+		{
+			get
+			{
+				Object val = GetFieldValue(81, 0, Fit.SubfieldIndexMainField);
+				if (val == null)
+				{
+					return null;
+				}
+
+				return (Convert.ToSingle(val));
+
+			}
+			set
+			{
+				SetFieldValue(81, 0, value, Fit.SubfieldIndexMainField);
+			}
+		}
+
+		///<summary>
+		/// Retrieves the MotorPower field
+		/// Units: watts
+		/// Comment: lev motor power</summary>
+		/// <returns>Returns nullable ushort representing the MotorPower field</returns>
+		public ushort? MotorPower
+		{
+			get
+			{
+				Object val = GetFieldValue(82, 0, Fit.SubfieldIndexMainField);
+				if (val == null)
+				{
+					return null;
+				}
+
+				return (Convert.ToUInt16(val));
+
+			}
+			set
+			{
+				SetFieldValue(82, 0, value, Fit.SubfieldIndexMainField);
+			}
+		}
+
+		///<summary>
+		/// Retrieves the VerticalRatio field
+		/// Units: percent</summary>
+		/// <returns>Returns nullable float representing the VerticalRatio field</returns>
+		public float? VerticalRatio
+		{
+			get
+			{
+				Object val = GetFieldValue(83, 0, Fit.SubfieldIndexMainField);
+				if (val == null)
+				{
+					return null;
+				}
+
+				return (Convert.ToSingle(val));
+
+			}
+			set
+			{
+				SetFieldValue(83, 0, value, Fit.SubfieldIndexMainField);
+			}
+		}
+
+		///<summary>
+		/// Retrieves the StanceTimeBalance field
+		/// Units: percent</summary>
+		/// <returns>Returns nullable float representing the StanceTimeBalance field</returns>
+		public float? StanceTimeBalance
+		{
+			get
+			{
+				Object val = GetFieldValue(84, 0, Fit.SubfieldIndexMainField);
+				if (val == null)
+				{
+					return null;
+				}
+
+				return (Convert.ToSingle(val));
+
+			}
+			set
+			{
+				SetFieldValue(84, 0, value, Fit.SubfieldIndexMainField);
+			}
+		}
+
+		///<summary>
+		/// Retrieves the StepLength field
+		/// Units: mm</summary>
+		/// <returns>Returns nullable float representing the StepLength field</returns>
+		public float? StepLength
+		{
+			get
+			{
+				Object val = GetFieldValue(85, 0, Fit.SubfieldIndexMainField);
+				if (val == null)
+				{
+					return null;
+				}
+
+				return (Convert.ToSingle(val));
+
+			}
+			set
+			{
+				SetFieldValue(85, 0, value, Fit.SubfieldIndexMainField);
+			}
+		}
+
+		///<summary>
+		/// Retrieves the CycleLength16 field
+		/// Units: m
+		/// Comment: Supports larger cycle sizes needed for paddlesports. Max cycle size: 655.35</summary>
+		/// <returns>Returns nullable float representing the CycleLength16 field</returns>
+		public float? CycleLength16
+		{
+			get
+			{
+				Object val = GetFieldValue(87, 0, Fit.SubfieldIndexMainField);
+				if (val == null)
+				{
+					return null;
+				}
+
+				return (Convert.ToSingle(val));
+
+			}
+			set
+			{
+				SetFieldValue(87, 0, value, Fit.SubfieldIndexMainField);
+			}
+		}
+
+		///<summary>
+		/// Retrieves the AbsolutePressure field
+		/// Units: Pa
+		/// Comment: Includes atmospheric pressure</summary>
+		/// <returns>Returns nullable uint representing the AbsolutePressure field</returns>
+		public uint? AbsolutePressure
+		{
+			get
+			{
+				Object val = GetFieldValue(91, 0, Fit.SubfieldIndexMainField);
+				if (val == null)
+				{
+					return null;
+				}
+
+				return (Convert.ToUInt32(val));
+
+			}
+			set
+			{
+				SetFieldValue(91, 0, value, Fit.SubfieldIndexMainField);
+			}
+		}
+
+		///<summary>
+		/// Retrieves the Depth field
+		/// Units: m
+		/// Comment: 0 if above water</summary>
+		/// <returns>Returns nullable float representing the Depth field</returns>
+		public float? Depth
+		{
+			get
+			{
+				Object val = GetFieldValue(92, 0, Fit.SubfieldIndexMainField);
+				if (val == null)
+				{
+					return null;
+				}
+
+				return (Convert.ToSingle(val));
+
+			}
+			set
+			{
+				SetFieldValue(92, 0, value, Fit.SubfieldIndexMainField);
+			}
+		}
+
+		///<summary>
+		/// Retrieves the NextStopDepth field
+		/// Units: m
+		/// Comment: 0 if above water</summary>
+		/// <returns>Returns nullable float representing the NextStopDepth field</returns>
+		public float? NextStopDepth
+		{
+			get
+			{
+				Object val = GetFieldValue(93, 0, Fit.SubfieldIndexMainField);
+				if (val == null)
+				{
+					return null;
+				}
+
+				return (Convert.ToSingle(val));
+
+			}
+			set
+			{
+				SetFieldValue(93, 0, value, Fit.SubfieldIndexMainField);
+			}
+		}
+
+		///<summary>
+		/// Retrieves the NextStopTime field
+		/// Units: s</summary>
+		/// <returns>Returns nullable uint representing the NextStopTime field</returns>
+		public uint? NextStopTime
+		{
+			get
+			{
+				Object val = GetFieldValue(94, 0, Fit.SubfieldIndexMainField);
+				if (val == null)
+				{
+					return null;
+				}
+
+				return (Convert.ToUInt32(val));
+
+			}
+			set
+			{
+				SetFieldValue(94, 0, value, Fit.SubfieldIndexMainField);
+			}
+		}
+
+		///<summary>
+		/// Retrieves the TimeToSurface field
+		/// Units: s</summary>
+		/// <returns>Returns nullable uint representing the TimeToSurface field</returns>
+		public uint? TimeToSurface
+		{
+			get
+			{
+				Object val = GetFieldValue(95, 0, Fit.SubfieldIndexMainField);
+				if (val == null)
+				{
+					return null;
+				}
+
+				return (Convert.ToUInt32(val));
+
+			}
+			set
+			{
+				SetFieldValue(95, 0, value, Fit.SubfieldIndexMainField);
+			}
+		}
+
+		///<summary>
+		/// Retrieves the NdlTime field
+		/// Units: s</summary>
+		/// <returns>Returns nullable uint representing the NdlTime field</returns>
+		public uint? NdlTime
+		{
+			get
+			{
+				Object val = GetFieldValue(96, 0, Fit.SubfieldIndexMainField);
+				if (val == null)
+				{
+					return null;
+				}
+
+				return (Convert.ToUInt32(val));
+
+			}
+			set
+			{
+				SetFieldValue(96, 0, value, Fit.SubfieldIndexMainField);
+			}
+		}
+
+		///<summary>
+		/// Retrieves the CnsLoad field
+		/// Units: percent</summary>
+		/// <returns>Returns nullable byte representing the CnsLoad field</returns>
+		public byte? CnsLoad
+		{
+			get
+			{
+				Object val = GetFieldValue(97, 0, Fit.SubfieldIndexMainField);
+				if (val == null)
+				{
+					return null;
+				}
+
+				return (Convert.ToByte(val));
+
+			}
+			set
+			{
+				SetFieldValue(97, 0, value, Fit.SubfieldIndexMainField);
+			}
+		}
+
+		///<summary>
+		/// Retrieves the N2Load field
+		/// Units: percent</summary>
+		/// <returns>Returns nullable ushort representing the N2Load field</returns>
+		public ushort? N2Load
+		{
+			get
+			{
+				Object val = GetFieldValue(98, 0, Fit.SubfieldIndexMainField);
+				if (val == null)
+				{
+					return null;
+				}
+
+				return (Convert.ToUInt16(val));
+
+			}
+			set
+			{
+				SetFieldValue(98, 0, value, Fit.SubfieldIndexMainField);
+			}
+		}
+
+		///<summary>
+		/// Retrieves the RespirationRate field
+		/// Units: s</summary>
+		/// <returns>Returns nullable byte representing the RespirationRate field</returns>
+		public byte? RespirationRate
+		{
+			get
+			{
+				Object val = GetFieldValue(99, 0, Fit.SubfieldIndexMainField);
+				if (val == null)
+				{
+					return null;
+				}
+
+				return (Convert.ToByte(val));
+
+			}
+			set
+			{
+				SetFieldValue(99, 0, value, Fit.SubfieldIndexMainField);
+			}
+		}
+
+		///<summary>
+		/// Retrieves the EnhancedRespirationRate field
+		/// Units: Breaths/min</summary>
+		/// <returns>Returns nullable float representing the EnhancedRespirationRate field</returns>
+		public float? EnhancedRespirationRate
+		{
+			get
+			{
+				Object val = GetFieldValue(108, 0, Fit.SubfieldIndexMainField);
+				if (val == null)
+				{
+					return null;
+				}
+
+				return (Convert.ToSingle(val));
+
+			}
+			set
+			{
+				SetFieldValue(108, 0, value, Fit.SubfieldIndexMainField);
+			}
+		}
+
+		///<summary>
+		/// Retrieves the Grit field
+		/// Comment: The grit score estimates how challenging a route could be for a cyclist in terms of time spent going over sharp turns or large grade slopes.</summary>
+		/// <returns>Returns nullable float representing the Grit field</returns>
+		public float? Grit
+		{
+			get
+			{
+				Object val = GetFieldValue(114, 0, Fit.SubfieldIndexMainField);
+				if (val == null)
+				{
+					return null;
+				}
+
+				return (Convert.ToSingle(val));
+
+			}
+			set
+			{
+				SetFieldValue(114, 0, value, Fit.SubfieldIndexMainField);
+			}
+		}
+
+		///<summary>
+		/// Retrieves the Flow field
+		/// Comment: The flow score estimates how long distance wise a cyclist deaccelerates over intervals where deacceleration is unnecessary such as smooth turns or small grade angle intervals.</summary>
+		/// <returns>Returns nullable float representing the Flow field</returns>
+		public float? Flow
+		{
+			get
+			{
+				Object val = GetFieldValue(115, 0, Fit.SubfieldIndexMainField);
+				if (val == null)
+				{
+					return null;
+				}
+
+				return (Convert.ToSingle(val));
+
+			}
+			set
+			{
+				SetFieldValue(115, 0, value, Fit.SubfieldIndexMainField);
+			}
+		}
+
+		///<summary>
+		/// Retrieves the CurrentStress field
+		/// Comment: Current Stress value</summary>
+		/// <returns>Returns nullable float representing the CurrentStress field</returns>
+		public float? CurrentStress
+		{
+			get
+			{
+				Object val = GetFieldValue(116, 0, Fit.SubfieldIndexMainField);
+				if (val == null)
+				{
+					return null;
+				}
+
+				return (Convert.ToSingle(val));
+
+			}
+			set
+			{
+				SetFieldValue(116, 0, value, Fit.SubfieldIndexMainField);
+			}
+		}
+
+		///<summary>
+		/// Retrieves the EbikeTravelRange field
+		/// Units: km</summary>
+		/// <returns>Returns nullable ushort representing the EbikeTravelRange field</returns>
+		public ushort? EbikeTravelRange
+		{
+			get
+			{
+				Object val = GetFieldValue(117, 0, Fit.SubfieldIndexMainField);
+				if (val == null)
+				{
+					return null;
+				}
+
+				return (Convert.ToUInt16(val));
+
+			}
+			set
+			{
+				SetFieldValue(117, 0, value, Fit.SubfieldIndexMainField);
+			}
+		}
+
+		///<summary>
+		/// Retrieves the EbikeBatteryLevel field
+		/// Units: percent</summary>
+		/// <returns>Returns nullable byte representing the EbikeBatteryLevel field</returns>
+		public byte? EbikeBatteryLevel
+		{
+			get
+			{
+				Object val = GetFieldValue(118, 0, Fit.SubfieldIndexMainField);
+				if (val == null)
+				{
+					return null;
+				}
+
+				return (Convert.ToByte(val));
+
+			}
+			set
+			{
+				SetFieldValue(118, 0, value, Fit.SubfieldIndexMainField);
+			}
+		}
+
+		///<summary>
+		/// Retrieves the EbikeAssistMode field
+		/// Units: depends on sensor</summary>
+		/// <returns>Returns nullable byte representing the EbikeAssistMode field</returns>
+		public byte? EbikeAssistMode
+		{
+			get
+			{
+				Object val = GetFieldValue(119, 0, Fit.SubfieldIndexMainField);
+				if (val == null)
+				{
+					return null;
+				}
+
+				return (Convert.ToByte(val));
+
+			}
+			set
+			{
+				SetFieldValue(119, 0, value, Fit.SubfieldIndexMainField);
+			}
+		}
+
+		///<summary>
+		/// Retrieves the EbikeAssistLevelPercent field
+		/// Units: percent</summary>
+		/// <returns>Returns nullable byte representing the EbikeAssistLevelPercent field</returns>
+		public byte? EbikeAssistLevelPercent
+		{
+			get
+			{
+				Object val = GetFieldValue(120, 0, Fit.SubfieldIndexMainField);
+				if (val == null)
+				{
+					return null;
+				}
+
+				return (Convert.ToByte(val));
+
+			}
+			set
+			{
+				SetFieldValue(120, 0, value, Fit.SubfieldIndexMainField);
+			}
+		}
+
+		///<summary>
+		/// Retrieves the AirTimeRemaining field
+		/// Units: s</summary>
+		/// <returns>Returns nullable uint representing the AirTimeRemaining field</returns>
+		public uint? AirTimeRemaining
+		{
+			get
+			{
+				Object val = GetFieldValue(123, 0, Fit.SubfieldIndexMainField);
+				if (val == null)
+				{
+					return null;
+				}
+
+				return (Convert.ToUInt32(val));
+
+			}
+			set
+			{
+				SetFieldValue(123, 0, value, Fit.SubfieldIndexMainField);
+			}
+		}
+
+		///<summary>
+		/// Retrieves the PressureSac field
+		/// Units: bar/min
+		/// Comment: Pressure-based surface air consumption</summary>
+		/// <returns>Returns nullable float representing the PressureSac field</returns>
+		public float? PressureSac
+		{
+			get
+			{
+				Object val = GetFieldValue(124, 0, Fit.SubfieldIndexMainField);
+				if (val == null)
+				{
+					return null;
+				}
+
+				return (Convert.ToSingle(val));
+
+			}
+			set
+			{
+				SetFieldValue(124, 0, value, Fit.SubfieldIndexMainField);
+			}
+		}
+
+		///<summary>
+		/// Retrieves the VolumeSac field
+		/// Units: L/min
+		/// Comment: Volumetric surface air consumption</summary>
+		/// <returns>Returns nullable float representing the VolumeSac field</returns>
+		public float? VolumeSac
+		{
+			get
+			{
+				Object val = GetFieldValue(125, 0, Fit.SubfieldIndexMainField);
+				if (val == null)
+				{
+					return null;
+				}
+
+				return (Convert.ToSingle(val));
+
+			}
+			set
+			{
+				SetFieldValue(125, 0, value, Fit.SubfieldIndexMainField);
+			}
+		}
+
+		///<summary>
+		/// Retrieves the Rmv field
+		/// Units: L/min
+		/// Comment: Respiratory minute volume</summary>
+		/// <returns>Returns nullable float representing the Rmv field</returns>
+		public float? Rmv
+		{
+			get
+			{
+				Object val = GetFieldValue(126, 0, Fit.SubfieldIndexMainField);
+				if (val == null)
+				{
+					return null;
+				}
+
+				return (Convert.ToSingle(val));
+
+			}
+			set
+			{
+				SetFieldValue(126, 0, value, Fit.SubfieldIndexMainField);
+			}
+		}
+
+		///<summary>
+		/// Retrieves the AscentRate field
+		/// Units: m/s</summary>
+		/// <returns>Returns nullable float representing the AscentRate field</returns>
+		public float? AscentRate
+		{
+			get
+			{
+				Object val = GetFieldValue(127, 0, Fit.SubfieldIndexMainField);
+				if (val == null)
+				{
+					return null;
+				}
+
+				return (Convert.ToSingle(val));
+
+			}
+			set
+			{
+				SetFieldValue(127, 0, value, Fit.SubfieldIndexMainField);
+			}
+		}
+
+		///<summary>
+		/// Retrieves the Po2 field
+		/// Units: percent
+		/// Comment: Current partial pressure of oxygen</summary>
+		/// <returns>Returns nullable float representing the Po2 field</returns>
+		public float? Po2
+		{
+			get
+			{
+				Object val = GetFieldValue(129, 0, Fit.SubfieldIndexMainField);
+				if (val == null)
+				{
+					return null;
+				}
+
+				return (Convert.ToSingle(val));
+
+			}
+			set
+			{
+				SetFieldValue(129, 0, value, Fit.SubfieldIndexMainField);
+			}
+		}
+
+		///<summary>
+		/// Retrieves the CoreTemperature field
+		/// Units: C</summary>
+		/// <returns>Returns nullable float representing the CoreTemperature field</returns>
+		public float? CoreTemperature
+		{
+			get
+			{
+				Object val = GetFieldValue(139, 0, Fit.SubfieldIndexMainField);
+				if (val == null)
+				{
+					return null;
+				}
+
+				return (Convert.ToSingle(val));
+
+			}
+			set
+			{
+				SetFieldValue(139, 0, value, Fit.SubfieldIndexMainField);
+			}
+		}
+
+		#endregion // Methods
+	} // Class
 } // namespace

--- a/Dynastream/Fit/Profile/Mesgs/RespirationRateMesg.cs
+++ b/Dynastream/Fit/Profile/Mesgs/RespirationRateMesg.cs
@@ -21,85 +21,81 @@ using System.Linq;
 
 namespace Dynastream.Fit
 {
-    /// <summary>
-    /// Implements the RespirationRate profile message.
-    /// </summary>
-    public class RespirationRateMesg : Mesg
-    {
-        #region Fields
-        #endregion
+	/// <summary>
+	/// Implements the RespirationRate profile message.
+	/// </summary>
+	public class RespirationRateMesg : Mesg
+	{
+		#region Fields
+		#endregion
 
-        /// <summary>
-        /// Field Numbers for <see cref="RespirationRateMesg"/>
-        /// </summary>
-        public sealed class FieldDefNum
-        {
-            public const byte Timestamp = 253;
-            public const byte RespirationRate = 0;
-            public const byte Invalid = Fit.FieldNumInvalid;
-        }
+		/// <summary>
+		/// Field Numbers for <see cref="RespirationRateMesg"/>
+		/// </summary>
+		public sealed class FieldDefNum
+		{
+			public const byte Timestamp = 253;
+			public const byte RespirationRate = 0;
+			public const byte Invalid = Fit.FieldNumInvalid;
+		}
 
-        #region Constructors
-        public RespirationRateMesg() : base(Profile.GetMesg(MesgNum.RespirationRate))
-        {
-        }
+		#region Constructors
+		public RespirationRateMesg() : base(Profile.GetMesg(MesgNum.RespirationRate))
+		{
+		}
 
-        public RespirationRateMesg(Mesg mesg) : base(mesg)
-        {
-        }
-        #endregion // Constructors
+		public RespirationRateMesg(Mesg mesg) : base(mesg)
+		{
+		}
+		#endregion // Constructors
 
-        #region Methods
-        ///<summary>
-        /// Retrieves the Timestamp field</summary>
-        /// <returns>Returns DateTime representing the Timestamp field</returns>
-        public DateTime GetTimestamp()
-        {
-            Object val = GetFieldValue(253, 0, Fit.SubfieldIndexMainField);
-            if(val == null)
-            {
-                return null;
-            }
+		#region Methods
+		///<summary>
+		/// Retrieves the Timestamp field</summary>
+		/// <returns>Returns DateTime representing the Timestamp field</returns>
+		public DateTime Timestamp
+		{
+			get
+			{
+				Object val = GetFieldValue(253, 0, Fit.SubfieldIndexMainField);
+				if (val == null)
+				{
+					return null;
+				}
 
-            return TimestampToDateTime(Convert.ToUInt32(val));
-            
-        }
+				return TimestampToDateTime(Convert.ToUInt32(val));
 
-        /// <summary>
-        /// Set Timestamp field</summary>
-        /// <param name="timestamp_">Nullable field value to be set</param>
-        public void SetTimestamp(DateTime timestamp_)
-        {
-            SetFieldValue(253, 0, timestamp_.GetTimeStamp(), Fit.SubfieldIndexMainField);
-        }
-        
-        ///<summary>
-        /// Retrieves the RespirationRate field
-        /// Units: breaths/min
-        /// Comment: Breaths * 100 /min, -300 indicates invalid, -200 indicates large motion, -100 indicates off wrist</summary>
-        /// <returns>Returns nullable float representing the RespirationRate field</returns>
-        public float? GetRespirationRate()
-        {
-            Object val = GetFieldValue(0, 0, Fit.SubfieldIndexMainField);
-            if(val == null)
-            {
-                return null;
-            }
+			}
+			set
+			{
+				SetFieldValue(253, 0, value.GetTimeStamp(), Fit.SubfieldIndexMainField);
+			}
+		}
 
-            return (Convert.ToSingle(val));
-            
-        }
+		///<summary>
+		/// Retrieves the RespirationRate field
+		/// Units: breaths/min
+		/// Comment: Breaths * 100 /min, -300 indicates invalid, -200 indicates large motion, -100 indicates off wrist</summary>
+		/// <returns>Returns nullable float representing the RespirationRate field</returns>
+		public float? RespirationRate
+		{
+			get
+			{
+				Object val = GetFieldValue(0, 0, Fit.SubfieldIndexMainField);
+				if (val == null)
+				{
+					return null;
+				}
 
-        /// <summary>
-        /// Set RespirationRate field
-        /// Units: breaths/min
-        /// Comment: Breaths * 100 /min, -300 indicates invalid, -200 indicates large motion, -100 indicates off wrist</summary>
-        /// <param name="respirationRate_">Nullable field value to be set</param>
-        public void SetRespirationRate(float? respirationRate_)
-        {
-            SetFieldValue(0, 0, respirationRate_, Fit.SubfieldIndexMainField);
-        }
-        
-        #endregion // Methods
-    } // Class
+				return (Convert.ToSingle(val));
+
+			}
+			set
+			{
+				SetFieldValue(0, 0, value, Fit.SubfieldIndexMainField);
+			}
+		}
+
+		#endregion // Methods
+	} // Class
 } // namespace

--- a/Dynastream/Fit/Profile/Mesgs/ScheduleMesg.cs
+++ b/Dynastream/Fit/Profile/Mesgs/ScheduleMesg.cs
@@ -21,257 +21,241 @@ using System.Linq;
 
 namespace Dynastream.Fit
 {
-    /// <summary>
-    /// Implements the Schedule profile message.
-    /// </summary>
-    public class ScheduleMesg : Mesg
-    {
-        #region Fields
-        static class ProductSubfield
-        {
-            public static ushort FaveroProduct = 0;
-            public static ushort GarminProduct = 1;
-            public static ushort Subfields = 2;
-            public static ushort Active = Fit.SubfieldIndexActiveSubfield;
-            public static ushort MainField = Fit.SubfieldIndexMainField;
-        }
-        #endregion
+	/// <summary>
+	/// Implements the Schedule profile message.
+	/// </summary>
+	public class ScheduleMesg : Mesg
+	{
+		#region Fields
+		static class ProductSubfield
+		{
+			public static ushort FaveroProduct = 0;
+			public static ushort GarminProduct = 1;
+			public static ushort Subfields = 2;
+			public static ushort Active = Fit.SubfieldIndexActiveSubfield;
+			public static ushort MainField = Fit.SubfieldIndexMainField;
+		}
+		#endregion
 
-        /// <summary>
-        /// Field Numbers for <see cref="ScheduleMesg"/>
-        /// </summary>
-        public sealed class FieldDefNum
-        {
-            public const byte Manufacturer = 0;
-            public const byte Product = 1;
-            public const byte SerialNumber = 2;
-            public const byte TimeCreated = 3;
-            public const byte Completed = 4;
-            public const byte Type = 5;
-            public const byte ScheduledTime = 6;
-            public const byte Invalid = Fit.FieldNumInvalid;
-        }
+		/// <summary>
+		/// Field Numbers for <see cref="ScheduleMesg"/>
+		/// </summary>
+		public sealed class FieldDefNum
+		{
+			public const byte Manufacturer = 0;
+			public const byte Product = 1;
+			public const byte SerialNumber = 2;
+			public const byte TimeCreated = 3;
+			public const byte Completed = 4;
+			public const byte Type = 5;
+			public const byte ScheduledTime = 6;
+			public const byte Invalid = Fit.FieldNumInvalid;
+		}
 
-        #region Constructors
-        public ScheduleMesg() : base(Profile.GetMesg(MesgNum.Schedule))
-        {
-        }
+		#region Constructors
+		public ScheduleMesg() : base(Profile.GetMesg(MesgNum.Schedule))
+		{
+		}
 
-        public ScheduleMesg(Mesg mesg) : base(mesg)
-        {
-        }
-        #endregion // Constructors
+		public ScheduleMesg(Mesg mesg) : base(mesg)
+		{
+		}
+		#endregion // Constructors
 
-        #region Methods
-        ///<summary>
-        /// Retrieves the Manufacturer field
-        /// Comment: Corresponds to file_id of scheduled workout / course.</summary>
-        /// <returns>Returns nullable ushort representing the Manufacturer field</returns>
-        public ushort? GetManufacturer()
-        {
-            Object val = GetFieldValue(0, 0, Fit.SubfieldIndexMainField);
-            if(val == null)
-            {
-                return null;
-            }
+		#region Methods
+		///<summary>
+		/// Retrieves the Manufacturer field
+		/// Comment: Corresponds to file_id of scheduled workout / course.</summary>
+		/// <returns>Returns nullable ushort representing the Manufacturer field</returns>
+		public ushort? Manufacturer
+		{
+			get
+			{
+				Object val = GetFieldValue(0, 0, Fit.SubfieldIndexMainField);
+				if (val == null)
+				{
+					return null;
+				}
 
-            return (Convert.ToUInt16(val));
-            
-        }
+				return (Convert.ToUInt16(val));
 
-        /// <summary>
-        /// Set Manufacturer field
-        /// Comment: Corresponds to file_id of scheduled workout / course.</summary>
-        /// <param name="manufacturer_">Nullable field value to be set</param>
-        public void SetManufacturer(ushort? manufacturer_)
-        {
-            SetFieldValue(0, 0, manufacturer_, Fit.SubfieldIndexMainField);
-        }
-        
-        ///<summary>
-        /// Retrieves the Product field
-        /// Comment: Corresponds to file_id of scheduled workout / course.</summary>
-        /// <returns>Returns nullable ushort representing the Product field</returns>
-        public ushort? GetProduct()
-        {
-            Object val = GetFieldValue(1, 0, Fit.SubfieldIndexMainField);
-            if(val == null)
-            {
-                return null;
-            }
+			}
+			set
+			{
+				SetFieldValue(0, 0, value, Fit.SubfieldIndexMainField);
+			}
+		}
 
-            return (Convert.ToUInt16(val));
-            
-        }
+		///<summary>
+		/// Retrieves the Product field
+		/// Comment: Corresponds to file_id of scheduled workout / course.</summary>
+		/// <returns>Returns nullable ushort representing the Product field</returns>
+		public ushort? Product
+		{
+			get
+			{
+				Object val = GetFieldValue(1, 0, Fit.SubfieldIndexMainField);
+				if (val == null)
+				{
+					return null;
+				}
 
-        /// <summary>
-        /// Set Product field
-        /// Comment: Corresponds to file_id of scheduled workout / course.</summary>
-        /// <param name="product_">Nullable field value to be set</param>
-        public void SetProduct(ushort? product_)
-        {
-            SetFieldValue(1, 0, product_, Fit.SubfieldIndexMainField);
-        }
-        
+				return (Convert.ToUInt16(val));
 
-        /// <summary>
-        /// Retrieves the FaveroProduct subfield</summary>
-        /// <returns>Nullable ushort representing the FaveroProduct subfield</returns>
-        public ushort? GetFaveroProduct()
-        {
-            Object val = GetFieldValue(1, 0, ProductSubfield.FaveroProduct);
-            if(val == null)
-            {
-                return null;
-            }
+			}
+			set
+			{
+				SetFieldValue(1, 0, value, Fit.SubfieldIndexMainField);
+			}
+		}
 
-            return (Convert.ToUInt16(val));
-            
-        }
 
-        /// <summary>
-        ///
-        /// Set FaveroProduct subfield</summary>
-        /// <param name="faveroProduct">Subfield value to be set</param>
-        public void SetFaveroProduct(ushort? faveroProduct)
-        {
-            SetFieldValue(1, 0, faveroProduct, ProductSubfield.FaveroProduct);
-        }
+		/// <summary>
+		/// Retrieves the FaveroProduct subfield</summary>
+		/// <returns>Nullable ushort representing the FaveroProduct subfield</returns>
+		public ushort? FaveroProduct
+		{
+			get
+			{
+				Object val = GetFieldValue(1, 0, ProductSubfield.FaveroProduct);
+				if (val == null)
+				{
+					return null;
+				}
 
-        /// <summary>
-        /// Retrieves the GarminProduct subfield</summary>
-        /// <returns>Nullable ushort representing the GarminProduct subfield</returns>
-        public ushort? GetGarminProduct()
-        {
-            Object val = GetFieldValue(1, 0, ProductSubfield.GarminProduct);
-            if(val == null)
-            {
-                return null;
-            }
+				return (Convert.ToUInt16(val));
 
-            return (Convert.ToUInt16(val));
-            
-        }
+			}
+			set
+			{
+				SetFieldValue(1, 0, value, ProductSubfield.FaveroProduct);
+			}
+		}
 
-        /// <summary>
-        ///
-        /// Set GarminProduct subfield</summary>
-        /// <param name="garminProduct">Subfield value to be set</param>
-        public void SetGarminProduct(ushort? garminProduct)
-        {
-            SetFieldValue(1, 0, garminProduct, ProductSubfield.GarminProduct);
-        }
-        ///<summary>
-        /// Retrieves the SerialNumber field
-        /// Comment: Corresponds to file_id of scheduled workout / course.</summary>
-        /// <returns>Returns nullable uint representing the SerialNumber field</returns>
-        public uint? GetSerialNumber()
-        {
-            Object val = GetFieldValue(2, 0, Fit.SubfieldIndexMainField);
-            if(val == null)
-            {
-                return null;
-            }
+		/// <summary>
+		/// Retrieves the GarminProduct subfield</summary>
+		/// <returns>Nullable ushort representing the GarminProduct subfield</returns>
+		public ushort? GarminProduct
+		{
+			get
+			{
+				Object val = GetFieldValue(1, 0, ProductSubfield.GarminProduct);
+				if (val == null)
+				{
+					return null;
+				}
 
-            return (Convert.ToUInt32(val));
-            
-        }
+				return (Convert.ToUInt16(val));
 
-        /// <summary>
-        /// Set SerialNumber field
-        /// Comment: Corresponds to file_id of scheduled workout / course.</summary>
-        /// <param name="serialNumber_">Nullable field value to be set</param>
-        public void SetSerialNumber(uint? serialNumber_)
-        {
-            SetFieldValue(2, 0, serialNumber_, Fit.SubfieldIndexMainField);
-        }
-        
-        ///<summary>
-        /// Retrieves the TimeCreated field
-        /// Comment: Corresponds to file_id of scheduled workout / course.</summary>
-        /// <returns>Returns DateTime representing the TimeCreated field</returns>
-        public DateTime GetTimeCreated()
-        {
-            Object val = GetFieldValue(3, 0, Fit.SubfieldIndexMainField);
-            if(val == null)
-            {
-                return null;
-            }
+			}
+			set
+			{
+				SetFieldValue(1, 0, value, ProductSubfield.GarminProduct);
+			}
+		}
+		///<summary>
+		/// Retrieves the SerialNumber field
+		/// Comment: Corresponds to file_id of scheduled workout / course.</summary>
+		/// <returns>Returns nullable uint representing the SerialNumber field</returns>
+		public uint? SerialNumber
+		{
+			get
+			{
+				Object val = GetFieldValue(2, 0, Fit.SubfieldIndexMainField);
+				if (val == null)
+				{
+					return null;
+				}
 
-            return TimestampToDateTime(Convert.ToUInt32(val));
-            
-        }
+				return (Convert.ToUInt32(val));
 
-        /// <summary>
-        /// Set TimeCreated field
-        /// Comment: Corresponds to file_id of scheduled workout / course.</summary>
-        /// <param name="timeCreated_">Nullable field value to be set</param>
-        public void SetTimeCreated(DateTime timeCreated_)
-        {
-            SetFieldValue(3, 0, timeCreated_.GetTimeStamp(), Fit.SubfieldIndexMainField);
-        }
-        
-        ///<summary>
-        /// Retrieves the Completed field
-        /// Comment: TRUE if this activity has been started</summary>
-        /// <returns>Returns nullable Bool enum representing the Completed field</returns>
-        public Bool? GetCompleted()
-        {
-            object obj = GetFieldValue(4, 0, Fit.SubfieldIndexMainField);
-            Bool? value = obj == null ? (Bool?)null : (Bool)obj;
-            return value;
-        }
+			}
+			set
+			{
+				SetFieldValue(2, 0, value, Fit.SubfieldIndexMainField);
+			}
+		}
 
-        /// <summary>
-        /// Set Completed field
-        /// Comment: TRUE if this activity has been started</summary>
-        /// <param name="completed_">Nullable field value to be set</param>
-        public void SetCompleted(Bool? completed_)
-        {
-            SetFieldValue(4, 0, completed_, Fit.SubfieldIndexMainField);
-        }
-        
-        ///<summary>
-        /// Retrieves the Type field</summary>
-        /// <returns>Returns nullable Schedule enum representing the Type field</returns>
-        new public Schedule? GetType()
-        {
-            object obj = GetFieldValue(5, 0, Fit.SubfieldIndexMainField);
-            Schedule? value = obj == null ? (Schedule?)null : (Schedule)obj;
-            return value;
-        }
+		///<summary>
+		/// Retrieves the TimeCreated field
+		/// Comment: Corresponds to file_id of scheduled workout / course.</summary>
+		/// <returns>Returns DateTime representing the TimeCreated field</returns>
+		public DateTime TimeCreated
+		{
+			get
+			{
+				Object val = GetFieldValue(3, 0, Fit.SubfieldIndexMainField);
+				if (val == null)
+				{
+					return null;
+				}
 
-        /// <summary>
-        /// Set Type field</summary>
-        /// <param name="type_">Nullable field value to be set</param>
-        public void SetType(Schedule? type_)
-        {
-            SetFieldValue(5, 0, type_, Fit.SubfieldIndexMainField);
-        }
-        
-        ///<summary>
-        /// Retrieves the ScheduledTime field</summary>
-        /// <returns>Returns nullable uint representing the ScheduledTime field</returns>
-        public uint? GetScheduledTime()
-        {
-            Object val = GetFieldValue(6, 0, Fit.SubfieldIndexMainField);
-            if(val == null)
-            {
-                return null;
-            }
+				return TimestampToDateTime(Convert.ToUInt32(val));
 
-            return (Convert.ToUInt32(val));
-            
-        }
+			}
+			set
+			{
+				SetFieldValue(3, 0, value.GetTimeStamp(), Fit.SubfieldIndexMainField);
+			}
+		}
 
-        /// <summary>
-        /// Set ScheduledTime field</summary>
-        /// <param name="scheduledTime_">Nullable field value to be set</param>
-        public void SetScheduledTime(uint? scheduledTime_)
-        {
-            SetFieldValue(6, 0, scheduledTime_, Fit.SubfieldIndexMainField);
-        }
-        
-        #endregion // Methods
-    } // Class
+		///<summary>
+		/// Retrieves the Completed field
+		/// Comment: TRUE if this activity has been started</summary>
+		/// <returns>Returns nullable Bool enum representing the Completed field</returns>
+		public Bool? Completed
+		{
+			get
+			{
+				object obj = GetFieldValue(4, 0, Fit.SubfieldIndexMainField);
+				Bool? value = obj == null ? (Bool?)null : (Bool)obj;
+				return value;
+			}
+			set
+			{
+				SetFieldValue(4, 0, value, Fit.SubfieldIndexMainField);
+			}
+		}
+
+		///<summary>
+		/// Retrieves the Type field</summary>
+		/// <returns>Returns nullable Schedule enum representing the Type field</returns>
+		public Schedule? Type
+		{
+			get
+			{
+				object obj = GetFieldValue(5, 0, Fit.SubfieldIndexMainField);
+				Schedule? value = obj == null ? (Schedule?)null : (Schedule)obj;
+				return value;
+			}
+			set
+			{
+				SetFieldValue(5, 0, value, Fit.SubfieldIndexMainField);
+			}
+		}
+
+		///<summary>
+		/// Retrieves the ScheduledTime field</summary>
+		/// <returns>Returns nullable uint representing the ScheduledTime field</returns>
+		public uint? ScheduledTime
+		{
+			get
+			{
+				Object val = GetFieldValue(6, 0, Fit.SubfieldIndexMainField);
+				if (val == null)
+				{
+					return null;
+				}
+
+				return (Convert.ToUInt32(val));
+
+			}
+			set
+			{
+				SetFieldValue(6, 0, value, Fit.SubfieldIndexMainField);
+			}
+		}
+
+		#endregion // Methods
+	} // Class
 } // namespace

--- a/Dynastream/Fit/Profile/Mesgs/SdmProfileMesg.cs
+++ b/Dynastream/Fit/Profile/Mesgs/SdmProfileMesg.cs
@@ -21,223 +21,211 @@ using System.Linq;
 
 namespace Dynastream.Fit
 {
-    /// <summary>
-    /// Implements the SdmProfile profile message.
-    /// </summary>
-    public class SdmProfileMesg : Mesg
-    {
-        #region Fields
-        #endregion
+	/// <summary>
+	/// Implements the SdmProfile profile message.
+	/// </summary>
+	public class SdmProfileMesg : Mesg
+	{
+		#region Fields
+		#endregion
 
-        /// <summary>
-        /// Field Numbers for <see cref="SdmProfileMesg"/>
-        /// </summary>
-        public sealed class FieldDefNum
-        {
-            public const byte MessageIndex = 254;
-            public const byte Enabled = 0;
-            public const byte SdmAntId = 1;
-            public const byte SdmCalFactor = 2;
-            public const byte Odometer = 3;
-            public const byte SpeedSource = 4;
-            public const byte SdmAntIdTransType = 5;
-            public const byte OdometerRollover = 7;
-            public const byte Invalid = Fit.FieldNumInvalid;
-        }
+		/// <summary>
+		/// Field Numbers for <see cref="SdmProfileMesg"/>
+		/// </summary>
+		public sealed class FieldDefNum
+		{
+			public const byte MessageIndex = 254;
+			public const byte Enabled = 0;
+			public const byte SdmAntId = 1;
+			public const byte SdmCalFactor = 2;
+			public const byte Odometer = 3;
+			public const byte SpeedSource = 4;
+			public const byte SdmAntIdTransType = 5;
+			public const byte OdometerRollover = 7;
+			public const byte Invalid = Fit.FieldNumInvalid;
+		}
 
-        #region Constructors
-        public SdmProfileMesg() : base(Profile.GetMesg(MesgNum.SdmProfile))
-        {
-        }
+		#region Constructors
+		public SdmProfileMesg() : base(Profile.GetMesg(MesgNum.SdmProfile))
+		{
+		}
 
-        public SdmProfileMesg(Mesg mesg) : base(mesg)
-        {
-        }
-        #endregion // Constructors
+		public SdmProfileMesg(Mesg mesg) : base(mesg)
+		{
+		}
+		#endregion // Constructors
 
-        #region Methods
-        ///<summary>
-        /// Retrieves the MessageIndex field</summary>
-        /// <returns>Returns nullable ushort representing the MessageIndex field</returns>
-        public ushort? GetMessageIndex()
-        {
-            Object val = GetFieldValue(254, 0, Fit.SubfieldIndexMainField);
-            if(val == null)
-            {
-                return null;
-            }
+		#region Methods
+		///<summary>
+		/// Retrieves the MessageIndex field</summary>
+		/// <returns>Returns nullable ushort representing the MessageIndex field</returns>
+		public ushort? MessageIndex
+		{
+			get
+			{
+				Object val = GetFieldValue(254, 0, Fit.SubfieldIndexMainField);
+				if (val == null)
+				{
+					return null;
+				}
 
-            return (Convert.ToUInt16(val));
-            
-        }
+				return (Convert.ToUInt16(val));
 
-        /// <summary>
-        /// Set MessageIndex field</summary>
-        /// <param name="messageIndex_">Nullable field value to be set</param>
-        public void SetMessageIndex(ushort? messageIndex_)
-        {
-            SetFieldValue(254, 0, messageIndex_, Fit.SubfieldIndexMainField);
-        }
-        
-        ///<summary>
-        /// Retrieves the Enabled field</summary>
-        /// <returns>Returns nullable Bool enum representing the Enabled field</returns>
-        public Bool? GetEnabled()
-        {
-            object obj = GetFieldValue(0, 0, Fit.SubfieldIndexMainField);
-            Bool? value = obj == null ? (Bool?)null : (Bool)obj;
-            return value;
-        }
+			}
+			set
+			{
+				SetFieldValue(254, 0, value, Fit.SubfieldIndexMainField);
+			}
+		}
 
-        /// <summary>
-        /// Set Enabled field</summary>
-        /// <param name="enabled_">Nullable field value to be set</param>
-        public void SetEnabled(Bool? enabled_)
-        {
-            SetFieldValue(0, 0, enabled_, Fit.SubfieldIndexMainField);
-        }
-        
-        ///<summary>
-        /// Retrieves the SdmAntId field</summary>
-        /// <returns>Returns nullable ushort representing the SdmAntId field</returns>
-        public ushort? GetSdmAntId()
-        {
-            Object val = GetFieldValue(1, 0, Fit.SubfieldIndexMainField);
-            if(val == null)
-            {
-                return null;
-            }
+		///<summary>
+		/// Retrieves the Enabled field</summary>
+		/// <returns>Returns nullable Bool enum representing the Enabled field</returns>
+		public Bool? Enabled
+		{
+			get
+			{
+				object obj = GetFieldValue(0, 0, Fit.SubfieldIndexMainField);
+				Bool? value = obj == null ? (Bool?)null : (Bool)obj;
+				return value;
+			}
+			set
+			{
+				SetFieldValue(0, 0, value, Fit.SubfieldIndexMainField);
+			}
+		}
 
-            return (Convert.ToUInt16(val));
-            
-        }
+		///<summary>
+		/// Retrieves the SdmAntId field</summary>
+		/// <returns>Returns nullable ushort representing the SdmAntId field</returns>
+		public ushort? SdmAntId
+		{
+			get
+			{
+				Object val = GetFieldValue(1, 0, Fit.SubfieldIndexMainField);
+				if (val == null)
+				{
+					return null;
+				}
 
-        /// <summary>
-        /// Set SdmAntId field</summary>
-        /// <param name="sdmAntId_">Nullable field value to be set</param>
-        public void SetSdmAntId(ushort? sdmAntId_)
-        {
-            SetFieldValue(1, 0, sdmAntId_, Fit.SubfieldIndexMainField);
-        }
-        
-        ///<summary>
-        /// Retrieves the SdmCalFactor field
-        /// Units: %</summary>
-        /// <returns>Returns nullable float representing the SdmCalFactor field</returns>
-        public float? GetSdmCalFactor()
-        {
-            Object val = GetFieldValue(2, 0, Fit.SubfieldIndexMainField);
-            if(val == null)
-            {
-                return null;
-            }
+				return (Convert.ToUInt16(val));
 
-            return (Convert.ToSingle(val));
-            
-        }
+			}
+			set
+			{
+				SetFieldValue(1, 0, value, Fit.SubfieldIndexMainField);
+			}
+		}
 
-        /// <summary>
-        /// Set SdmCalFactor field
-        /// Units: %</summary>
-        /// <param name="sdmCalFactor_">Nullable field value to be set</param>
-        public void SetSdmCalFactor(float? sdmCalFactor_)
-        {
-            SetFieldValue(2, 0, sdmCalFactor_, Fit.SubfieldIndexMainField);
-        }
-        
-        ///<summary>
-        /// Retrieves the Odometer field
-        /// Units: m</summary>
-        /// <returns>Returns nullable float representing the Odometer field</returns>
-        public float? GetOdometer()
-        {
-            Object val = GetFieldValue(3, 0, Fit.SubfieldIndexMainField);
-            if(val == null)
-            {
-                return null;
-            }
+		///<summary>
+		/// Retrieves the SdmCalFactor field
+		/// Units: %</summary>
+		/// <returns>Returns nullable float representing the SdmCalFactor field</returns>
+		public float? SdmCalFactor
+		{
+			get
+			{
+				Object val = GetFieldValue(2, 0, Fit.SubfieldIndexMainField);
+				if (val == null)
+				{
+					return null;
+				}
 
-            return (Convert.ToSingle(val));
-            
-        }
+				return (Convert.ToSingle(val));
 
-        /// <summary>
-        /// Set Odometer field
-        /// Units: m</summary>
-        /// <param name="odometer_">Nullable field value to be set</param>
-        public void SetOdometer(float? odometer_)
-        {
-            SetFieldValue(3, 0, odometer_, Fit.SubfieldIndexMainField);
-        }
-        
-        ///<summary>
-        /// Retrieves the SpeedSource field
-        /// Comment: Use footpod for speed source instead of GPS</summary>
-        /// <returns>Returns nullable Bool enum representing the SpeedSource field</returns>
-        public Bool? GetSpeedSource()
-        {
-            object obj = GetFieldValue(4, 0, Fit.SubfieldIndexMainField);
-            Bool? value = obj == null ? (Bool?)null : (Bool)obj;
-            return value;
-        }
+			}
+			set
+			{
+				SetFieldValue(2, 0, value, Fit.SubfieldIndexMainField);
+			}
+		}
 
-        /// <summary>
-        /// Set SpeedSource field
-        /// Comment: Use footpod for speed source instead of GPS</summary>
-        /// <param name="speedSource_">Nullable field value to be set</param>
-        public void SetSpeedSource(Bool? speedSource_)
-        {
-            SetFieldValue(4, 0, speedSource_, Fit.SubfieldIndexMainField);
-        }
-        
-        ///<summary>
-        /// Retrieves the SdmAntIdTransType field</summary>
-        /// <returns>Returns nullable byte representing the SdmAntIdTransType field</returns>
-        public byte? GetSdmAntIdTransType()
-        {
-            Object val = GetFieldValue(5, 0, Fit.SubfieldIndexMainField);
-            if(val == null)
-            {
-                return null;
-            }
+		///<summary>
+		/// Retrieves the Odometer field
+		/// Units: m</summary>
+		/// <returns>Returns nullable float representing the Odometer field</returns>
+		public float? Odometer
+		{
+			get
+			{
+				Object val = GetFieldValue(3, 0, Fit.SubfieldIndexMainField);
+				if (val == null)
+				{
+					return null;
+				}
 
-            return (Convert.ToByte(val));
-            
-        }
+				return (Convert.ToSingle(val));
 
-        /// <summary>
-        /// Set SdmAntIdTransType field</summary>
-        /// <param name="sdmAntIdTransType_">Nullable field value to be set</param>
-        public void SetSdmAntIdTransType(byte? sdmAntIdTransType_)
-        {
-            SetFieldValue(5, 0, sdmAntIdTransType_, Fit.SubfieldIndexMainField);
-        }
-        
-        ///<summary>
-        /// Retrieves the OdometerRollover field
-        /// Comment: Rollover counter that can be used to extend the odometer</summary>
-        /// <returns>Returns nullable byte representing the OdometerRollover field</returns>
-        public byte? GetOdometerRollover()
-        {
-            Object val = GetFieldValue(7, 0, Fit.SubfieldIndexMainField);
-            if(val == null)
-            {
-                return null;
-            }
+			}
+			set
+			{
+				SetFieldValue(3, 0, value, Fit.SubfieldIndexMainField);
+			}
+		}
 
-            return (Convert.ToByte(val));
-            
-        }
+		///<summary>
+		/// Retrieves the SpeedSource field
+		/// Comment: Use footpod for speed source instead of GPS</summary>
+		/// <returns>Returns nullable Bool enum representing the SpeedSource field</returns>
+		public Bool? SpeedSource
+		{
+			get
+			{
+				object obj = GetFieldValue(4, 0, Fit.SubfieldIndexMainField);
+				Bool? value = obj == null ? (Bool?)null : (Bool)obj;
+				return value;
+			}
+			set
+			{
+				SetFieldValue(4, 0, value, Fit.SubfieldIndexMainField);
+			}
+		}
 
-        /// <summary>
-        /// Set OdometerRollover field
-        /// Comment: Rollover counter that can be used to extend the odometer</summary>
-        /// <param name="odometerRollover_">Nullable field value to be set</param>
-        public void SetOdometerRollover(byte? odometerRollover_)
-        {
-            SetFieldValue(7, 0, odometerRollover_, Fit.SubfieldIndexMainField);
-        }
-        
-        #endregion // Methods
-    } // Class
+		///<summary>
+		/// Retrieves the SdmAntIdTransType field</summary>
+		/// <returns>Returns nullable byte representing the SdmAntIdTransType field</returns>
+		public byte? SdmAntIdTransType
+		{
+			get
+			{
+				Object val = GetFieldValue(5, 0, Fit.SubfieldIndexMainField);
+				if (val == null)
+				{
+					return null;
+				}
+
+				return (Convert.ToByte(val));
+
+			}
+			set
+			{
+				SetFieldValue(5, 0, value, Fit.SubfieldIndexMainField);
+			}
+		}
+
+		///<summary>
+		/// Retrieves the OdometerRollover field
+		/// Comment: Rollover counter that can be used to extend the odometer</summary>
+		/// <returns>Returns nullable byte representing the OdometerRollover field</returns>
+		public byte? OdometerRollover
+		{
+			get
+			{
+				Object val = GetFieldValue(7, 0, Fit.SubfieldIndexMainField);
+				if (val == null)
+				{
+					return null;
+				}
+
+				return (Convert.ToByte(val));
+
+			}
+			set
+			{
+				SetFieldValue(7, 0, value, Fit.SubfieldIndexMainField);
+			}
+		}
+
+		#endregion // Methods
+	} // Class
 } // namespace

--- a/Dynastream/Fit/Profile/Mesgs/SegmentFileMesg.cs
+++ b/Dynastream/Fit/Profile/Mesgs/SegmentFileMesg.cs
@@ -21,339 +21,329 @@ using System.Linq;
 
 namespace Dynastream.Fit
 {
-    /// <summary>
-    /// Implements the SegmentFile profile message.
-    /// </summary>
-    public class SegmentFileMesg : Mesg
-    {
-        #region Fields
-        #endregion
+	/// <summary>
+	/// Implements the SegmentFile profile message.
+	/// </summary>
+	public class SegmentFileMesg : Mesg
+	{
+		#region Fields
+		#endregion
 
-        /// <summary>
-        /// Field Numbers for <see cref="SegmentFileMesg"/>
-        /// </summary>
-        public sealed class FieldDefNum
-        {
-            public const byte MessageIndex = 254;
-            public const byte FileUuid = 1;
-            public const byte Enabled = 3;
-            public const byte UserProfilePrimaryKey = 4;
-            public const byte LeaderType = 7;
-            public const byte LeaderGroupPrimaryKey = 8;
-            public const byte LeaderActivityId = 9;
-            public const byte LeaderActivityIdString = 10;
-            public const byte DefaultRaceLeader = 11;
-            public const byte Invalid = Fit.FieldNumInvalid;
-        }
+		/// <summary>
+		/// Field Numbers for <see cref="SegmentFileMesg"/>
+		/// </summary>
+		public sealed class FieldDefNum
+		{
+			public const byte MessageIndex = 254;
+			public const byte FileUuid = 1;
+			public const byte Enabled = 3;
+			public const byte UserProfilePrimaryKey = 4;
+			public const byte LeaderType = 7;
+			public const byte LeaderGroupPrimaryKey = 8;
+			public const byte LeaderActivityId = 9;
+			public const byte LeaderActivityIdString = 10;
+			public const byte DefaultRaceLeader = 11;
+			public const byte Invalid = Fit.FieldNumInvalid;
+		}
 
-        #region Constructors
-        public SegmentFileMesg() : base(Profile.GetMesg(MesgNum.SegmentFile))
-        {
-        }
+		#region Constructors
+		public SegmentFileMesg() : base(Profile.GetMesg(MesgNum.SegmentFile))
+		{
+		}
 
-        public SegmentFileMesg(Mesg mesg) : base(mesg)
-        {
-        }
-        #endregion // Constructors
+		public SegmentFileMesg(Mesg mesg) : base(mesg)
+		{
+		}
+		#endregion // Constructors
 
-        #region Methods
-        ///<summary>
-        /// Retrieves the MessageIndex field</summary>
-        /// <returns>Returns nullable ushort representing the MessageIndex field</returns>
-        public ushort? GetMessageIndex()
-        {
-            Object val = GetFieldValue(254, 0, Fit.SubfieldIndexMainField);
-            if(val == null)
-            {
-                return null;
-            }
+		#region Methods
+		///<summary>
+		/// Retrieves the MessageIndex field</summary>
+		/// <returns>Returns nullable ushort representing the MessageIndex field</returns>
+		public ushort? MessageIndex
+		{
+			get
+			{
+				Object val = GetFieldValue(254, 0, Fit.SubfieldIndexMainField);
+				if (val == null)
+				{
+					return null;
+				}
 
-            return (Convert.ToUInt16(val));
-            
-        }
+				return (Convert.ToUInt16(val));
 
-        /// <summary>
-        /// Set MessageIndex field</summary>
-        /// <param name="messageIndex_">Nullable field value to be set</param>
-        public void SetMessageIndex(ushort? messageIndex_)
-        {
-            SetFieldValue(254, 0, messageIndex_, Fit.SubfieldIndexMainField);
-        }
-        
-        ///<summary>
-        /// Retrieves the FileUuid field
-        /// Comment: UUID of the segment file</summary>
-        /// <returns>Returns byte[] representing the FileUuid field</returns>
-        public byte[] GetFileUuid()
-        {
-            byte[] data = (byte[])GetFieldValue(1, 0, Fit.SubfieldIndexMainField);
-            return data.Take(data.Length - 1).ToArray();
-        }
+			}
+			set
+			{
+				SetFieldValue(254, 0, value, Fit.SubfieldIndexMainField);
+			}
+		}
 
-        ///<summary>
-        /// Retrieves the FileUuid field
-        /// Comment: UUID of the segment file</summary>
-        /// <returns>Returns String representing the FileUuid field</returns>
-        public String GetFileUuidAsString()
-        {
-            byte[] data = (byte[])GetFieldValue(1, 0, Fit.SubfieldIndexMainField);
-            return data != null ? Encoding.UTF8.GetString(data, 0, data.Length - 1) : null;
-        }
+		///<summary>
+		/// Retrieves the FileUuid field
+		/// Comment: UUID of the segment file</summary>
+		/// <returns>Returns byte[] representing the FileUuid field</returns>
+		public byte[] FileUuid
+		{
+			get
+			{
+				byte[] data = (byte[])GetFieldValue(1, 0, Fit.SubfieldIndexMainField);
+				return data.Take(data.Length - 1).ToArray();
+			}
+			set
+			{
+				SetFieldValue(1, 0, value, Fit.SubfieldIndexMainField);
+			}
+		}
 
-        ///<summary>
-        /// Set FileUuid field
-        /// Comment: UUID of the segment file</summary>
-        /// <param name="fileUuid_"> field value to be set</param>
-        public void SetFileUuid(String fileUuid_)
-        {
-            byte[] data = Encoding.UTF8.GetBytes(fileUuid_);
-            byte[] zdata = new byte[data.Length + 1];
-            data.CopyTo(zdata, 0);
-            SetFieldValue(1, 0, zdata, Fit.SubfieldIndexMainField);
-        }
+		///<summary>
+		/// Retrieves the FileUuid field
+		/// Comment: UUID of the segment file</summary>
+		/// <returns>Returns String representing the FileUuid field</returns>
+		public String GetFileUuidAsString()
+		{
+			byte[] data = (byte[])GetFieldValue(1, 0, Fit.SubfieldIndexMainField);
+			return data != null ? Encoding.UTF8.GetString(data, 0, data.Length - 1) : null;
+		}
 
-        
-        /// <summary>
-        /// Set FileUuid field
-        /// Comment: UUID of the segment file</summary>
-        /// <param name="fileUuid_">field value to be set</param>
-        public void SetFileUuid(byte[] fileUuid_)
-        {
-            SetFieldValue(1, 0, fileUuid_, Fit.SubfieldIndexMainField);
-        }
-        
-        ///<summary>
-        /// Retrieves the Enabled field
-        /// Comment: Enabled state of the segment file</summary>
-        /// <returns>Returns nullable Bool enum representing the Enabled field</returns>
-        public Bool? GetEnabled()
-        {
-            object obj = GetFieldValue(3, 0, Fit.SubfieldIndexMainField);
-            Bool? value = obj == null ? (Bool?)null : (Bool)obj;
-            return value;
-        }
+		///<summary>
+		/// Set FileUuid field
+		/// Comment: UUID of the segment file</summary>
+		/// <param name="fileUuid_"> field value to be set</param>
+		public void SetFileUuid(String fileUuid_)
+		{
+			byte[] data = Encoding.UTF8.GetBytes(fileUuid_);
+			byte[] zdata = new byte[data.Length + 1];
+			data.CopyTo(zdata, 0);
+			SetFieldValue(1, 0, zdata, Fit.SubfieldIndexMainField);
+		}
 
-        /// <summary>
-        /// Set Enabled field
-        /// Comment: Enabled state of the segment file</summary>
-        /// <param name="enabled_">Nullable field value to be set</param>
-        public void SetEnabled(Bool? enabled_)
-        {
-            SetFieldValue(3, 0, enabled_, Fit.SubfieldIndexMainField);
-        }
-        
-        ///<summary>
-        /// Retrieves the UserProfilePrimaryKey field
-        /// Comment: Primary key of the user that created the segment file</summary>
-        /// <returns>Returns nullable uint representing the UserProfilePrimaryKey field</returns>
-        public uint? GetUserProfilePrimaryKey()
-        {
-            Object val = GetFieldValue(4, 0, Fit.SubfieldIndexMainField);
-            if(val == null)
-            {
-                return null;
-            }
+		///<summary>
+		/// Retrieves the Enabled field
+		/// Comment: Enabled state of the segment file</summary>
+		/// <returns>Returns nullable Bool enum representing the Enabled field</returns>
+		public Bool? Enabled
+		{
+			get
+			{
+				object obj = GetFieldValue(3, 0, Fit.SubfieldIndexMainField);
+				Bool? value = obj == null ? (Bool?)null : (Bool)obj;
+				return value;
+			}
+			set
+			{
+				SetFieldValue(3, 0, value, Fit.SubfieldIndexMainField);
+			}
+		}
 
-            return (Convert.ToUInt32(val));
-            
-        }
+		///<summary>
+		/// Retrieves the UserProfilePrimaryKey field
+		/// Comment: Primary key of the user that created the segment file</summary>
+		/// <returns>Returns nullable uint representing the UserProfilePrimaryKey field</returns>
+		public uint? UserProfilePrimaryKey
+		{
+			get
+			{
+				Object val = GetFieldValue(4, 0, Fit.SubfieldIndexMainField);
+				if (val == null)
+				{
+					return null;
+				}
 
-        /// <summary>
-        /// Set UserProfilePrimaryKey field
-        /// Comment: Primary key of the user that created the segment file</summary>
-        /// <param name="userProfilePrimaryKey_">Nullable field value to be set</param>
-        public void SetUserProfilePrimaryKey(uint? userProfilePrimaryKey_)
-        {
-            SetFieldValue(4, 0, userProfilePrimaryKey_, Fit.SubfieldIndexMainField);
-        }
-        
-        
-        /// <summary>
-        ///
-        /// </summary>
-        /// <returns>returns number of elements in field LeaderType</returns>
-        public int GetNumLeaderType()
-        {
-            return GetNumFieldValues(7, Fit.SubfieldIndexMainField);
-        }
+				return (Convert.ToUInt32(val));
 
-        ///<summary>
-        /// Retrieves the LeaderType field
-        /// Comment: Leader type of each leader in the segment file</summary>
-        /// <param name="index">0 based index of LeaderType element to retrieve</param>
-        /// <returns>Returns nullable SegmentLeaderboardType enum representing the LeaderType field</returns>
-        public SegmentLeaderboardType? GetLeaderType(int index)
-        {
-            object obj = GetFieldValue(7, index, Fit.SubfieldIndexMainField);
-            SegmentLeaderboardType? value = obj == null ? (SegmentLeaderboardType?)null : (SegmentLeaderboardType)obj;
-            return value;
-        }
+			}
+			set
+			{
+				SetFieldValue(4, 0, value, Fit.SubfieldIndexMainField);
+			}
+		}
 
-        /// <summary>
-        /// Set LeaderType field
-        /// Comment: Leader type of each leader in the segment file</summary>
-        /// <param name="index">0 based index of leader_type</param>
-        /// <param name="leaderType_">Nullable field value to be set</param>
-        public void SetLeaderType(int index, SegmentLeaderboardType? leaderType_)
-        {
-            SetFieldValue(7, index, leaderType_, Fit.SubfieldIndexMainField);
-        }
-        
-        
-        /// <summary>
-        ///
-        /// </summary>
-        /// <returns>returns number of elements in field LeaderGroupPrimaryKey</returns>
-        public int GetNumLeaderGroupPrimaryKey()
-        {
-            return GetNumFieldValues(8, Fit.SubfieldIndexMainField);
-        }
 
-        ///<summary>
-        /// Retrieves the LeaderGroupPrimaryKey field
-        /// Comment: Group primary key of each leader in the segment file</summary>
-        /// <param name="index">0 based index of LeaderGroupPrimaryKey element to retrieve</param>
-        /// <returns>Returns nullable uint representing the LeaderGroupPrimaryKey field</returns>
-        public uint? GetLeaderGroupPrimaryKey(int index)
-        {
-            Object val = GetFieldValue(8, index, Fit.SubfieldIndexMainField);
-            if(val == null)
-            {
-                return null;
-            }
+		/// <summary>
+		///
+		/// </summary>
+		/// <returns>returns number of elements in field LeaderType</returns>
+		public int GetNumLeaderType()
+		{
+			return GetNumFieldValues(7, Fit.SubfieldIndexMainField);
+		}
 
-            return (Convert.ToUInt32(val));
-            
-        }
+		///<summary>
+		/// Retrieves the LeaderType field
+		/// Comment: Leader type of each leader in the segment file</summary>
+		/// <param name="index">0 based index of LeaderType element to retrieve</param>
+		/// <returns>Returns nullable SegmentLeaderboardType enum representing the LeaderType field</returns>
+		public SegmentLeaderboardType? GetLeaderType(int index)
+		{
+			object obj = GetFieldValue(7, index, Fit.SubfieldIndexMainField);
+			SegmentLeaderboardType? value = obj == null ? (SegmentLeaderboardType?)null : (SegmentLeaderboardType)obj;
+			return value;
+		}
 
-        /// <summary>
-        /// Set LeaderGroupPrimaryKey field
-        /// Comment: Group primary key of each leader in the segment file</summary>
-        /// <param name="index">0 based index of leader_group_primary_key</param>
-        /// <param name="leaderGroupPrimaryKey_">Nullable field value to be set</param>
-        public void SetLeaderGroupPrimaryKey(int index, uint? leaderGroupPrimaryKey_)
-        {
-            SetFieldValue(8, index, leaderGroupPrimaryKey_, Fit.SubfieldIndexMainField);
-        }
-        
-        
-        /// <summary>
-        ///
-        /// </summary>
-        /// <returns>returns number of elements in field LeaderActivityId</returns>
-        public int GetNumLeaderActivityId()
-        {
-            return GetNumFieldValues(9, Fit.SubfieldIndexMainField);
-        }
+		/// <summary>
+		/// Set LeaderType field
+		/// Comment: Leader type of each leader in the segment file</summary>
+		/// <param name="index">0 based index of leader_type</param>
+		/// <param name="leaderType_">Nullable field value to be set</param>
+		public void SetLeaderType(int index, SegmentLeaderboardType? leaderType_)
+		{
+			SetFieldValue(7, index, leaderType_, Fit.SubfieldIndexMainField);
+		}
 
-        ///<summary>
-        /// Retrieves the LeaderActivityId field
-        /// Comment: Activity ID of each leader in the segment file</summary>
-        /// <param name="index">0 based index of LeaderActivityId element to retrieve</param>
-        /// <returns>Returns nullable uint representing the LeaderActivityId field</returns>
-        public uint? GetLeaderActivityId(int index)
-        {
-            Object val = GetFieldValue(9, index, Fit.SubfieldIndexMainField);
-            if(val == null)
-            {
-                return null;
-            }
 
-            return (Convert.ToUInt32(val));
-            
-        }
+		/// <summary>
+		///
+		/// </summary>
+		/// <returns>returns number of elements in field LeaderGroupPrimaryKey</returns>
+		public int GetNumLeaderGroupPrimaryKey()
+		{
+			return GetNumFieldValues(8, Fit.SubfieldIndexMainField);
+		}
 
-        /// <summary>
-        /// Set LeaderActivityId field
-        /// Comment: Activity ID of each leader in the segment file</summary>
-        /// <param name="index">0 based index of leader_activity_id</param>
-        /// <param name="leaderActivityId_">Nullable field value to be set</param>
-        public void SetLeaderActivityId(int index, uint? leaderActivityId_)
-        {
-            SetFieldValue(9, index, leaderActivityId_, Fit.SubfieldIndexMainField);
-        }
-        
-        
-        /// <summary>
-        ///
-        /// </summary>
-        /// <returns>returns number of elements in field LeaderActivityIdString</returns>
-        public int GetNumLeaderActivityIdString()
-        {
-            return GetNumFieldValues(10, Fit.SubfieldIndexMainField);
-        }
+		///<summary>
+		/// Retrieves the LeaderGroupPrimaryKey field
+		/// Comment: Group primary key of each leader in the segment file</summary>
+		/// <param name="index">0 based index of LeaderGroupPrimaryKey element to retrieve</param>
+		/// <returns>Returns nullable uint representing the LeaderGroupPrimaryKey field</returns>
+		public uint? GetLeaderGroupPrimaryKey(int index)
+		{
+			Object val = GetFieldValue(8, index, Fit.SubfieldIndexMainField);
+			if (val == null)
+			{
+				return null;
+			}
 
-        ///<summary>
-        /// Retrieves the LeaderActivityIdString field
-        /// Comment: String version of the activity ID of each leader in the segment file. 21 characters long for each ID, express in decimal</summary>
-        /// <param name="index">0 based index of LeaderActivityIdString element to retrieve</param>
-        /// <returns>Returns byte[] representing the LeaderActivityIdString field</returns>
-        public byte[] GetLeaderActivityIdString(int index)
-        {
-            byte[] data = (byte[])GetFieldValue(10, index, Fit.SubfieldIndexMainField);
-            return data.Take(data.Length - 1).ToArray();
-        }
+			return (Convert.ToUInt32(val));
 
-        ///<summary>
-        /// Retrieves the LeaderActivityIdString field
-        /// Comment: String version of the activity ID of each leader in the segment file. 21 characters long for each ID, express in decimal</summary>
-        /// <param name="index">0 based index of LeaderActivityIdString element to retrieve</param>
-        /// <returns>Returns String representing the LeaderActivityIdString field</returns>
-        public String GetLeaderActivityIdStringAsString(int index)
-        {
-            byte[] data = (byte[])GetFieldValue(10, index, Fit.SubfieldIndexMainField);
-            return data != null ? Encoding.UTF8.GetString(data, 0, data.Length - 1) : null;
-        }
+		}
 
-        ///<summary>
-        /// Set LeaderActivityIdString field
-        /// Comment: String version of the activity ID of each leader in the segment file. 21 characters long for each ID, express in decimal</summary>
-        /// <param name="index">0 based index of LeaderActivityIdString element to retrieve</param>
-        /// <param name="leaderActivityIdString_"> field value to be set</param>
-        public void SetLeaderActivityIdString(int index, String leaderActivityIdString_)
-        {
-            byte[] data = Encoding.UTF8.GetBytes(leaderActivityIdString_);
-            byte[] zdata = new byte[data.Length + 1];
-            data.CopyTo(zdata, 0);
-            SetFieldValue(10, index, zdata, Fit.SubfieldIndexMainField);
-        }
+		/// <summary>
+		/// Set LeaderGroupPrimaryKey field
+		/// Comment: Group primary key of each leader in the segment file</summary>
+		/// <param name="index">0 based index of leader_group_primary_key</param>
+		/// <param name="leaderGroupPrimaryKey_">Nullable field value to be set</param>
+		public void SetLeaderGroupPrimaryKey(int index, uint? leaderGroupPrimaryKey_)
+		{
+			SetFieldValue(8, index, leaderGroupPrimaryKey_, Fit.SubfieldIndexMainField);
+		}
 
-        
-        /// <summary>
-        /// Set LeaderActivityIdString field
-        /// Comment: String version of the activity ID of each leader in the segment file. 21 characters long for each ID, express in decimal</summary>
-        /// <param name="index">0 based index of leader_activity_id_string</param>
-        /// <param name="leaderActivityIdString_">field value to be set</param>
-        public void SetLeaderActivityIdString(int index, byte[] leaderActivityIdString_)
-        {
-            SetFieldValue(10, index, leaderActivityIdString_, Fit.SubfieldIndexMainField);
-        }
-        
-        ///<summary>
-        /// Retrieves the DefaultRaceLeader field
-        /// Comment: Index for the Leader Board entry selected as the default race participant</summary>
-        /// <returns>Returns nullable byte representing the DefaultRaceLeader field</returns>
-        public byte? GetDefaultRaceLeader()
-        {
-            Object val = GetFieldValue(11, 0, Fit.SubfieldIndexMainField);
-            if(val == null)
-            {
-                return null;
-            }
 
-            return (Convert.ToByte(val));
-            
-        }
+		/// <summary>
+		///
+		/// </summary>
+		/// <returns>returns number of elements in field LeaderActivityId</returns>
+		public int GetNumLeaderActivityId()
+		{
+			return GetNumFieldValues(9, Fit.SubfieldIndexMainField);
+		}
 
-        /// <summary>
-        /// Set DefaultRaceLeader field
-        /// Comment: Index for the Leader Board entry selected as the default race participant</summary>
-        /// <param name="defaultRaceLeader_">Nullable field value to be set</param>
-        public void SetDefaultRaceLeader(byte? defaultRaceLeader_)
-        {
-            SetFieldValue(11, 0, defaultRaceLeader_, Fit.SubfieldIndexMainField);
-        }
-        
-        #endregion // Methods
-    } // Class
+		///<summary>
+		/// Retrieves the LeaderActivityId field
+		/// Comment: Activity ID of each leader in the segment file</summary>
+		/// <param name="index">0 based index of LeaderActivityId element to retrieve</param>
+		/// <returns>Returns nullable uint representing the LeaderActivityId field</returns>
+		public uint? GetLeaderActivityId(int index)
+		{
+			Object val = GetFieldValue(9, index, Fit.SubfieldIndexMainField);
+			if (val == null)
+			{
+				return null;
+			}
+
+			return (Convert.ToUInt32(val));
+
+		}
+
+		/// <summary>
+		/// Set LeaderActivityId field
+		/// Comment: Activity ID of each leader in the segment file</summary>
+		/// <param name="index">0 based index of leader_activity_id</param>
+		/// <param name="leaderActivityId_">Nullable field value to be set</param>
+		public void SetLeaderActivityId(int index, uint? leaderActivityId_)
+		{
+			SetFieldValue(9, index, leaderActivityId_, Fit.SubfieldIndexMainField);
+		}
+
+
+		/// <summary>
+		///
+		/// </summary>
+		/// <returns>returns number of elements in field LeaderActivityIdString</returns>
+		public int GetNumLeaderActivityIdString()
+		{
+			return GetNumFieldValues(10, Fit.SubfieldIndexMainField);
+		}
+
+		///<summary>
+		/// Retrieves the LeaderActivityIdString field
+		/// Comment: String version of the activity ID of each leader in the segment file. 21 characters long for each ID, express in decimal</summary>
+		/// <param name="index">0 based index of LeaderActivityIdString element to retrieve</param>
+		/// <returns>Returns byte[] representing the LeaderActivityIdString field</returns>
+		public byte[] GetLeaderActivityIdString(int index)
+		{
+			byte[] data = (byte[])GetFieldValue(10, index, Fit.SubfieldIndexMainField);
+			return data.Take(data.Length - 1).ToArray();
+		}
+
+		///<summary>
+		/// Retrieves the LeaderActivityIdString field
+		/// Comment: String version of the activity ID of each leader in the segment file. 21 characters long for each ID, express in decimal</summary>
+		/// <param name="index">0 based index of LeaderActivityIdString element to retrieve</param>
+		/// <returns>Returns String representing the LeaderActivityIdString field</returns>
+		public String GetLeaderActivityIdStringAsString(int index)
+		{
+			byte[] data = (byte[])GetFieldValue(10, index, Fit.SubfieldIndexMainField);
+			return data != null ? Encoding.UTF8.GetString(data, 0, data.Length - 1) : null;
+		}
+
+		///<summary>
+		/// Set LeaderActivityIdString field
+		/// Comment: String version of the activity ID of each leader in the segment file. 21 characters long for each ID, express in decimal</summary>
+		/// <param name="index">0 based index of LeaderActivityIdString element to retrieve</param>
+		/// <param name="leaderActivityIdString_"> field value to be set</param>
+		public void SetLeaderActivityIdString(int index, String leaderActivityIdString_)
+		{
+			byte[] data = Encoding.UTF8.GetBytes(leaderActivityIdString_);
+			byte[] zdata = new byte[data.Length + 1];
+			data.CopyTo(zdata, 0);
+			SetFieldValue(10, index, zdata, Fit.SubfieldIndexMainField);
+		}
+
+
+		/// <summary>
+		/// Set LeaderActivityIdString field
+		/// Comment: String version of the activity ID of each leader in the segment file. 21 characters long for each ID, express in decimal</summary>
+		/// <param name="index">0 based index of leader_activity_id_string</param>
+		/// <param name="leaderActivityIdString_">field value to be set</param>
+		public void SetLeaderActivityIdString(int index, byte[] leaderActivityIdString_)
+		{
+			SetFieldValue(10, index, leaderActivityIdString_, Fit.SubfieldIndexMainField);
+		}
+
+		///<summary>
+		/// Retrieves the DefaultRaceLeader field
+		/// Comment: Index for the Leader Board entry selected as the default race participant</summary>
+		/// <returns>Returns nullable byte representing the DefaultRaceLeader field</returns>
+		public byte? DefaultRaceLeader
+		{
+			get
+			{
+				Object val = GetFieldValue(11, 0, Fit.SubfieldIndexMainField);
+				if (val == null)
+				{
+					return null;
+				}
+
+				return (Convert.ToByte(val));
+
+			}
+			set
+			{
+				SetFieldValue(11, 0, value, Fit.SubfieldIndexMainField);
+			}
+		}
+
+		#endregion // Methods
+	} // Class
 } // namespace

--- a/Dynastream/Fit/Profile/Mesgs/SegmentIdMesg.cs
+++ b/Dynastream/Fit/Profile/Mesgs/SegmentIdMesg.cs
@@ -21,281 +21,261 @@ using System.Linq;
 
 namespace Dynastream.Fit
 {
-    /// <summary>
-    /// Implements the SegmentId profile message.
-    /// </summary>
-    public class SegmentIdMesg : Mesg
-    {
-        #region Fields
-        #endregion
+	/// <summary>
+	/// Implements the SegmentId profile message.
+	/// </summary>
+	public class SegmentIdMesg : Mesg
+	{
+		#region Fields
+		#endregion
 
-        /// <summary>
-        /// Field Numbers for <see cref="SegmentIdMesg"/>
-        /// </summary>
-        public sealed class FieldDefNum
-        {
-            public const byte Name = 0;
-            public const byte Uuid = 1;
-            public const byte Sport = 2;
-            public const byte Enabled = 3;
-            public const byte UserProfilePrimaryKey = 4;
-            public const byte DeviceId = 5;
-            public const byte DefaultRaceLeader = 6;
-            public const byte DeleteStatus = 7;
-            public const byte SelectionType = 8;
-            public const byte Invalid = Fit.FieldNumInvalid;
-        }
+		/// <summary>
+		/// Field Numbers for <see cref="SegmentIdMesg"/>
+		/// </summary>
+		public sealed class FieldDefNum
+		{
+			public const byte Name = 0;
+			public const byte Uuid = 1;
+			public const byte Sport = 2;
+			public const byte Enabled = 3;
+			public const byte UserProfilePrimaryKey = 4;
+			public const byte DeviceId = 5;
+			public const byte DefaultRaceLeader = 6;
+			public const byte DeleteStatus = 7;
+			public const byte SelectionType = 8;
+			public const byte Invalid = Fit.FieldNumInvalid;
+		}
 
-        #region Constructors
-        public SegmentIdMesg() : base(Profile.GetMesg(MesgNum.SegmentId))
-        {
-        }
+		#region Constructors
+		public SegmentIdMesg() : base(Profile.GetMesg(MesgNum.SegmentId))
+		{
+		}
 
-        public SegmentIdMesg(Mesg mesg) : base(mesg)
-        {
-        }
-        #endregion // Constructors
+		public SegmentIdMesg(Mesg mesg) : base(mesg)
+		{
+		}
+		#endregion // Constructors
 
-        #region Methods
-        ///<summary>
-        /// Retrieves the Name field
-        /// Comment: Friendly name assigned to segment</summary>
-        /// <returns>Returns byte[] representing the Name field</returns>
-        public byte[] GetName()
-        {
-            byte[] data = (byte[])GetFieldValue(0, 0, Fit.SubfieldIndexMainField);
-            return data.Take(data.Length - 1).ToArray();
-        }
+		#region Methods
+		///<summary>
+		/// Retrieves the Name field
+		/// Comment: Friendly name assigned to segment</summary>
+		/// <returns>Returns byte[] representing the Name field</returns>
+		public byte[] Name
+		{
+			get
+			{
+				byte[] data = (byte[])GetFieldValue(0, 0, Fit.SubfieldIndexMainField);
+				return data.Take(data.Length - 1).ToArray();
+			}
+			set
+			{
+				SetFieldValue(0, 0, value, Fit.SubfieldIndexMainField);
+			}
+		}
 
-        ///<summary>
-        /// Retrieves the Name field
-        /// Comment: Friendly name assigned to segment</summary>
-        /// <returns>Returns String representing the Name field</returns>
-        public String GetNameAsString()
-        {
-            byte[] data = (byte[])GetFieldValue(0, 0, Fit.SubfieldIndexMainField);
-            return data != null ? Encoding.UTF8.GetString(data, 0, data.Length - 1) : null;
-        }
+		///<summary>
+		/// Retrieves the Name field
+		/// Comment: Friendly name assigned to segment</summary>
+		/// <returns>Returns String representing the Name field</returns>
+		public String GetNameAsString()
+		{
+			byte[] data = (byte[])GetFieldValue(0, 0, Fit.SubfieldIndexMainField);
+			return data != null ? Encoding.UTF8.GetString(data, 0, data.Length - 1) : null;
+		}
 
-        ///<summary>
-        /// Set Name field
-        /// Comment: Friendly name assigned to segment</summary>
-        /// <param name="name_"> field value to be set</param>
-        public void SetName(String name_)
-        {
-            byte[] data = Encoding.UTF8.GetBytes(name_);
-            byte[] zdata = new byte[data.Length + 1];
-            data.CopyTo(zdata, 0);
-            SetFieldValue(0, 0, zdata, Fit.SubfieldIndexMainField);
-        }
+		///<summary>
+		/// Set Name field
+		/// Comment: Friendly name assigned to segment</summary>
+		/// <param name="name_"> field value to be set</param>
+		public void SetName(String name_)
+		{
+			byte[] data = Encoding.UTF8.GetBytes(name_);
+			byte[] zdata = new byte[data.Length + 1];
+			data.CopyTo(zdata, 0);
+			SetFieldValue(0, 0, zdata, Fit.SubfieldIndexMainField);
+		}
 
-        
-        /// <summary>
-        /// Set Name field
-        /// Comment: Friendly name assigned to segment</summary>
-        /// <param name="name_">field value to be set</param>
-        public void SetName(byte[] name_)
-        {
-            SetFieldValue(0, 0, name_, Fit.SubfieldIndexMainField);
-        }
-        
-        ///<summary>
-        /// Retrieves the Uuid field
-        /// Comment: UUID of the segment</summary>
-        /// <returns>Returns byte[] representing the Uuid field</returns>
-        public byte[] GetUuid()
-        {
-            byte[] data = (byte[])GetFieldValue(1, 0, Fit.SubfieldIndexMainField);
-            return data.Take(data.Length - 1).ToArray();
-        }
+		///<summary>
+		/// Retrieves the Uuid field
+		/// Comment: UUID of the segment</summary>
+		/// <returns>Returns byte[] representing the Uuid field</returns>
+		public byte[] Uuid
+		{
+			get
+			{
+				byte[] data = (byte[])GetFieldValue(1, 0, Fit.SubfieldIndexMainField);
+				return data.Take(data.Length - 1).ToArray();
+			}
+			set
+			{
+				SetFieldValue(1, 0, value, Fit.SubfieldIndexMainField);
+			}
+		}
 
-        ///<summary>
-        /// Retrieves the Uuid field
-        /// Comment: UUID of the segment</summary>
-        /// <returns>Returns String representing the Uuid field</returns>
-        public String GetUuidAsString()
-        {
-            byte[] data = (byte[])GetFieldValue(1, 0, Fit.SubfieldIndexMainField);
-            return data != null ? Encoding.UTF8.GetString(data, 0, data.Length - 1) : null;
-        }
+		///<summary>
+		/// Retrieves the Uuid field
+		/// Comment: UUID of the segment</summary>
+		/// <returns>Returns String representing the Uuid field</returns>
+		public String GetUuidAsString()
+		{
+			byte[] data = (byte[])GetFieldValue(1, 0, Fit.SubfieldIndexMainField);
+			return data != null ? Encoding.UTF8.GetString(data, 0, data.Length - 1) : null;
+		}
 
-        ///<summary>
-        /// Set Uuid field
-        /// Comment: UUID of the segment</summary>
-        /// <param name="uuid_"> field value to be set</param>
-        public void SetUuid(String uuid_)
-        {
-            byte[] data = Encoding.UTF8.GetBytes(uuid_);
-            byte[] zdata = new byte[data.Length + 1];
-            data.CopyTo(zdata, 0);
-            SetFieldValue(1, 0, zdata, Fit.SubfieldIndexMainField);
-        }
+		///<summary>
+		/// Set Uuid field
+		/// Comment: UUID of the segment</summary>
+		/// <param name="uuid_"> field value to be set</param>
+		public void SetUuid(String uuid_)
+		{
+			byte[] data = Encoding.UTF8.GetBytes(uuid_);
+			byte[] zdata = new byte[data.Length + 1];
+			data.CopyTo(zdata, 0);
+			SetFieldValue(1, 0, zdata, Fit.SubfieldIndexMainField);
+		}
 
-        
-        /// <summary>
-        /// Set Uuid field
-        /// Comment: UUID of the segment</summary>
-        /// <param name="uuid_">field value to be set</param>
-        public void SetUuid(byte[] uuid_)
-        {
-            SetFieldValue(1, 0, uuid_, Fit.SubfieldIndexMainField);
-        }
-        
-        ///<summary>
-        /// Retrieves the Sport field
-        /// Comment: Sport associated with the segment</summary>
-        /// <returns>Returns nullable Sport enum representing the Sport field</returns>
-        public Sport? GetSport()
-        {
-            object obj = GetFieldValue(2, 0, Fit.SubfieldIndexMainField);
-            Sport? value = obj == null ? (Sport?)null : (Sport)obj;
-            return value;
-        }
+		///<summary>
+		/// Retrieves the Sport field
+		/// Comment: Sport associated with the segment</summary>
+		/// <returns>Returns nullable Sport enum representing the Sport field</returns>
+		public Sport? Sport
+		{
+			get
+			{
+				object obj = GetFieldValue(2, 0, Fit.SubfieldIndexMainField);
+				Sport? value = obj == null ? (Sport?)null : (Sport)obj;
+				return value;
+			}
+			set
+			{
+				SetFieldValue(2, 0, value, Fit.SubfieldIndexMainField);
+			}
+		}
 
-        /// <summary>
-        /// Set Sport field
-        /// Comment: Sport associated with the segment</summary>
-        /// <param name="sport_">Nullable field value to be set</param>
-        public void SetSport(Sport? sport_)
-        {
-            SetFieldValue(2, 0, sport_, Fit.SubfieldIndexMainField);
-        }
-        
-        ///<summary>
-        /// Retrieves the Enabled field
-        /// Comment: Segment enabled for evaluation</summary>
-        /// <returns>Returns nullable Bool enum representing the Enabled field</returns>
-        public Bool? GetEnabled()
-        {
-            object obj = GetFieldValue(3, 0, Fit.SubfieldIndexMainField);
-            Bool? value = obj == null ? (Bool?)null : (Bool)obj;
-            return value;
-        }
+		///<summary>
+		/// Retrieves the Enabled field
+		/// Comment: Segment enabled for evaluation</summary>
+		/// <returns>Returns nullable Bool enum representing the Enabled field</returns>
+		public Bool? Enabled
+		{
+			get
+			{
+				object obj = GetFieldValue(3, 0, Fit.SubfieldIndexMainField);
+				Bool? value = obj == null ? (Bool?)null : (Bool)obj;
+				return value;
+			}
+			set
+			{
+				SetFieldValue(3, 0, value, Fit.SubfieldIndexMainField);
+			}
+		}
 
-        /// <summary>
-        /// Set Enabled field
-        /// Comment: Segment enabled for evaluation</summary>
-        /// <param name="enabled_">Nullable field value to be set</param>
-        public void SetEnabled(Bool? enabled_)
-        {
-            SetFieldValue(3, 0, enabled_, Fit.SubfieldIndexMainField);
-        }
-        
-        ///<summary>
-        /// Retrieves the UserProfilePrimaryKey field
-        /// Comment: Primary key of the user that created the segment</summary>
-        /// <returns>Returns nullable uint representing the UserProfilePrimaryKey field</returns>
-        public uint? GetUserProfilePrimaryKey()
-        {
-            Object val = GetFieldValue(4, 0, Fit.SubfieldIndexMainField);
-            if(val == null)
-            {
-                return null;
-            }
+		///<summary>
+		/// Retrieves the UserProfilePrimaryKey field
+		/// Comment: Primary key of the user that created the segment</summary>
+		/// <returns>Returns nullable uint representing the UserProfilePrimaryKey field</returns>
+		public uint? UserProfilePrimaryKey
+		{
+			get
+			{
+				Object val = GetFieldValue(4, 0, Fit.SubfieldIndexMainField);
+				if (val == null)
+				{
+					return null;
+				}
 
-            return (Convert.ToUInt32(val));
-            
-        }
+				return (Convert.ToUInt32(val));
 
-        /// <summary>
-        /// Set UserProfilePrimaryKey field
-        /// Comment: Primary key of the user that created the segment</summary>
-        /// <param name="userProfilePrimaryKey_">Nullable field value to be set</param>
-        public void SetUserProfilePrimaryKey(uint? userProfilePrimaryKey_)
-        {
-            SetFieldValue(4, 0, userProfilePrimaryKey_, Fit.SubfieldIndexMainField);
-        }
-        
-        ///<summary>
-        /// Retrieves the DeviceId field
-        /// Comment: ID of the device that created the segment</summary>
-        /// <returns>Returns nullable uint representing the DeviceId field</returns>
-        public uint? GetDeviceId()
-        {
-            Object val = GetFieldValue(5, 0, Fit.SubfieldIndexMainField);
-            if(val == null)
-            {
-                return null;
-            }
+			}
+			set
+			{
+				SetFieldValue(4, 0, value, Fit.SubfieldIndexMainField);
+			}
+		}
 
-            return (Convert.ToUInt32(val));
-            
-        }
+		///<summary>
+		/// Retrieves the DeviceId field
+		/// Comment: ID of the device that created the segment</summary>
+		/// <returns>Returns nullable uint representing the DeviceId field</returns>
+		public uint? DeviceId
+		{
+			get
+			{
+				Object val = GetFieldValue(5, 0, Fit.SubfieldIndexMainField);
+				if (val == null)
+				{
+					return null;
+				}
 
-        /// <summary>
-        /// Set DeviceId field
-        /// Comment: ID of the device that created the segment</summary>
-        /// <param name="deviceId_">Nullable field value to be set</param>
-        public void SetDeviceId(uint? deviceId_)
-        {
-            SetFieldValue(5, 0, deviceId_, Fit.SubfieldIndexMainField);
-        }
-        
-        ///<summary>
-        /// Retrieves the DefaultRaceLeader field
-        /// Comment: Index for the Leader Board entry selected as the default race participant</summary>
-        /// <returns>Returns nullable byte representing the DefaultRaceLeader field</returns>
-        public byte? GetDefaultRaceLeader()
-        {
-            Object val = GetFieldValue(6, 0, Fit.SubfieldIndexMainField);
-            if(val == null)
-            {
-                return null;
-            }
+				return (Convert.ToUInt32(val));
 
-            return (Convert.ToByte(val));
-            
-        }
+			}
+			set
+			{
+				SetFieldValue(5, 0, value, Fit.SubfieldIndexMainField);
+			}
+		}
 
-        /// <summary>
-        /// Set DefaultRaceLeader field
-        /// Comment: Index for the Leader Board entry selected as the default race participant</summary>
-        /// <param name="defaultRaceLeader_">Nullable field value to be set</param>
-        public void SetDefaultRaceLeader(byte? defaultRaceLeader_)
-        {
-            SetFieldValue(6, 0, defaultRaceLeader_, Fit.SubfieldIndexMainField);
-        }
-        
-        ///<summary>
-        /// Retrieves the DeleteStatus field
-        /// Comment: Indicates if any segments should be deleted</summary>
-        /// <returns>Returns nullable SegmentDeleteStatus enum representing the DeleteStatus field</returns>
-        public SegmentDeleteStatus? GetDeleteStatus()
-        {
-            object obj = GetFieldValue(7, 0, Fit.SubfieldIndexMainField);
-            SegmentDeleteStatus? value = obj == null ? (SegmentDeleteStatus?)null : (SegmentDeleteStatus)obj;
-            return value;
-        }
+		///<summary>
+		/// Retrieves the DefaultRaceLeader field
+		/// Comment: Index for the Leader Board entry selected as the default race participant</summary>
+		/// <returns>Returns nullable byte representing the DefaultRaceLeader field</returns>
+		public byte? DefaultRaceLeader
+		{
+			get
+			{
+				Object val = GetFieldValue(6, 0, Fit.SubfieldIndexMainField);
+				if (val == null)
+				{
+					return null;
+				}
 
-        /// <summary>
-        /// Set DeleteStatus field
-        /// Comment: Indicates if any segments should be deleted</summary>
-        /// <param name="deleteStatus_">Nullable field value to be set</param>
-        public void SetDeleteStatus(SegmentDeleteStatus? deleteStatus_)
-        {
-            SetFieldValue(7, 0, deleteStatus_, Fit.SubfieldIndexMainField);
-        }
-        
-        ///<summary>
-        /// Retrieves the SelectionType field
-        /// Comment: Indicates how the segment was selected to be sent to the device</summary>
-        /// <returns>Returns nullable SegmentSelectionType enum representing the SelectionType field</returns>
-        public SegmentSelectionType? GetSelectionType()
-        {
-            object obj = GetFieldValue(8, 0, Fit.SubfieldIndexMainField);
-            SegmentSelectionType? value = obj == null ? (SegmentSelectionType?)null : (SegmentSelectionType)obj;
-            return value;
-        }
+				return (Convert.ToByte(val));
 
-        /// <summary>
-        /// Set SelectionType field
-        /// Comment: Indicates how the segment was selected to be sent to the device</summary>
-        /// <param name="selectionType_">Nullable field value to be set</param>
-        public void SetSelectionType(SegmentSelectionType? selectionType_)
-        {
-            SetFieldValue(8, 0, selectionType_, Fit.SubfieldIndexMainField);
-        }
-        
-        #endregion // Methods
-    } // Class
+			}
+			set
+			{
+				SetFieldValue(6, 0, value, Fit.SubfieldIndexMainField);
+			}
+		}
+
+		///<summary>
+		/// Retrieves the DeleteStatus field
+		/// Comment: Indicates if any segments should be deleted</summary>
+		/// <returns>Returns nullable SegmentDeleteStatus enum representing the DeleteStatus field</returns>
+		public SegmentDeleteStatus? DeleteStatus
+		{
+			get
+			{
+				object obj = GetFieldValue(7, 0, Fit.SubfieldIndexMainField);
+				SegmentDeleteStatus? value = obj == null ? (SegmentDeleteStatus?)null : (SegmentDeleteStatus)obj;
+				return value;
+			}
+			set
+			{
+				SetFieldValue(7, 0, value, Fit.SubfieldIndexMainField);
+			}
+		}
+
+		///<summary>
+		/// Retrieves the SelectionType field
+		/// Comment: Indicates how the segment was selected to be sent to the device</summary>
+		/// <returns>Returns nullable SegmentSelectionType enum representing the SelectionType field</returns>
+		public SegmentSelectionType? SelectionType
+		{
+			get
+			{
+				object obj = GetFieldValue(8, 0, Fit.SubfieldIndexMainField);
+				SegmentSelectionType? value = obj == null ? (SegmentSelectionType?)null : (SegmentSelectionType)obj;
+				return value;
+			}
+			set
+			{
+				SetFieldValue(8, 0, value, Fit.SubfieldIndexMainField);
+			}
+		}
+
+		#endregion // Methods
+	} // Class
 } // namespace

--- a/Dynastream/Fit/Profile/Mesgs/SegmentLapMesg.cs
+++ b/Dynastream/Fit/Profile/Mesgs/SegmentLapMesg.cs
@@ -21,2708 +21,2531 @@ using System.Linq;
 
 namespace Dynastream.Fit
 {
-    /// <summary>
-    /// Implements the SegmentLap profile message.
-    /// </summary>
-    public class SegmentLapMesg : Mesg
-    {
-        #region Fields
-        static class TotalCyclesSubfield
-        {
-            public static ushort TotalStrokes = 0;
-            public static ushort Subfields = 1;
-            public static ushort Active = Fit.SubfieldIndexActiveSubfield;
-            public static ushort MainField = Fit.SubfieldIndexMainField;
-        }
-        #endregion
-
-        /// <summary>
-        /// Field Numbers for <see cref="SegmentLapMesg"/>
-        /// </summary>
-        public sealed class FieldDefNum
-        {
-            public const byte MessageIndex = 254;
-            public const byte Timestamp = 253;
-            public const byte Event = 0;
-            public const byte EventType = 1;
-            public const byte StartTime = 2;
-            public const byte StartPositionLat = 3;
-            public const byte StartPositionLong = 4;
-            public const byte EndPositionLat = 5;
-            public const byte EndPositionLong = 6;
-            public const byte TotalElapsedTime = 7;
-            public const byte TotalTimerTime = 8;
-            public const byte TotalDistance = 9;
-            public const byte TotalCycles = 10;
-            public const byte TotalCalories = 11;
-            public const byte TotalFatCalories = 12;
-            public const byte AvgSpeed = 13;
-            public const byte MaxSpeed = 14;
-            public const byte AvgHeartRate = 15;
-            public const byte MaxHeartRate = 16;
-            public const byte AvgCadence = 17;
-            public const byte MaxCadence = 18;
-            public const byte AvgPower = 19;
-            public const byte MaxPower = 20;
-            public const byte TotalAscent = 21;
-            public const byte TotalDescent = 22;
-            public const byte Sport = 23;
-            public const byte EventGroup = 24;
-            public const byte NecLat = 25;
-            public const byte NecLong = 26;
-            public const byte SwcLat = 27;
-            public const byte SwcLong = 28;
-            public const byte Name = 29;
-            public const byte NormalizedPower = 30;
-            public const byte LeftRightBalance = 31;
-            public const byte SubSport = 32;
-            public const byte TotalWork = 33;
-            public const byte AvgAltitude = 34;
-            public const byte MaxAltitude = 35;
-            public const byte GpsAccuracy = 36;
-            public const byte AvgGrade = 37;
-            public const byte AvgPosGrade = 38;
-            public const byte AvgNegGrade = 39;
-            public const byte MaxPosGrade = 40;
-            public const byte MaxNegGrade = 41;
-            public const byte AvgTemperature = 42;
-            public const byte MaxTemperature = 43;
-            public const byte TotalMovingTime = 44;
-            public const byte AvgPosVerticalSpeed = 45;
-            public const byte AvgNegVerticalSpeed = 46;
-            public const byte MaxPosVerticalSpeed = 47;
-            public const byte MaxNegVerticalSpeed = 48;
-            public const byte TimeInHrZone = 49;
-            public const byte TimeInSpeedZone = 50;
-            public const byte TimeInCadenceZone = 51;
-            public const byte TimeInPowerZone = 52;
-            public const byte RepetitionNum = 53;
-            public const byte MinAltitude = 54;
-            public const byte MinHeartRate = 55;
-            public const byte ActiveTime = 56;
-            public const byte WktStepIndex = 57;
-            public const byte SportEvent = 58;
-            public const byte AvgLeftTorqueEffectiveness = 59;
-            public const byte AvgRightTorqueEffectiveness = 60;
-            public const byte AvgLeftPedalSmoothness = 61;
-            public const byte AvgRightPedalSmoothness = 62;
-            public const byte AvgCombinedPedalSmoothness = 63;
-            public const byte Status = 64;
-            public const byte Uuid = 65;
-            public const byte AvgFractionalCadence = 66;
-            public const byte MaxFractionalCadence = 67;
-            public const byte TotalFractionalCycles = 68;
-            public const byte FrontGearShiftCount = 69;
-            public const byte RearGearShiftCount = 70;
-            public const byte TimeStanding = 71;
-            public const byte StandCount = 72;
-            public const byte AvgLeftPco = 73;
-            public const byte AvgRightPco = 74;
-            public const byte AvgLeftPowerPhase = 75;
-            public const byte AvgLeftPowerPhasePeak = 76;
-            public const byte AvgRightPowerPhase = 77;
-            public const byte AvgRightPowerPhasePeak = 78;
-            public const byte AvgPowerPosition = 79;
-            public const byte MaxPowerPosition = 80;
-            public const byte AvgCadencePosition = 81;
-            public const byte MaxCadencePosition = 82;
-            public const byte Manufacturer = 83;
-            public const byte TotalGrit = 84;
-            public const byte TotalFlow = 85;
-            public const byte AvgGrit = 86;
-            public const byte AvgFlow = 87;
-            public const byte TotalFractionalAscent = 89;
-            public const byte TotalFractionalDescent = 90;
-            public const byte EnhancedAvgAltitude = 91;
-            public const byte EnhancedMaxAltitude = 92;
-            public const byte EnhancedMinAltitude = 93;
-            public const byte Invalid = Fit.FieldNumInvalid;
-        }
-
-        #region Constructors
-        public SegmentLapMesg() : base(Profile.GetMesg(MesgNum.SegmentLap))
-        {
-        }
-
-        public SegmentLapMesg(Mesg mesg) : base(mesg)
-        {
-        }
-        #endregion // Constructors
-
-        #region Methods
-        ///<summary>
-        /// Retrieves the MessageIndex field</summary>
-        /// <returns>Returns nullable ushort representing the MessageIndex field</returns>
-        public ushort? GetMessageIndex()
-        {
-            Object val = GetFieldValue(254, 0, Fit.SubfieldIndexMainField);
-            if(val == null)
-            {
-                return null;
-            }
-
-            return (Convert.ToUInt16(val));
-            
-        }
-
-        /// <summary>
-        /// Set MessageIndex field</summary>
-        /// <param name="messageIndex_">Nullable field value to be set</param>
-        public void SetMessageIndex(ushort? messageIndex_)
-        {
-            SetFieldValue(254, 0, messageIndex_, Fit.SubfieldIndexMainField);
-        }
-        
-        ///<summary>
-        /// Retrieves the Timestamp field
-        /// Units: s
-        /// Comment: Lap end time.</summary>
-        /// <returns>Returns DateTime representing the Timestamp field</returns>
-        public DateTime GetTimestamp()
-        {
-            Object val = GetFieldValue(253, 0, Fit.SubfieldIndexMainField);
-            if(val == null)
-            {
-                return null;
-            }
-
-            return TimestampToDateTime(Convert.ToUInt32(val));
-            
-        }
-
-        /// <summary>
-        /// Set Timestamp field
-        /// Units: s
-        /// Comment: Lap end time.</summary>
-        /// <param name="timestamp_">Nullable field value to be set</param>
-        public void SetTimestamp(DateTime timestamp_)
-        {
-            SetFieldValue(253, 0, timestamp_.GetTimeStamp(), Fit.SubfieldIndexMainField);
-        }
-        
-        ///<summary>
-        /// Retrieves the Event field</summary>
-        /// <returns>Returns nullable Event enum representing the Event field</returns>
-        public Event? GetEvent()
-        {
-            object obj = GetFieldValue(0, 0, Fit.SubfieldIndexMainField);
-            Event? value = obj == null ? (Event?)null : (Event)obj;
-            return value;
-        }
-
-        /// <summary>
-        /// Set Event field</summary>
-        /// <param name="event_">Nullable field value to be set</param>
-        public void SetEvent(Event? event_)
-        {
-            SetFieldValue(0, 0, event_, Fit.SubfieldIndexMainField);
-        }
-        
-        ///<summary>
-        /// Retrieves the EventType field</summary>
-        /// <returns>Returns nullable EventType enum representing the EventType field</returns>
-        public EventType? GetEventType()
-        {
-            object obj = GetFieldValue(1, 0, Fit.SubfieldIndexMainField);
-            EventType? value = obj == null ? (EventType?)null : (EventType)obj;
-            return value;
-        }
-
-        /// <summary>
-        /// Set EventType field</summary>
-        /// <param name="eventType_">Nullable field value to be set</param>
-        public void SetEventType(EventType? eventType_)
-        {
-            SetFieldValue(1, 0, eventType_, Fit.SubfieldIndexMainField);
-        }
-        
-        ///<summary>
-        /// Retrieves the StartTime field</summary>
-        /// <returns>Returns DateTime representing the StartTime field</returns>
-        public DateTime GetStartTime()
-        {
-            Object val = GetFieldValue(2, 0, Fit.SubfieldIndexMainField);
-            if(val == null)
-            {
-                return null;
-            }
-
-            return TimestampToDateTime(Convert.ToUInt32(val));
-            
-        }
-
-        /// <summary>
-        /// Set StartTime field</summary>
-        /// <param name="startTime_">Nullable field value to be set</param>
-        public void SetStartTime(DateTime startTime_)
-        {
-            SetFieldValue(2, 0, startTime_.GetTimeStamp(), Fit.SubfieldIndexMainField);
-        }
-        
-        ///<summary>
-        /// Retrieves the StartPositionLat field
-        /// Units: semicircles</summary>
-        /// <returns>Returns nullable int representing the StartPositionLat field</returns>
-        public int? GetStartPositionLat()
-        {
-            Object val = GetFieldValue(3, 0, Fit.SubfieldIndexMainField);
-            if(val == null)
-            {
-                return null;
-            }
-
-            return (Convert.ToInt32(val));
-            
-        }
-
-        /// <summary>
-        /// Set StartPositionLat field
-        /// Units: semicircles</summary>
-        /// <param name="startPositionLat_">Nullable field value to be set</param>
-        public void SetStartPositionLat(int? startPositionLat_)
-        {
-            SetFieldValue(3, 0, startPositionLat_, Fit.SubfieldIndexMainField);
-        }
-        
-        ///<summary>
-        /// Retrieves the StartPositionLong field
-        /// Units: semicircles</summary>
-        /// <returns>Returns nullable int representing the StartPositionLong field</returns>
-        public int? GetStartPositionLong()
-        {
-            Object val = GetFieldValue(4, 0, Fit.SubfieldIndexMainField);
-            if(val == null)
-            {
-                return null;
-            }
-
-            return (Convert.ToInt32(val));
-            
-        }
-
-        /// <summary>
-        /// Set StartPositionLong field
-        /// Units: semicircles</summary>
-        /// <param name="startPositionLong_">Nullable field value to be set</param>
-        public void SetStartPositionLong(int? startPositionLong_)
-        {
-            SetFieldValue(4, 0, startPositionLong_, Fit.SubfieldIndexMainField);
-        }
-        
-        ///<summary>
-        /// Retrieves the EndPositionLat field
-        /// Units: semicircles</summary>
-        /// <returns>Returns nullable int representing the EndPositionLat field</returns>
-        public int? GetEndPositionLat()
-        {
-            Object val = GetFieldValue(5, 0, Fit.SubfieldIndexMainField);
-            if(val == null)
-            {
-                return null;
-            }
-
-            return (Convert.ToInt32(val));
-            
-        }
-
-        /// <summary>
-        /// Set EndPositionLat field
-        /// Units: semicircles</summary>
-        /// <param name="endPositionLat_">Nullable field value to be set</param>
-        public void SetEndPositionLat(int? endPositionLat_)
-        {
-            SetFieldValue(5, 0, endPositionLat_, Fit.SubfieldIndexMainField);
-        }
-        
-        ///<summary>
-        /// Retrieves the EndPositionLong field
-        /// Units: semicircles</summary>
-        /// <returns>Returns nullable int representing the EndPositionLong field</returns>
-        public int? GetEndPositionLong()
-        {
-            Object val = GetFieldValue(6, 0, Fit.SubfieldIndexMainField);
-            if(val == null)
-            {
-                return null;
-            }
-
-            return (Convert.ToInt32(val));
-            
-        }
-
-        /// <summary>
-        /// Set EndPositionLong field
-        /// Units: semicircles</summary>
-        /// <param name="endPositionLong_">Nullable field value to be set</param>
-        public void SetEndPositionLong(int? endPositionLong_)
-        {
-            SetFieldValue(6, 0, endPositionLong_, Fit.SubfieldIndexMainField);
-        }
-        
-        ///<summary>
-        /// Retrieves the TotalElapsedTime field
-        /// Units: s
-        /// Comment: Time (includes pauses)</summary>
-        /// <returns>Returns nullable float representing the TotalElapsedTime field</returns>
-        public float? GetTotalElapsedTime()
-        {
-            Object val = GetFieldValue(7, 0, Fit.SubfieldIndexMainField);
-            if(val == null)
-            {
-                return null;
-            }
-
-            return (Convert.ToSingle(val));
-            
-        }
-
-        /// <summary>
-        /// Set TotalElapsedTime field
-        /// Units: s
-        /// Comment: Time (includes pauses)</summary>
-        /// <param name="totalElapsedTime_">Nullable field value to be set</param>
-        public void SetTotalElapsedTime(float? totalElapsedTime_)
-        {
-            SetFieldValue(7, 0, totalElapsedTime_, Fit.SubfieldIndexMainField);
-        }
-        
-        ///<summary>
-        /// Retrieves the TotalTimerTime field
-        /// Units: s
-        /// Comment: Timer Time (excludes pauses)</summary>
-        /// <returns>Returns nullable float representing the TotalTimerTime field</returns>
-        public float? GetTotalTimerTime()
-        {
-            Object val = GetFieldValue(8, 0, Fit.SubfieldIndexMainField);
-            if(val == null)
-            {
-                return null;
-            }
-
-            return (Convert.ToSingle(val));
-            
-        }
-
-        /// <summary>
-        /// Set TotalTimerTime field
-        /// Units: s
-        /// Comment: Timer Time (excludes pauses)</summary>
-        /// <param name="totalTimerTime_">Nullable field value to be set</param>
-        public void SetTotalTimerTime(float? totalTimerTime_)
-        {
-            SetFieldValue(8, 0, totalTimerTime_, Fit.SubfieldIndexMainField);
-        }
-        
-        ///<summary>
-        /// Retrieves the TotalDistance field
-        /// Units: m</summary>
-        /// <returns>Returns nullable float representing the TotalDistance field</returns>
-        public float? GetTotalDistance()
-        {
-            Object val = GetFieldValue(9, 0, Fit.SubfieldIndexMainField);
-            if(val == null)
-            {
-                return null;
-            }
-
-            return (Convert.ToSingle(val));
-            
-        }
-
-        /// <summary>
-        /// Set TotalDistance field
-        /// Units: m</summary>
-        /// <param name="totalDistance_">Nullable field value to be set</param>
-        public void SetTotalDistance(float? totalDistance_)
-        {
-            SetFieldValue(9, 0, totalDistance_, Fit.SubfieldIndexMainField);
-        }
-        
-        ///<summary>
-        /// Retrieves the TotalCycles field
-        /// Units: cycles</summary>
-        /// <returns>Returns nullable uint representing the TotalCycles field</returns>
-        public uint? GetTotalCycles()
-        {
-            Object val = GetFieldValue(10, 0, Fit.SubfieldIndexMainField);
-            if(val == null)
-            {
-                return null;
-            }
-
-            return (Convert.ToUInt32(val));
-            
-        }
-
-        /// <summary>
-        /// Set TotalCycles field
-        /// Units: cycles</summary>
-        /// <param name="totalCycles_">Nullable field value to be set</param>
-        public void SetTotalCycles(uint? totalCycles_)
-        {
-            SetFieldValue(10, 0, totalCycles_, Fit.SubfieldIndexMainField);
-        }
-        
-
-        /// <summary>
-        /// Retrieves the TotalStrokes subfield
-        /// Units: strokes</summary>
-        /// <returns>Nullable uint representing the TotalStrokes subfield</returns>
-        public uint? GetTotalStrokes()
-        {
-            Object val = GetFieldValue(10, 0, TotalCyclesSubfield.TotalStrokes);
-            if(val == null)
-            {
-                return null;
-            }
-
-            return (Convert.ToUInt32(val));
-            
-        }
-
-        /// <summary>
-        ///
-        /// Set TotalStrokes subfield
-        /// Units: strokes</summary>
-        /// <param name="totalStrokes">Subfield value to be set</param>
-        public void SetTotalStrokes(uint? totalStrokes)
-        {
-            SetFieldValue(10, 0, totalStrokes, TotalCyclesSubfield.TotalStrokes);
-        }
-        ///<summary>
-        /// Retrieves the TotalCalories field
-        /// Units: kcal</summary>
-        /// <returns>Returns nullable ushort representing the TotalCalories field</returns>
-        public ushort? GetTotalCalories()
-        {
-            Object val = GetFieldValue(11, 0, Fit.SubfieldIndexMainField);
-            if(val == null)
-            {
-                return null;
-            }
-
-            return (Convert.ToUInt16(val));
-            
-        }
-
-        /// <summary>
-        /// Set TotalCalories field
-        /// Units: kcal</summary>
-        /// <param name="totalCalories_">Nullable field value to be set</param>
-        public void SetTotalCalories(ushort? totalCalories_)
-        {
-            SetFieldValue(11, 0, totalCalories_, Fit.SubfieldIndexMainField);
-        }
-        
-        ///<summary>
-        /// Retrieves the TotalFatCalories field
-        /// Units: kcal
-        /// Comment: If New Leaf</summary>
-        /// <returns>Returns nullable ushort representing the TotalFatCalories field</returns>
-        public ushort? GetTotalFatCalories()
-        {
-            Object val = GetFieldValue(12, 0, Fit.SubfieldIndexMainField);
-            if(val == null)
-            {
-                return null;
-            }
-
-            return (Convert.ToUInt16(val));
-            
-        }
-
-        /// <summary>
-        /// Set TotalFatCalories field
-        /// Units: kcal
-        /// Comment: If New Leaf</summary>
-        /// <param name="totalFatCalories_">Nullable field value to be set</param>
-        public void SetTotalFatCalories(ushort? totalFatCalories_)
-        {
-            SetFieldValue(12, 0, totalFatCalories_, Fit.SubfieldIndexMainField);
-        }
-        
-        ///<summary>
-        /// Retrieves the AvgSpeed field
-        /// Units: m/s</summary>
-        /// <returns>Returns nullable float representing the AvgSpeed field</returns>
-        public float? GetAvgSpeed()
-        {
-            Object val = GetFieldValue(13, 0, Fit.SubfieldIndexMainField);
-            if(val == null)
-            {
-                return null;
-            }
-
-            return (Convert.ToSingle(val));
-            
-        }
-
-        /// <summary>
-        /// Set AvgSpeed field
-        /// Units: m/s</summary>
-        /// <param name="avgSpeed_">Nullable field value to be set</param>
-        public void SetAvgSpeed(float? avgSpeed_)
-        {
-            SetFieldValue(13, 0, avgSpeed_, Fit.SubfieldIndexMainField);
-        }
-        
-        ///<summary>
-        /// Retrieves the MaxSpeed field
-        /// Units: m/s</summary>
-        /// <returns>Returns nullable float representing the MaxSpeed field</returns>
-        public float? GetMaxSpeed()
-        {
-            Object val = GetFieldValue(14, 0, Fit.SubfieldIndexMainField);
-            if(val == null)
-            {
-                return null;
-            }
-
-            return (Convert.ToSingle(val));
-            
-        }
-
-        /// <summary>
-        /// Set MaxSpeed field
-        /// Units: m/s</summary>
-        /// <param name="maxSpeed_">Nullable field value to be set</param>
-        public void SetMaxSpeed(float? maxSpeed_)
-        {
-            SetFieldValue(14, 0, maxSpeed_, Fit.SubfieldIndexMainField);
-        }
-        
-        ///<summary>
-        /// Retrieves the AvgHeartRate field
-        /// Units: bpm</summary>
-        /// <returns>Returns nullable byte representing the AvgHeartRate field</returns>
-        public byte? GetAvgHeartRate()
-        {
-            Object val = GetFieldValue(15, 0, Fit.SubfieldIndexMainField);
-            if(val == null)
-            {
-                return null;
-            }
-
-            return (Convert.ToByte(val));
-            
-        }
-
-        /// <summary>
-        /// Set AvgHeartRate field
-        /// Units: bpm</summary>
-        /// <param name="avgHeartRate_">Nullable field value to be set</param>
-        public void SetAvgHeartRate(byte? avgHeartRate_)
-        {
-            SetFieldValue(15, 0, avgHeartRate_, Fit.SubfieldIndexMainField);
-        }
-        
-        ///<summary>
-        /// Retrieves the MaxHeartRate field
-        /// Units: bpm</summary>
-        /// <returns>Returns nullable byte representing the MaxHeartRate field</returns>
-        public byte? GetMaxHeartRate()
-        {
-            Object val = GetFieldValue(16, 0, Fit.SubfieldIndexMainField);
-            if(val == null)
-            {
-                return null;
-            }
-
-            return (Convert.ToByte(val));
-            
-        }
-
-        /// <summary>
-        /// Set MaxHeartRate field
-        /// Units: bpm</summary>
-        /// <param name="maxHeartRate_">Nullable field value to be set</param>
-        public void SetMaxHeartRate(byte? maxHeartRate_)
-        {
-            SetFieldValue(16, 0, maxHeartRate_, Fit.SubfieldIndexMainField);
-        }
-        
-        ///<summary>
-        /// Retrieves the AvgCadence field
-        /// Units: rpm
-        /// Comment: total_cycles / total_timer_time if non_zero_avg_cadence otherwise total_cycles / total_elapsed_time</summary>
-        /// <returns>Returns nullable byte representing the AvgCadence field</returns>
-        public byte? GetAvgCadence()
-        {
-            Object val = GetFieldValue(17, 0, Fit.SubfieldIndexMainField);
-            if(val == null)
-            {
-                return null;
-            }
-
-            return (Convert.ToByte(val));
-            
-        }
-
-        /// <summary>
-        /// Set AvgCadence field
-        /// Units: rpm
-        /// Comment: total_cycles / total_timer_time if non_zero_avg_cadence otherwise total_cycles / total_elapsed_time</summary>
-        /// <param name="avgCadence_">Nullable field value to be set</param>
-        public void SetAvgCadence(byte? avgCadence_)
-        {
-            SetFieldValue(17, 0, avgCadence_, Fit.SubfieldIndexMainField);
-        }
-        
-        ///<summary>
-        /// Retrieves the MaxCadence field
-        /// Units: rpm</summary>
-        /// <returns>Returns nullable byte representing the MaxCadence field</returns>
-        public byte? GetMaxCadence()
-        {
-            Object val = GetFieldValue(18, 0, Fit.SubfieldIndexMainField);
-            if(val == null)
-            {
-                return null;
-            }
-
-            return (Convert.ToByte(val));
-            
-        }
-
-        /// <summary>
-        /// Set MaxCadence field
-        /// Units: rpm</summary>
-        /// <param name="maxCadence_">Nullable field value to be set</param>
-        public void SetMaxCadence(byte? maxCadence_)
-        {
-            SetFieldValue(18, 0, maxCadence_, Fit.SubfieldIndexMainField);
-        }
-        
-        ///<summary>
-        /// Retrieves the AvgPower field
-        /// Units: watts
-        /// Comment: total_power / total_timer_time if non_zero_avg_power otherwise total_power / total_elapsed_time</summary>
-        /// <returns>Returns nullable ushort representing the AvgPower field</returns>
-        public ushort? GetAvgPower()
-        {
-            Object val = GetFieldValue(19, 0, Fit.SubfieldIndexMainField);
-            if(val == null)
-            {
-                return null;
-            }
-
-            return (Convert.ToUInt16(val));
-            
-        }
-
-        /// <summary>
-        /// Set AvgPower field
-        /// Units: watts
-        /// Comment: total_power / total_timer_time if non_zero_avg_power otherwise total_power / total_elapsed_time</summary>
-        /// <param name="avgPower_">Nullable field value to be set</param>
-        public void SetAvgPower(ushort? avgPower_)
-        {
-            SetFieldValue(19, 0, avgPower_, Fit.SubfieldIndexMainField);
-        }
-        
-        ///<summary>
-        /// Retrieves the MaxPower field
-        /// Units: watts</summary>
-        /// <returns>Returns nullable ushort representing the MaxPower field</returns>
-        public ushort? GetMaxPower()
-        {
-            Object val = GetFieldValue(20, 0, Fit.SubfieldIndexMainField);
-            if(val == null)
-            {
-                return null;
-            }
-
-            return (Convert.ToUInt16(val));
-            
-        }
-
-        /// <summary>
-        /// Set MaxPower field
-        /// Units: watts</summary>
-        /// <param name="maxPower_">Nullable field value to be set</param>
-        public void SetMaxPower(ushort? maxPower_)
-        {
-            SetFieldValue(20, 0, maxPower_, Fit.SubfieldIndexMainField);
-        }
-        
-        ///<summary>
-        /// Retrieves the TotalAscent field
-        /// Units: m</summary>
-        /// <returns>Returns nullable ushort representing the TotalAscent field</returns>
-        public ushort? GetTotalAscent()
-        {
-            Object val = GetFieldValue(21, 0, Fit.SubfieldIndexMainField);
-            if(val == null)
-            {
-                return null;
-            }
-
-            return (Convert.ToUInt16(val));
-            
-        }
-
-        /// <summary>
-        /// Set TotalAscent field
-        /// Units: m</summary>
-        /// <param name="totalAscent_">Nullable field value to be set</param>
-        public void SetTotalAscent(ushort? totalAscent_)
-        {
-            SetFieldValue(21, 0, totalAscent_, Fit.SubfieldIndexMainField);
-        }
-        
-        ///<summary>
-        /// Retrieves the TotalDescent field
-        /// Units: m</summary>
-        /// <returns>Returns nullable ushort representing the TotalDescent field</returns>
-        public ushort? GetTotalDescent()
-        {
-            Object val = GetFieldValue(22, 0, Fit.SubfieldIndexMainField);
-            if(val == null)
-            {
-                return null;
-            }
-
-            return (Convert.ToUInt16(val));
-            
-        }
-
-        /// <summary>
-        /// Set TotalDescent field
-        /// Units: m</summary>
-        /// <param name="totalDescent_">Nullable field value to be set</param>
-        public void SetTotalDescent(ushort? totalDescent_)
-        {
-            SetFieldValue(22, 0, totalDescent_, Fit.SubfieldIndexMainField);
-        }
-        
-        ///<summary>
-        /// Retrieves the Sport field</summary>
-        /// <returns>Returns nullable Sport enum representing the Sport field</returns>
-        public Sport? GetSport()
-        {
-            object obj = GetFieldValue(23, 0, Fit.SubfieldIndexMainField);
-            Sport? value = obj == null ? (Sport?)null : (Sport)obj;
-            return value;
-        }
-
-        /// <summary>
-        /// Set Sport field</summary>
-        /// <param name="sport_">Nullable field value to be set</param>
-        public void SetSport(Sport? sport_)
-        {
-            SetFieldValue(23, 0, sport_, Fit.SubfieldIndexMainField);
-        }
-        
-        ///<summary>
-        /// Retrieves the EventGroup field</summary>
-        /// <returns>Returns nullable byte representing the EventGroup field</returns>
-        public byte? GetEventGroup()
-        {
-            Object val = GetFieldValue(24, 0, Fit.SubfieldIndexMainField);
-            if(val == null)
-            {
-                return null;
-            }
-
-            return (Convert.ToByte(val));
-            
-        }
-
-        /// <summary>
-        /// Set EventGroup field</summary>
-        /// <param name="eventGroup_">Nullable field value to be set</param>
-        public void SetEventGroup(byte? eventGroup_)
-        {
-            SetFieldValue(24, 0, eventGroup_, Fit.SubfieldIndexMainField);
-        }
-        
-        ///<summary>
-        /// Retrieves the NecLat field
-        /// Units: semicircles
-        /// Comment: North east corner latitude.</summary>
-        /// <returns>Returns nullable int representing the NecLat field</returns>
-        public int? GetNecLat()
-        {
-            Object val = GetFieldValue(25, 0, Fit.SubfieldIndexMainField);
-            if(val == null)
-            {
-                return null;
-            }
-
-            return (Convert.ToInt32(val));
-            
-        }
-
-        /// <summary>
-        /// Set NecLat field
-        /// Units: semicircles
-        /// Comment: North east corner latitude.</summary>
-        /// <param name="necLat_">Nullable field value to be set</param>
-        public void SetNecLat(int? necLat_)
-        {
-            SetFieldValue(25, 0, necLat_, Fit.SubfieldIndexMainField);
-        }
-        
-        ///<summary>
-        /// Retrieves the NecLong field
-        /// Units: semicircles
-        /// Comment: North east corner longitude.</summary>
-        /// <returns>Returns nullable int representing the NecLong field</returns>
-        public int? GetNecLong()
-        {
-            Object val = GetFieldValue(26, 0, Fit.SubfieldIndexMainField);
-            if(val == null)
-            {
-                return null;
-            }
-
-            return (Convert.ToInt32(val));
-            
-        }
-
-        /// <summary>
-        /// Set NecLong field
-        /// Units: semicircles
-        /// Comment: North east corner longitude.</summary>
-        /// <param name="necLong_">Nullable field value to be set</param>
-        public void SetNecLong(int? necLong_)
-        {
-            SetFieldValue(26, 0, necLong_, Fit.SubfieldIndexMainField);
-        }
-        
-        ///<summary>
-        /// Retrieves the SwcLat field
-        /// Units: semicircles
-        /// Comment: South west corner latitude.</summary>
-        /// <returns>Returns nullable int representing the SwcLat field</returns>
-        public int? GetSwcLat()
-        {
-            Object val = GetFieldValue(27, 0, Fit.SubfieldIndexMainField);
-            if(val == null)
-            {
-                return null;
-            }
-
-            return (Convert.ToInt32(val));
-            
-        }
-
-        /// <summary>
-        /// Set SwcLat field
-        /// Units: semicircles
-        /// Comment: South west corner latitude.</summary>
-        /// <param name="swcLat_">Nullable field value to be set</param>
-        public void SetSwcLat(int? swcLat_)
-        {
-            SetFieldValue(27, 0, swcLat_, Fit.SubfieldIndexMainField);
-        }
-        
-        ///<summary>
-        /// Retrieves the SwcLong field
-        /// Units: semicircles
-        /// Comment: South west corner latitude.</summary>
-        /// <returns>Returns nullable int representing the SwcLong field</returns>
-        public int? GetSwcLong()
-        {
-            Object val = GetFieldValue(28, 0, Fit.SubfieldIndexMainField);
-            if(val == null)
-            {
-                return null;
-            }
-
-            return (Convert.ToInt32(val));
-            
-        }
-
-        /// <summary>
-        /// Set SwcLong field
-        /// Units: semicircles
-        /// Comment: South west corner latitude.</summary>
-        /// <param name="swcLong_">Nullable field value to be set</param>
-        public void SetSwcLong(int? swcLong_)
-        {
-            SetFieldValue(28, 0, swcLong_, Fit.SubfieldIndexMainField);
-        }
-        
-        ///<summary>
-        /// Retrieves the Name field</summary>
-        /// <returns>Returns byte[] representing the Name field</returns>
-        public byte[] GetName()
-        {
-            byte[] data = (byte[])GetFieldValue(29, 0, Fit.SubfieldIndexMainField);
-            return data.Take(data.Length - 1).ToArray();
-        }
-
-        ///<summary>
-        /// Retrieves the Name field</summary>
-        /// <returns>Returns String representing the Name field</returns>
-        public String GetNameAsString()
-        {
-            byte[] data = (byte[])GetFieldValue(29, 0, Fit.SubfieldIndexMainField);
-            return data != null ? Encoding.UTF8.GetString(data, 0, data.Length - 1) : null;
-        }
-
-        ///<summary>
-        /// Set Name field</summary>
-        /// <param name="name_"> field value to be set</param>
-        public void SetName(String name_)
-        {
-            byte[] data = Encoding.UTF8.GetBytes(name_);
-            byte[] zdata = new byte[data.Length + 1];
-            data.CopyTo(zdata, 0);
-            SetFieldValue(29, 0, zdata, Fit.SubfieldIndexMainField);
-        }
-
-        
-        /// <summary>
-        /// Set Name field</summary>
-        /// <param name="name_">field value to be set</param>
-        public void SetName(byte[] name_)
-        {
-            SetFieldValue(29, 0, name_, Fit.SubfieldIndexMainField);
-        }
-        
-        ///<summary>
-        /// Retrieves the NormalizedPower field
-        /// Units: watts</summary>
-        /// <returns>Returns nullable ushort representing the NormalizedPower field</returns>
-        public ushort? GetNormalizedPower()
-        {
-            Object val = GetFieldValue(30, 0, Fit.SubfieldIndexMainField);
-            if(val == null)
-            {
-                return null;
-            }
-
-            return (Convert.ToUInt16(val));
-            
-        }
-
-        /// <summary>
-        /// Set NormalizedPower field
-        /// Units: watts</summary>
-        /// <param name="normalizedPower_">Nullable field value to be set</param>
-        public void SetNormalizedPower(ushort? normalizedPower_)
-        {
-            SetFieldValue(30, 0, normalizedPower_, Fit.SubfieldIndexMainField);
-        }
-        
-        ///<summary>
-        /// Retrieves the LeftRightBalance field</summary>
-        /// <returns>Returns nullable ushort representing the LeftRightBalance field</returns>
-        public ushort? GetLeftRightBalance()
-        {
-            Object val = GetFieldValue(31, 0, Fit.SubfieldIndexMainField);
-            if(val == null)
-            {
-                return null;
-            }
-
-            return (Convert.ToUInt16(val));
-            
-        }
-
-        /// <summary>
-        /// Set LeftRightBalance field</summary>
-        /// <param name="leftRightBalance_">Nullable field value to be set</param>
-        public void SetLeftRightBalance(ushort? leftRightBalance_)
-        {
-            SetFieldValue(31, 0, leftRightBalance_, Fit.SubfieldIndexMainField);
-        }
-        
-        ///<summary>
-        /// Retrieves the SubSport field</summary>
-        /// <returns>Returns nullable SubSport enum representing the SubSport field</returns>
-        public SubSport? GetSubSport()
-        {
-            object obj = GetFieldValue(32, 0, Fit.SubfieldIndexMainField);
-            SubSport? value = obj == null ? (SubSport?)null : (SubSport)obj;
-            return value;
-        }
-
-        /// <summary>
-        /// Set SubSport field</summary>
-        /// <param name="subSport_">Nullable field value to be set</param>
-        public void SetSubSport(SubSport? subSport_)
-        {
-            SetFieldValue(32, 0, subSport_, Fit.SubfieldIndexMainField);
-        }
-        
-        ///<summary>
-        /// Retrieves the TotalWork field
-        /// Units: J</summary>
-        /// <returns>Returns nullable uint representing the TotalWork field</returns>
-        public uint? GetTotalWork()
-        {
-            Object val = GetFieldValue(33, 0, Fit.SubfieldIndexMainField);
-            if(val == null)
-            {
-                return null;
-            }
-
-            return (Convert.ToUInt32(val));
-            
-        }
-
-        /// <summary>
-        /// Set TotalWork field
-        /// Units: J</summary>
-        /// <param name="totalWork_">Nullable field value to be set</param>
-        public void SetTotalWork(uint? totalWork_)
-        {
-            SetFieldValue(33, 0, totalWork_, Fit.SubfieldIndexMainField);
-        }
-        
-        ///<summary>
-        /// Retrieves the AvgAltitude field
-        /// Units: m</summary>
-        /// <returns>Returns nullable float representing the AvgAltitude field</returns>
-        public float? GetAvgAltitude()
-        {
-            Object val = GetFieldValue(34, 0, Fit.SubfieldIndexMainField);
-            if(val == null)
-            {
-                return null;
-            }
-
-            return (Convert.ToSingle(val));
-            
-        }
-
-        /// <summary>
-        /// Set AvgAltitude field
-        /// Units: m</summary>
-        /// <param name="avgAltitude_">Nullable field value to be set</param>
-        public void SetAvgAltitude(float? avgAltitude_)
-        {
-            SetFieldValue(34, 0, avgAltitude_, Fit.SubfieldIndexMainField);
-        }
-        
-        ///<summary>
-        /// Retrieves the MaxAltitude field
-        /// Units: m</summary>
-        /// <returns>Returns nullable float representing the MaxAltitude field</returns>
-        public float? GetMaxAltitude()
-        {
-            Object val = GetFieldValue(35, 0, Fit.SubfieldIndexMainField);
-            if(val == null)
-            {
-                return null;
-            }
-
-            return (Convert.ToSingle(val));
-            
-        }
-
-        /// <summary>
-        /// Set MaxAltitude field
-        /// Units: m</summary>
-        /// <param name="maxAltitude_">Nullable field value to be set</param>
-        public void SetMaxAltitude(float? maxAltitude_)
-        {
-            SetFieldValue(35, 0, maxAltitude_, Fit.SubfieldIndexMainField);
-        }
-        
-        ///<summary>
-        /// Retrieves the GpsAccuracy field
-        /// Units: m</summary>
-        /// <returns>Returns nullable byte representing the GpsAccuracy field</returns>
-        public byte? GetGpsAccuracy()
-        {
-            Object val = GetFieldValue(36, 0, Fit.SubfieldIndexMainField);
-            if(val == null)
-            {
-                return null;
-            }
-
-            return (Convert.ToByte(val));
-            
-        }
-
-        /// <summary>
-        /// Set GpsAccuracy field
-        /// Units: m</summary>
-        /// <param name="gpsAccuracy_">Nullable field value to be set</param>
-        public void SetGpsAccuracy(byte? gpsAccuracy_)
-        {
-            SetFieldValue(36, 0, gpsAccuracy_, Fit.SubfieldIndexMainField);
-        }
-        
-        ///<summary>
-        /// Retrieves the AvgGrade field
-        /// Units: %</summary>
-        /// <returns>Returns nullable float representing the AvgGrade field</returns>
-        public float? GetAvgGrade()
-        {
-            Object val = GetFieldValue(37, 0, Fit.SubfieldIndexMainField);
-            if(val == null)
-            {
-                return null;
-            }
-
-            return (Convert.ToSingle(val));
-            
-        }
-
-        /// <summary>
-        /// Set AvgGrade field
-        /// Units: %</summary>
-        /// <param name="avgGrade_">Nullable field value to be set</param>
-        public void SetAvgGrade(float? avgGrade_)
-        {
-            SetFieldValue(37, 0, avgGrade_, Fit.SubfieldIndexMainField);
-        }
-        
-        ///<summary>
-        /// Retrieves the AvgPosGrade field
-        /// Units: %</summary>
-        /// <returns>Returns nullable float representing the AvgPosGrade field</returns>
-        public float? GetAvgPosGrade()
-        {
-            Object val = GetFieldValue(38, 0, Fit.SubfieldIndexMainField);
-            if(val == null)
-            {
-                return null;
-            }
-
-            return (Convert.ToSingle(val));
-            
-        }
-
-        /// <summary>
-        /// Set AvgPosGrade field
-        /// Units: %</summary>
-        /// <param name="avgPosGrade_">Nullable field value to be set</param>
-        public void SetAvgPosGrade(float? avgPosGrade_)
-        {
-            SetFieldValue(38, 0, avgPosGrade_, Fit.SubfieldIndexMainField);
-        }
-        
-        ///<summary>
-        /// Retrieves the AvgNegGrade field
-        /// Units: %</summary>
-        /// <returns>Returns nullable float representing the AvgNegGrade field</returns>
-        public float? GetAvgNegGrade()
-        {
-            Object val = GetFieldValue(39, 0, Fit.SubfieldIndexMainField);
-            if(val == null)
-            {
-                return null;
-            }
-
-            return (Convert.ToSingle(val));
-            
-        }
-
-        /// <summary>
-        /// Set AvgNegGrade field
-        /// Units: %</summary>
-        /// <param name="avgNegGrade_">Nullable field value to be set</param>
-        public void SetAvgNegGrade(float? avgNegGrade_)
-        {
-            SetFieldValue(39, 0, avgNegGrade_, Fit.SubfieldIndexMainField);
-        }
-        
-        ///<summary>
-        /// Retrieves the MaxPosGrade field
-        /// Units: %</summary>
-        /// <returns>Returns nullable float representing the MaxPosGrade field</returns>
-        public float? GetMaxPosGrade()
-        {
-            Object val = GetFieldValue(40, 0, Fit.SubfieldIndexMainField);
-            if(val == null)
-            {
-                return null;
-            }
-
-            return (Convert.ToSingle(val));
-            
-        }
-
-        /// <summary>
-        /// Set MaxPosGrade field
-        /// Units: %</summary>
-        /// <param name="maxPosGrade_">Nullable field value to be set</param>
-        public void SetMaxPosGrade(float? maxPosGrade_)
-        {
-            SetFieldValue(40, 0, maxPosGrade_, Fit.SubfieldIndexMainField);
-        }
-        
-        ///<summary>
-        /// Retrieves the MaxNegGrade field
-        /// Units: %</summary>
-        /// <returns>Returns nullable float representing the MaxNegGrade field</returns>
-        public float? GetMaxNegGrade()
-        {
-            Object val = GetFieldValue(41, 0, Fit.SubfieldIndexMainField);
-            if(val == null)
-            {
-                return null;
-            }
-
-            return (Convert.ToSingle(val));
-            
-        }
-
-        /// <summary>
-        /// Set MaxNegGrade field
-        /// Units: %</summary>
-        /// <param name="maxNegGrade_">Nullable field value to be set</param>
-        public void SetMaxNegGrade(float? maxNegGrade_)
-        {
-            SetFieldValue(41, 0, maxNegGrade_, Fit.SubfieldIndexMainField);
-        }
-        
-        ///<summary>
-        /// Retrieves the AvgTemperature field
-        /// Units: C</summary>
-        /// <returns>Returns nullable sbyte representing the AvgTemperature field</returns>
-        public sbyte? GetAvgTemperature()
-        {
-            Object val = GetFieldValue(42, 0, Fit.SubfieldIndexMainField);
-            if(val == null)
-            {
-                return null;
-            }
-
-            return (Convert.ToSByte(val));
-            
-        }
-
-        /// <summary>
-        /// Set AvgTemperature field
-        /// Units: C</summary>
-        /// <param name="avgTemperature_">Nullable field value to be set</param>
-        public void SetAvgTemperature(sbyte? avgTemperature_)
-        {
-            SetFieldValue(42, 0, avgTemperature_, Fit.SubfieldIndexMainField);
-        }
-        
-        ///<summary>
-        /// Retrieves the MaxTemperature field
-        /// Units: C</summary>
-        /// <returns>Returns nullable sbyte representing the MaxTemperature field</returns>
-        public sbyte? GetMaxTemperature()
-        {
-            Object val = GetFieldValue(43, 0, Fit.SubfieldIndexMainField);
-            if(val == null)
-            {
-                return null;
-            }
-
-            return (Convert.ToSByte(val));
-            
-        }
-
-        /// <summary>
-        /// Set MaxTemperature field
-        /// Units: C</summary>
-        /// <param name="maxTemperature_">Nullable field value to be set</param>
-        public void SetMaxTemperature(sbyte? maxTemperature_)
-        {
-            SetFieldValue(43, 0, maxTemperature_, Fit.SubfieldIndexMainField);
-        }
-        
-        ///<summary>
-        /// Retrieves the TotalMovingTime field
-        /// Units: s</summary>
-        /// <returns>Returns nullable float representing the TotalMovingTime field</returns>
-        public float? GetTotalMovingTime()
-        {
-            Object val = GetFieldValue(44, 0, Fit.SubfieldIndexMainField);
-            if(val == null)
-            {
-                return null;
-            }
-
-            return (Convert.ToSingle(val));
-            
-        }
-
-        /// <summary>
-        /// Set TotalMovingTime field
-        /// Units: s</summary>
-        /// <param name="totalMovingTime_">Nullable field value to be set</param>
-        public void SetTotalMovingTime(float? totalMovingTime_)
-        {
-            SetFieldValue(44, 0, totalMovingTime_, Fit.SubfieldIndexMainField);
-        }
-        
-        ///<summary>
-        /// Retrieves the AvgPosVerticalSpeed field
-        /// Units: m/s</summary>
-        /// <returns>Returns nullable float representing the AvgPosVerticalSpeed field</returns>
-        public float? GetAvgPosVerticalSpeed()
-        {
-            Object val = GetFieldValue(45, 0, Fit.SubfieldIndexMainField);
-            if(val == null)
-            {
-                return null;
-            }
-
-            return (Convert.ToSingle(val));
-            
-        }
-
-        /// <summary>
-        /// Set AvgPosVerticalSpeed field
-        /// Units: m/s</summary>
-        /// <param name="avgPosVerticalSpeed_">Nullable field value to be set</param>
-        public void SetAvgPosVerticalSpeed(float? avgPosVerticalSpeed_)
-        {
-            SetFieldValue(45, 0, avgPosVerticalSpeed_, Fit.SubfieldIndexMainField);
-        }
-        
-        ///<summary>
-        /// Retrieves the AvgNegVerticalSpeed field
-        /// Units: m/s</summary>
-        /// <returns>Returns nullable float representing the AvgNegVerticalSpeed field</returns>
-        public float? GetAvgNegVerticalSpeed()
-        {
-            Object val = GetFieldValue(46, 0, Fit.SubfieldIndexMainField);
-            if(val == null)
-            {
-                return null;
-            }
-
-            return (Convert.ToSingle(val));
-            
-        }
-
-        /// <summary>
-        /// Set AvgNegVerticalSpeed field
-        /// Units: m/s</summary>
-        /// <param name="avgNegVerticalSpeed_">Nullable field value to be set</param>
-        public void SetAvgNegVerticalSpeed(float? avgNegVerticalSpeed_)
-        {
-            SetFieldValue(46, 0, avgNegVerticalSpeed_, Fit.SubfieldIndexMainField);
-        }
-        
-        ///<summary>
-        /// Retrieves the MaxPosVerticalSpeed field
-        /// Units: m/s</summary>
-        /// <returns>Returns nullable float representing the MaxPosVerticalSpeed field</returns>
-        public float? GetMaxPosVerticalSpeed()
-        {
-            Object val = GetFieldValue(47, 0, Fit.SubfieldIndexMainField);
-            if(val == null)
-            {
-                return null;
-            }
-
-            return (Convert.ToSingle(val));
-            
-        }
-
-        /// <summary>
-        /// Set MaxPosVerticalSpeed field
-        /// Units: m/s</summary>
-        /// <param name="maxPosVerticalSpeed_">Nullable field value to be set</param>
-        public void SetMaxPosVerticalSpeed(float? maxPosVerticalSpeed_)
-        {
-            SetFieldValue(47, 0, maxPosVerticalSpeed_, Fit.SubfieldIndexMainField);
-        }
-        
-        ///<summary>
-        /// Retrieves the MaxNegVerticalSpeed field
-        /// Units: m/s</summary>
-        /// <returns>Returns nullable float representing the MaxNegVerticalSpeed field</returns>
-        public float? GetMaxNegVerticalSpeed()
-        {
-            Object val = GetFieldValue(48, 0, Fit.SubfieldIndexMainField);
-            if(val == null)
-            {
-                return null;
-            }
-
-            return (Convert.ToSingle(val));
-            
-        }
-
-        /// <summary>
-        /// Set MaxNegVerticalSpeed field
-        /// Units: m/s</summary>
-        /// <param name="maxNegVerticalSpeed_">Nullable field value to be set</param>
-        public void SetMaxNegVerticalSpeed(float? maxNegVerticalSpeed_)
-        {
-            SetFieldValue(48, 0, maxNegVerticalSpeed_, Fit.SubfieldIndexMainField);
-        }
-        
-        
-        /// <summary>
-        ///
-        /// </summary>
-        /// <returns>returns number of elements in field TimeInHrZone</returns>
-        public int GetNumTimeInHrZone()
-        {
-            return GetNumFieldValues(49, Fit.SubfieldIndexMainField);
-        }
-
-        ///<summary>
-        /// Retrieves the TimeInHrZone field
-        /// Units: s</summary>
-        /// <param name="index">0 based index of TimeInHrZone element to retrieve</param>
-        /// <returns>Returns nullable float representing the TimeInHrZone field</returns>
-        public float? GetTimeInHrZone(int index)
-        {
-            Object val = GetFieldValue(49, index, Fit.SubfieldIndexMainField);
-            if(val == null)
-            {
-                return null;
-            }
-
-            return (Convert.ToSingle(val));
-            
-        }
-
-        /// <summary>
-        /// Set TimeInHrZone field
-        /// Units: s</summary>
-        /// <param name="index">0 based index of time_in_hr_zone</param>
-        /// <param name="timeInHrZone_">Nullable field value to be set</param>
-        public void SetTimeInHrZone(int index, float? timeInHrZone_)
-        {
-            SetFieldValue(49, index, timeInHrZone_, Fit.SubfieldIndexMainField);
-        }
-        
-        
-        /// <summary>
-        ///
-        /// </summary>
-        /// <returns>returns number of elements in field TimeInSpeedZone</returns>
-        public int GetNumTimeInSpeedZone()
-        {
-            return GetNumFieldValues(50, Fit.SubfieldIndexMainField);
-        }
-
-        ///<summary>
-        /// Retrieves the TimeInSpeedZone field
-        /// Units: s</summary>
-        /// <param name="index">0 based index of TimeInSpeedZone element to retrieve</param>
-        /// <returns>Returns nullable float representing the TimeInSpeedZone field</returns>
-        public float? GetTimeInSpeedZone(int index)
-        {
-            Object val = GetFieldValue(50, index, Fit.SubfieldIndexMainField);
-            if(val == null)
-            {
-                return null;
-            }
-
-            return (Convert.ToSingle(val));
-            
-        }
-
-        /// <summary>
-        /// Set TimeInSpeedZone field
-        /// Units: s</summary>
-        /// <param name="index">0 based index of time_in_speed_zone</param>
-        /// <param name="timeInSpeedZone_">Nullable field value to be set</param>
-        public void SetTimeInSpeedZone(int index, float? timeInSpeedZone_)
-        {
-            SetFieldValue(50, index, timeInSpeedZone_, Fit.SubfieldIndexMainField);
-        }
-        
-        
-        /// <summary>
-        ///
-        /// </summary>
-        /// <returns>returns number of elements in field TimeInCadenceZone</returns>
-        public int GetNumTimeInCadenceZone()
-        {
-            return GetNumFieldValues(51, Fit.SubfieldIndexMainField);
-        }
-
-        ///<summary>
-        /// Retrieves the TimeInCadenceZone field
-        /// Units: s</summary>
-        /// <param name="index">0 based index of TimeInCadenceZone element to retrieve</param>
-        /// <returns>Returns nullable float representing the TimeInCadenceZone field</returns>
-        public float? GetTimeInCadenceZone(int index)
-        {
-            Object val = GetFieldValue(51, index, Fit.SubfieldIndexMainField);
-            if(val == null)
-            {
-                return null;
-            }
-
-            return (Convert.ToSingle(val));
-            
-        }
-
-        /// <summary>
-        /// Set TimeInCadenceZone field
-        /// Units: s</summary>
-        /// <param name="index">0 based index of time_in_cadence_zone</param>
-        /// <param name="timeInCadenceZone_">Nullable field value to be set</param>
-        public void SetTimeInCadenceZone(int index, float? timeInCadenceZone_)
-        {
-            SetFieldValue(51, index, timeInCadenceZone_, Fit.SubfieldIndexMainField);
-        }
-        
-        
-        /// <summary>
-        ///
-        /// </summary>
-        /// <returns>returns number of elements in field TimeInPowerZone</returns>
-        public int GetNumTimeInPowerZone()
-        {
-            return GetNumFieldValues(52, Fit.SubfieldIndexMainField);
-        }
-
-        ///<summary>
-        /// Retrieves the TimeInPowerZone field
-        /// Units: s</summary>
-        /// <param name="index">0 based index of TimeInPowerZone element to retrieve</param>
-        /// <returns>Returns nullable float representing the TimeInPowerZone field</returns>
-        public float? GetTimeInPowerZone(int index)
-        {
-            Object val = GetFieldValue(52, index, Fit.SubfieldIndexMainField);
-            if(val == null)
-            {
-                return null;
-            }
-
-            return (Convert.ToSingle(val));
-            
-        }
-
-        /// <summary>
-        /// Set TimeInPowerZone field
-        /// Units: s</summary>
-        /// <param name="index">0 based index of time_in_power_zone</param>
-        /// <param name="timeInPowerZone_">Nullable field value to be set</param>
-        public void SetTimeInPowerZone(int index, float? timeInPowerZone_)
-        {
-            SetFieldValue(52, index, timeInPowerZone_, Fit.SubfieldIndexMainField);
-        }
-        
-        ///<summary>
-        /// Retrieves the RepetitionNum field</summary>
-        /// <returns>Returns nullable ushort representing the RepetitionNum field</returns>
-        public ushort? GetRepetitionNum()
-        {
-            Object val = GetFieldValue(53, 0, Fit.SubfieldIndexMainField);
-            if(val == null)
-            {
-                return null;
-            }
-
-            return (Convert.ToUInt16(val));
-            
-        }
-
-        /// <summary>
-        /// Set RepetitionNum field</summary>
-        /// <param name="repetitionNum_">Nullable field value to be set</param>
-        public void SetRepetitionNum(ushort? repetitionNum_)
-        {
-            SetFieldValue(53, 0, repetitionNum_, Fit.SubfieldIndexMainField);
-        }
-        
-        ///<summary>
-        /// Retrieves the MinAltitude field
-        /// Units: m</summary>
-        /// <returns>Returns nullable float representing the MinAltitude field</returns>
-        public float? GetMinAltitude()
-        {
-            Object val = GetFieldValue(54, 0, Fit.SubfieldIndexMainField);
-            if(val == null)
-            {
-                return null;
-            }
-
-            return (Convert.ToSingle(val));
-            
-        }
-
-        /// <summary>
-        /// Set MinAltitude field
-        /// Units: m</summary>
-        /// <param name="minAltitude_">Nullable field value to be set</param>
-        public void SetMinAltitude(float? minAltitude_)
-        {
-            SetFieldValue(54, 0, minAltitude_, Fit.SubfieldIndexMainField);
-        }
-        
-        ///<summary>
-        /// Retrieves the MinHeartRate field
-        /// Units: bpm</summary>
-        /// <returns>Returns nullable byte representing the MinHeartRate field</returns>
-        public byte? GetMinHeartRate()
-        {
-            Object val = GetFieldValue(55, 0, Fit.SubfieldIndexMainField);
-            if(val == null)
-            {
-                return null;
-            }
-
-            return (Convert.ToByte(val));
-            
-        }
-
-        /// <summary>
-        /// Set MinHeartRate field
-        /// Units: bpm</summary>
-        /// <param name="minHeartRate_">Nullable field value to be set</param>
-        public void SetMinHeartRate(byte? minHeartRate_)
-        {
-            SetFieldValue(55, 0, minHeartRate_, Fit.SubfieldIndexMainField);
-        }
-        
-        ///<summary>
-        /// Retrieves the ActiveTime field
-        /// Units: s</summary>
-        /// <returns>Returns nullable float representing the ActiveTime field</returns>
-        public float? GetActiveTime()
-        {
-            Object val = GetFieldValue(56, 0, Fit.SubfieldIndexMainField);
-            if(val == null)
-            {
-                return null;
-            }
-
-            return (Convert.ToSingle(val));
-            
-        }
-
-        /// <summary>
-        /// Set ActiveTime field
-        /// Units: s</summary>
-        /// <param name="activeTime_">Nullable field value to be set</param>
-        public void SetActiveTime(float? activeTime_)
-        {
-            SetFieldValue(56, 0, activeTime_, Fit.SubfieldIndexMainField);
-        }
-        
-        ///<summary>
-        /// Retrieves the WktStepIndex field</summary>
-        /// <returns>Returns nullable ushort representing the WktStepIndex field</returns>
-        public ushort? GetWktStepIndex()
-        {
-            Object val = GetFieldValue(57, 0, Fit.SubfieldIndexMainField);
-            if(val == null)
-            {
-                return null;
-            }
-
-            return (Convert.ToUInt16(val));
-            
-        }
-
-        /// <summary>
-        /// Set WktStepIndex field</summary>
-        /// <param name="wktStepIndex_">Nullable field value to be set</param>
-        public void SetWktStepIndex(ushort? wktStepIndex_)
-        {
-            SetFieldValue(57, 0, wktStepIndex_, Fit.SubfieldIndexMainField);
-        }
-        
-        ///<summary>
-        /// Retrieves the SportEvent field</summary>
-        /// <returns>Returns nullable SportEvent enum representing the SportEvent field</returns>
-        public SportEvent? GetSportEvent()
-        {
-            object obj = GetFieldValue(58, 0, Fit.SubfieldIndexMainField);
-            SportEvent? value = obj == null ? (SportEvent?)null : (SportEvent)obj;
-            return value;
-        }
-
-        /// <summary>
-        /// Set SportEvent field</summary>
-        /// <param name="sportEvent_">Nullable field value to be set</param>
-        public void SetSportEvent(SportEvent? sportEvent_)
-        {
-            SetFieldValue(58, 0, sportEvent_, Fit.SubfieldIndexMainField);
-        }
-        
-        ///<summary>
-        /// Retrieves the AvgLeftTorqueEffectiveness field
-        /// Units: percent</summary>
-        /// <returns>Returns nullable float representing the AvgLeftTorqueEffectiveness field</returns>
-        public float? GetAvgLeftTorqueEffectiveness()
-        {
-            Object val = GetFieldValue(59, 0, Fit.SubfieldIndexMainField);
-            if(val == null)
-            {
-                return null;
-            }
-
-            return (Convert.ToSingle(val));
-            
-        }
-
-        /// <summary>
-        /// Set AvgLeftTorqueEffectiveness field
-        /// Units: percent</summary>
-        /// <param name="avgLeftTorqueEffectiveness_">Nullable field value to be set</param>
-        public void SetAvgLeftTorqueEffectiveness(float? avgLeftTorqueEffectiveness_)
-        {
-            SetFieldValue(59, 0, avgLeftTorqueEffectiveness_, Fit.SubfieldIndexMainField);
-        }
-        
-        ///<summary>
-        /// Retrieves the AvgRightTorqueEffectiveness field
-        /// Units: percent</summary>
-        /// <returns>Returns nullable float representing the AvgRightTorqueEffectiveness field</returns>
-        public float? GetAvgRightTorqueEffectiveness()
-        {
-            Object val = GetFieldValue(60, 0, Fit.SubfieldIndexMainField);
-            if(val == null)
-            {
-                return null;
-            }
-
-            return (Convert.ToSingle(val));
-            
-        }
-
-        /// <summary>
-        /// Set AvgRightTorqueEffectiveness field
-        /// Units: percent</summary>
-        /// <param name="avgRightTorqueEffectiveness_">Nullable field value to be set</param>
-        public void SetAvgRightTorqueEffectiveness(float? avgRightTorqueEffectiveness_)
-        {
-            SetFieldValue(60, 0, avgRightTorqueEffectiveness_, Fit.SubfieldIndexMainField);
-        }
-        
-        ///<summary>
-        /// Retrieves the AvgLeftPedalSmoothness field
-        /// Units: percent</summary>
-        /// <returns>Returns nullable float representing the AvgLeftPedalSmoothness field</returns>
-        public float? GetAvgLeftPedalSmoothness()
-        {
-            Object val = GetFieldValue(61, 0, Fit.SubfieldIndexMainField);
-            if(val == null)
-            {
-                return null;
-            }
-
-            return (Convert.ToSingle(val));
-            
-        }
-
-        /// <summary>
-        /// Set AvgLeftPedalSmoothness field
-        /// Units: percent</summary>
-        /// <param name="avgLeftPedalSmoothness_">Nullable field value to be set</param>
-        public void SetAvgLeftPedalSmoothness(float? avgLeftPedalSmoothness_)
-        {
-            SetFieldValue(61, 0, avgLeftPedalSmoothness_, Fit.SubfieldIndexMainField);
-        }
-        
-        ///<summary>
-        /// Retrieves the AvgRightPedalSmoothness field
-        /// Units: percent</summary>
-        /// <returns>Returns nullable float representing the AvgRightPedalSmoothness field</returns>
-        public float? GetAvgRightPedalSmoothness()
-        {
-            Object val = GetFieldValue(62, 0, Fit.SubfieldIndexMainField);
-            if(val == null)
-            {
-                return null;
-            }
-
-            return (Convert.ToSingle(val));
-            
-        }
-
-        /// <summary>
-        /// Set AvgRightPedalSmoothness field
-        /// Units: percent</summary>
-        /// <param name="avgRightPedalSmoothness_">Nullable field value to be set</param>
-        public void SetAvgRightPedalSmoothness(float? avgRightPedalSmoothness_)
-        {
-            SetFieldValue(62, 0, avgRightPedalSmoothness_, Fit.SubfieldIndexMainField);
-        }
-        
-        ///<summary>
-        /// Retrieves the AvgCombinedPedalSmoothness field
-        /// Units: percent</summary>
-        /// <returns>Returns nullable float representing the AvgCombinedPedalSmoothness field</returns>
-        public float? GetAvgCombinedPedalSmoothness()
-        {
-            Object val = GetFieldValue(63, 0, Fit.SubfieldIndexMainField);
-            if(val == null)
-            {
-                return null;
-            }
-
-            return (Convert.ToSingle(val));
-            
-        }
-
-        /// <summary>
-        /// Set AvgCombinedPedalSmoothness field
-        /// Units: percent</summary>
-        /// <param name="avgCombinedPedalSmoothness_">Nullable field value to be set</param>
-        public void SetAvgCombinedPedalSmoothness(float? avgCombinedPedalSmoothness_)
-        {
-            SetFieldValue(63, 0, avgCombinedPedalSmoothness_, Fit.SubfieldIndexMainField);
-        }
-        
-        ///<summary>
-        /// Retrieves the Status field</summary>
-        /// <returns>Returns nullable SegmentLapStatus enum representing the Status field</returns>
-        public SegmentLapStatus? GetStatus()
-        {
-            object obj = GetFieldValue(64, 0, Fit.SubfieldIndexMainField);
-            SegmentLapStatus? value = obj == null ? (SegmentLapStatus?)null : (SegmentLapStatus)obj;
-            return value;
-        }
-
-        /// <summary>
-        /// Set Status field</summary>
-        /// <param name="status_">Nullable field value to be set</param>
-        public void SetStatus(SegmentLapStatus? status_)
-        {
-            SetFieldValue(64, 0, status_, Fit.SubfieldIndexMainField);
-        }
-        
-        ///<summary>
-        /// Retrieves the Uuid field</summary>
-        /// <returns>Returns byte[] representing the Uuid field</returns>
-        public byte[] GetUuid()
-        {
-            byte[] data = (byte[])GetFieldValue(65, 0, Fit.SubfieldIndexMainField);
-            return data.Take(data.Length - 1).ToArray();
-        }
-
-        ///<summary>
-        /// Retrieves the Uuid field</summary>
-        /// <returns>Returns String representing the Uuid field</returns>
-        public String GetUuidAsString()
-        {
-            byte[] data = (byte[])GetFieldValue(65, 0, Fit.SubfieldIndexMainField);
-            return data != null ? Encoding.UTF8.GetString(data, 0, data.Length - 1) : null;
-        }
-
-        ///<summary>
-        /// Set Uuid field</summary>
-        /// <param name="uuid_"> field value to be set</param>
-        public void SetUuid(String uuid_)
-        {
-            byte[] data = Encoding.UTF8.GetBytes(uuid_);
-            byte[] zdata = new byte[data.Length + 1];
-            data.CopyTo(zdata, 0);
-            SetFieldValue(65, 0, zdata, Fit.SubfieldIndexMainField);
-        }
-
-        
-        /// <summary>
-        /// Set Uuid field</summary>
-        /// <param name="uuid_">field value to be set</param>
-        public void SetUuid(byte[] uuid_)
-        {
-            SetFieldValue(65, 0, uuid_, Fit.SubfieldIndexMainField);
-        }
-        
-        ///<summary>
-        /// Retrieves the AvgFractionalCadence field
-        /// Units: rpm
-        /// Comment: fractional part of the avg_cadence</summary>
-        /// <returns>Returns nullable float representing the AvgFractionalCadence field</returns>
-        public float? GetAvgFractionalCadence()
-        {
-            Object val = GetFieldValue(66, 0, Fit.SubfieldIndexMainField);
-            if(val == null)
-            {
-                return null;
-            }
-
-            return (Convert.ToSingle(val));
-            
-        }
-
-        /// <summary>
-        /// Set AvgFractionalCadence field
-        /// Units: rpm
-        /// Comment: fractional part of the avg_cadence</summary>
-        /// <param name="avgFractionalCadence_">Nullable field value to be set</param>
-        public void SetAvgFractionalCadence(float? avgFractionalCadence_)
-        {
-            SetFieldValue(66, 0, avgFractionalCadence_, Fit.SubfieldIndexMainField);
-        }
-        
-        ///<summary>
-        /// Retrieves the MaxFractionalCadence field
-        /// Units: rpm
-        /// Comment: fractional part of the max_cadence</summary>
-        /// <returns>Returns nullable float representing the MaxFractionalCadence field</returns>
-        public float? GetMaxFractionalCadence()
-        {
-            Object val = GetFieldValue(67, 0, Fit.SubfieldIndexMainField);
-            if(val == null)
-            {
-                return null;
-            }
-
-            return (Convert.ToSingle(val));
-            
-        }
-
-        /// <summary>
-        /// Set MaxFractionalCadence field
-        /// Units: rpm
-        /// Comment: fractional part of the max_cadence</summary>
-        /// <param name="maxFractionalCadence_">Nullable field value to be set</param>
-        public void SetMaxFractionalCadence(float? maxFractionalCadence_)
-        {
-            SetFieldValue(67, 0, maxFractionalCadence_, Fit.SubfieldIndexMainField);
-        }
-        
-        ///<summary>
-        /// Retrieves the TotalFractionalCycles field
-        /// Units: cycles
-        /// Comment: fractional part of the total_cycles</summary>
-        /// <returns>Returns nullable float representing the TotalFractionalCycles field</returns>
-        public float? GetTotalFractionalCycles()
-        {
-            Object val = GetFieldValue(68, 0, Fit.SubfieldIndexMainField);
-            if(val == null)
-            {
-                return null;
-            }
-
-            return (Convert.ToSingle(val));
-            
-        }
-
-        /// <summary>
-        /// Set TotalFractionalCycles field
-        /// Units: cycles
-        /// Comment: fractional part of the total_cycles</summary>
-        /// <param name="totalFractionalCycles_">Nullable field value to be set</param>
-        public void SetTotalFractionalCycles(float? totalFractionalCycles_)
-        {
-            SetFieldValue(68, 0, totalFractionalCycles_, Fit.SubfieldIndexMainField);
-        }
-        
-        ///<summary>
-        /// Retrieves the FrontGearShiftCount field</summary>
-        /// <returns>Returns nullable ushort representing the FrontGearShiftCount field</returns>
-        public ushort? GetFrontGearShiftCount()
-        {
-            Object val = GetFieldValue(69, 0, Fit.SubfieldIndexMainField);
-            if(val == null)
-            {
-                return null;
-            }
-
-            return (Convert.ToUInt16(val));
-            
-        }
-
-        /// <summary>
-        /// Set FrontGearShiftCount field</summary>
-        /// <param name="frontGearShiftCount_">Nullable field value to be set</param>
-        public void SetFrontGearShiftCount(ushort? frontGearShiftCount_)
-        {
-            SetFieldValue(69, 0, frontGearShiftCount_, Fit.SubfieldIndexMainField);
-        }
-        
-        ///<summary>
-        /// Retrieves the RearGearShiftCount field</summary>
-        /// <returns>Returns nullable ushort representing the RearGearShiftCount field</returns>
-        public ushort? GetRearGearShiftCount()
-        {
-            Object val = GetFieldValue(70, 0, Fit.SubfieldIndexMainField);
-            if(val == null)
-            {
-                return null;
-            }
-
-            return (Convert.ToUInt16(val));
-            
-        }
-
-        /// <summary>
-        /// Set RearGearShiftCount field</summary>
-        /// <param name="rearGearShiftCount_">Nullable field value to be set</param>
-        public void SetRearGearShiftCount(ushort? rearGearShiftCount_)
-        {
-            SetFieldValue(70, 0, rearGearShiftCount_, Fit.SubfieldIndexMainField);
-        }
-        
-        ///<summary>
-        /// Retrieves the TimeStanding field
-        /// Units: s
-        /// Comment: Total time spent in the standing position</summary>
-        /// <returns>Returns nullable float representing the TimeStanding field</returns>
-        public float? GetTimeStanding()
-        {
-            Object val = GetFieldValue(71, 0, Fit.SubfieldIndexMainField);
-            if(val == null)
-            {
-                return null;
-            }
-
-            return (Convert.ToSingle(val));
-            
-        }
-
-        /// <summary>
-        /// Set TimeStanding field
-        /// Units: s
-        /// Comment: Total time spent in the standing position</summary>
-        /// <param name="timeStanding_">Nullable field value to be set</param>
-        public void SetTimeStanding(float? timeStanding_)
-        {
-            SetFieldValue(71, 0, timeStanding_, Fit.SubfieldIndexMainField);
-        }
-        
-        ///<summary>
-        /// Retrieves the StandCount field
-        /// Comment: Number of transitions to the standing state</summary>
-        /// <returns>Returns nullable ushort representing the StandCount field</returns>
-        public ushort? GetStandCount()
-        {
-            Object val = GetFieldValue(72, 0, Fit.SubfieldIndexMainField);
-            if(val == null)
-            {
-                return null;
-            }
-
-            return (Convert.ToUInt16(val));
-            
-        }
-
-        /// <summary>
-        /// Set StandCount field
-        /// Comment: Number of transitions to the standing state</summary>
-        /// <param name="standCount_">Nullable field value to be set</param>
-        public void SetStandCount(ushort? standCount_)
-        {
-            SetFieldValue(72, 0, standCount_, Fit.SubfieldIndexMainField);
-        }
-        
-        ///<summary>
-        /// Retrieves the AvgLeftPco field
-        /// Units: mm
-        /// Comment: Average left platform center offset</summary>
-        /// <returns>Returns nullable sbyte representing the AvgLeftPco field</returns>
-        public sbyte? GetAvgLeftPco()
-        {
-            Object val = GetFieldValue(73, 0, Fit.SubfieldIndexMainField);
-            if(val == null)
-            {
-                return null;
-            }
-
-            return (Convert.ToSByte(val));
-            
-        }
-
-        /// <summary>
-        /// Set AvgLeftPco field
-        /// Units: mm
-        /// Comment: Average left platform center offset</summary>
-        /// <param name="avgLeftPco_">Nullable field value to be set</param>
-        public void SetAvgLeftPco(sbyte? avgLeftPco_)
-        {
-            SetFieldValue(73, 0, avgLeftPco_, Fit.SubfieldIndexMainField);
-        }
-        
-        ///<summary>
-        /// Retrieves the AvgRightPco field
-        /// Units: mm
-        /// Comment: Average right platform center offset</summary>
-        /// <returns>Returns nullable sbyte representing the AvgRightPco field</returns>
-        public sbyte? GetAvgRightPco()
-        {
-            Object val = GetFieldValue(74, 0, Fit.SubfieldIndexMainField);
-            if(val == null)
-            {
-                return null;
-            }
-
-            return (Convert.ToSByte(val));
-            
-        }
-
-        /// <summary>
-        /// Set AvgRightPco field
-        /// Units: mm
-        /// Comment: Average right platform center offset</summary>
-        /// <param name="avgRightPco_">Nullable field value to be set</param>
-        public void SetAvgRightPco(sbyte? avgRightPco_)
-        {
-            SetFieldValue(74, 0, avgRightPco_, Fit.SubfieldIndexMainField);
-        }
-        
-        
-        /// <summary>
-        ///
-        /// </summary>
-        /// <returns>returns number of elements in field AvgLeftPowerPhase</returns>
-        public int GetNumAvgLeftPowerPhase()
-        {
-            return GetNumFieldValues(75, Fit.SubfieldIndexMainField);
-        }
-
-        ///<summary>
-        /// Retrieves the AvgLeftPowerPhase field
-        /// Units: degrees
-        /// Comment: Average left power phase angles. Data value indexes defined by power_phase_type.</summary>
-        /// <param name="index">0 based index of AvgLeftPowerPhase element to retrieve</param>
-        /// <returns>Returns nullable float representing the AvgLeftPowerPhase field</returns>
-        public float? GetAvgLeftPowerPhase(int index)
-        {
-            Object val = GetFieldValue(75, index, Fit.SubfieldIndexMainField);
-            if(val == null)
-            {
-                return null;
-            }
-
-            return (Convert.ToSingle(val));
-            
-        }
-
-        /// <summary>
-        /// Set AvgLeftPowerPhase field
-        /// Units: degrees
-        /// Comment: Average left power phase angles. Data value indexes defined by power_phase_type.</summary>
-        /// <param name="index">0 based index of avg_left_power_phase</param>
-        /// <param name="avgLeftPowerPhase_">Nullable field value to be set</param>
-        public void SetAvgLeftPowerPhase(int index, float? avgLeftPowerPhase_)
-        {
-            SetFieldValue(75, index, avgLeftPowerPhase_, Fit.SubfieldIndexMainField);
-        }
-        
-        
-        /// <summary>
-        ///
-        /// </summary>
-        /// <returns>returns number of elements in field AvgLeftPowerPhasePeak</returns>
-        public int GetNumAvgLeftPowerPhasePeak()
-        {
-            return GetNumFieldValues(76, Fit.SubfieldIndexMainField);
-        }
-
-        ///<summary>
-        /// Retrieves the AvgLeftPowerPhasePeak field
-        /// Units: degrees
-        /// Comment: Average left power phase peak angles. Data value indexes defined by power_phase_type.</summary>
-        /// <param name="index">0 based index of AvgLeftPowerPhasePeak element to retrieve</param>
-        /// <returns>Returns nullable float representing the AvgLeftPowerPhasePeak field</returns>
-        public float? GetAvgLeftPowerPhasePeak(int index)
-        {
-            Object val = GetFieldValue(76, index, Fit.SubfieldIndexMainField);
-            if(val == null)
-            {
-                return null;
-            }
-
-            return (Convert.ToSingle(val));
-            
-        }
-
-        /// <summary>
-        /// Set AvgLeftPowerPhasePeak field
-        /// Units: degrees
-        /// Comment: Average left power phase peak angles. Data value indexes defined by power_phase_type.</summary>
-        /// <param name="index">0 based index of avg_left_power_phase_peak</param>
-        /// <param name="avgLeftPowerPhasePeak_">Nullable field value to be set</param>
-        public void SetAvgLeftPowerPhasePeak(int index, float? avgLeftPowerPhasePeak_)
-        {
-            SetFieldValue(76, index, avgLeftPowerPhasePeak_, Fit.SubfieldIndexMainField);
-        }
-        
-        
-        /// <summary>
-        ///
-        /// </summary>
-        /// <returns>returns number of elements in field AvgRightPowerPhase</returns>
-        public int GetNumAvgRightPowerPhase()
-        {
-            return GetNumFieldValues(77, Fit.SubfieldIndexMainField);
-        }
-
-        ///<summary>
-        /// Retrieves the AvgRightPowerPhase field
-        /// Units: degrees
-        /// Comment: Average right power phase angles. Data value indexes defined by power_phase_type.</summary>
-        /// <param name="index">0 based index of AvgRightPowerPhase element to retrieve</param>
-        /// <returns>Returns nullable float representing the AvgRightPowerPhase field</returns>
-        public float? GetAvgRightPowerPhase(int index)
-        {
-            Object val = GetFieldValue(77, index, Fit.SubfieldIndexMainField);
-            if(val == null)
-            {
-                return null;
-            }
-
-            return (Convert.ToSingle(val));
-            
-        }
-
-        /// <summary>
-        /// Set AvgRightPowerPhase field
-        /// Units: degrees
-        /// Comment: Average right power phase angles. Data value indexes defined by power_phase_type.</summary>
-        /// <param name="index">0 based index of avg_right_power_phase</param>
-        /// <param name="avgRightPowerPhase_">Nullable field value to be set</param>
-        public void SetAvgRightPowerPhase(int index, float? avgRightPowerPhase_)
-        {
-            SetFieldValue(77, index, avgRightPowerPhase_, Fit.SubfieldIndexMainField);
-        }
-        
-        
-        /// <summary>
-        ///
-        /// </summary>
-        /// <returns>returns number of elements in field AvgRightPowerPhasePeak</returns>
-        public int GetNumAvgRightPowerPhasePeak()
-        {
-            return GetNumFieldValues(78, Fit.SubfieldIndexMainField);
-        }
-
-        ///<summary>
-        /// Retrieves the AvgRightPowerPhasePeak field
-        /// Units: degrees
-        /// Comment: Average right power phase peak angles. Data value indexes defined by power_phase_type.</summary>
-        /// <param name="index">0 based index of AvgRightPowerPhasePeak element to retrieve</param>
-        /// <returns>Returns nullable float representing the AvgRightPowerPhasePeak field</returns>
-        public float? GetAvgRightPowerPhasePeak(int index)
-        {
-            Object val = GetFieldValue(78, index, Fit.SubfieldIndexMainField);
-            if(val == null)
-            {
-                return null;
-            }
-
-            return (Convert.ToSingle(val));
-            
-        }
-
-        /// <summary>
-        /// Set AvgRightPowerPhasePeak field
-        /// Units: degrees
-        /// Comment: Average right power phase peak angles. Data value indexes defined by power_phase_type.</summary>
-        /// <param name="index">0 based index of avg_right_power_phase_peak</param>
-        /// <param name="avgRightPowerPhasePeak_">Nullable field value to be set</param>
-        public void SetAvgRightPowerPhasePeak(int index, float? avgRightPowerPhasePeak_)
-        {
-            SetFieldValue(78, index, avgRightPowerPhasePeak_, Fit.SubfieldIndexMainField);
-        }
-        
-        
-        /// <summary>
-        ///
-        /// </summary>
-        /// <returns>returns number of elements in field AvgPowerPosition</returns>
-        public int GetNumAvgPowerPosition()
-        {
-            return GetNumFieldValues(79, Fit.SubfieldIndexMainField);
-        }
-
-        ///<summary>
-        /// Retrieves the AvgPowerPosition field
-        /// Units: watts
-        /// Comment: Average power by position. Data value indexes defined by rider_position_type.</summary>
-        /// <param name="index">0 based index of AvgPowerPosition element to retrieve</param>
-        /// <returns>Returns nullable ushort representing the AvgPowerPosition field</returns>
-        public ushort? GetAvgPowerPosition(int index)
-        {
-            Object val = GetFieldValue(79, index, Fit.SubfieldIndexMainField);
-            if(val == null)
-            {
-                return null;
-            }
-
-            return (Convert.ToUInt16(val));
-            
-        }
-
-        /// <summary>
-        /// Set AvgPowerPosition field
-        /// Units: watts
-        /// Comment: Average power by position. Data value indexes defined by rider_position_type.</summary>
-        /// <param name="index">0 based index of avg_power_position</param>
-        /// <param name="avgPowerPosition_">Nullable field value to be set</param>
-        public void SetAvgPowerPosition(int index, ushort? avgPowerPosition_)
-        {
-            SetFieldValue(79, index, avgPowerPosition_, Fit.SubfieldIndexMainField);
-        }
-        
-        
-        /// <summary>
-        ///
-        /// </summary>
-        /// <returns>returns number of elements in field MaxPowerPosition</returns>
-        public int GetNumMaxPowerPosition()
-        {
-            return GetNumFieldValues(80, Fit.SubfieldIndexMainField);
-        }
-
-        ///<summary>
-        /// Retrieves the MaxPowerPosition field
-        /// Units: watts
-        /// Comment: Maximum power by position. Data value indexes defined by rider_position_type.</summary>
-        /// <param name="index">0 based index of MaxPowerPosition element to retrieve</param>
-        /// <returns>Returns nullable ushort representing the MaxPowerPosition field</returns>
-        public ushort? GetMaxPowerPosition(int index)
-        {
-            Object val = GetFieldValue(80, index, Fit.SubfieldIndexMainField);
-            if(val == null)
-            {
-                return null;
-            }
-
-            return (Convert.ToUInt16(val));
-            
-        }
-
-        /// <summary>
-        /// Set MaxPowerPosition field
-        /// Units: watts
-        /// Comment: Maximum power by position. Data value indexes defined by rider_position_type.</summary>
-        /// <param name="index">0 based index of max_power_position</param>
-        /// <param name="maxPowerPosition_">Nullable field value to be set</param>
-        public void SetMaxPowerPosition(int index, ushort? maxPowerPosition_)
-        {
-            SetFieldValue(80, index, maxPowerPosition_, Fit.SubfieldIndexMainField);
-        }
-        
-        
-        /// <summary>
-        ///
-        /// </summary>
-        /// <returns>returns number of elements in field AvgCadencePosition</returns>
-        public int GetNumAvgCadencePosition()
-        {
-            return GetNumFieldValues(81, Fit.SubfieldIndexMainField);
-        }
-
-        ///<summary>
-        /// Retrieves the AvgCadencePosition field
-        /// Units: rpm
-        /// Comment: Average cadence by position. Data value indexes defined by rider_position_type.</summary>
-        /// <param name="index">0 based index of AvgCadencePosition element to retrieve</param>
-        /// <returns>Returns nullable byte representing the AvgCadencePosition field</returns>
-        public byte? GetAvgCadencePosition(int index)
-        {
-            Object val = GetFieldValue(81, index, Fit.SubfieldIndexMainField);
-            if(val == null)
-            {
-                return null;
-            }
-
-            return (Convert.ToByte(val));
-            
-        }
-
-        /// <summary>
-        /// Set AvgCadencePosition field
-        /// Units: rpm
-        /// Comment: Average cadence by position. Data value indexes defined by rider_position_type.</summary>
-        /// <param name="index">0 based index of avg_cadence_position</param>
-        /// <param name="avgCadencePosition_">Nullable field value to be set</param>
-        public void SetAvgCadencePosition(int index, byte? avgCadencePosition_)
-        {
-            SetFieldValue(81, index, avgCadencePosition_, Fit.SubfieldIndexMainField);
-        }
-        
-        
-        /// <summary>
-        ///
-        /// </summary>
-        /// <returns>returns number of elements in field MaxCadencePosition</returns>
-        public int GetNumMaxCadencePosition()
-        {
-            return GetNumFieldValues(82, Fit.SubfieldIndexMainField);
-        }
-
-        ///<summary>
-        /// Retrieves the MaxCadencePosition field
-        /// Units: rpm
-        /// Comment: Maximum cadence by position. Data value indexes defined by rider_position_type.</summary>
-        /// <param name="index">0 based index of MaxCadencePosition element to retrieve</param>
-        /// <returns>Returns nullable byte representing the MaxCadencePosition field</returns>
-        public byte? GetMaxCadencePosition(int index)
-        {
-            Object val = GetFieldValue(82, index, Fit.SubfieldIndexMainField);
-            if(val == null)
-            {
-                return null;
-            }
-
-            return (Convert.ToByte(val));
-            
-        }
-
-        /// <summary>
-        /// Set MaxCadencePosition field
-        /// Units: rpm
-        /// Comment: Maximum cadence by position. Data value indexes defined by rider_position_type.</summary>
-        /// <param name="index">0 based index of max_cadence_position</param>
-        /// <param name="maxCadencePosition_">Nullable field value to be set</param>
-        public void SetMaxCadencePosition(int index, byte? maxCadencePosition_)
-        {
-            SetFieldValue(82, index, maxCadencePosition_, Fit.SubfieldIndexMainField);
-        }
-        
-        ///<summary>
-        /// Retrieves the Manufacturer field
-        /// Comment: Manufacturer that produced the segment</summary>
-        /// <returns>Returns nullable ushort representing the Manufacturer field</returns>
-        public ushort? GetManufacturer()
-        {
-            Object val = GetFieldValue(83, 0, Fit.SubfieldIndexMainField);
-            if(val == null)
-            {
-                return null;
-            }
-
-            return (Convert.ToUInt16(val));
-            
-        }
-
-        /// <summary>
-        /// Set Manufacturer field
-        /// Comment: Manufacturer that produced the segment</summary>
-        /// <param name="manufacturer_">Nullable field value to be set</param>
-        public void SetManufacturer(ushort? manufacturer_)
-        {
-            SetFieldValue(83, 0, manufacturer_, Fit.SubfieldIndexMainField);
-        }
-        
-        ///<summary>
-        /// Retrieves the TotalGrit field
-        /// Units: kGrit
-        /// Comment: The grit score estimates how challenging a route could be for a cyclist in terms of time spent going over sharp turns or large grade slopes.</summary>
-        /// <returns>Returns nullable float representing the TotalGrit field</returns>
-        public float? GetTotalGrit()
-        {
-            Object val = GetFieldValue(84, 0, Fit.SubfieldIndexMainField);
-            if(val == null)
-            {
-                return null;
-            }
-
-            return (Convert.ToSingle(val));
-            
-        }
-
-        /// <summary>
-        /// Set TotalGrit field
-        /// Units: kGrit
-        /// Comment: The grit score estimates how challenging a route could be for a cyclist in terms of time spent going over sharp turns or large grade slopes.</summary>
-        /// <param name="totalGrit_">Nullable field value to be set</param>
-        public void SetTotalGrit(float? totalGrit_)
-        {
-            SetFieldValue(84, 0, totalGrit_, Fit.SubfieldIndexMainField);
-        }
-        
-        ///<summary>
-        /// Retrieves the TotalFlow field
-        /// Units: Flow
-        /// Comment: The flow score estimates how long distance wise a cyclist deaccelerates over intervals where deacceleration is unnecessary such as smooth turns or small grade angle intervals.</summary>
-        /// <returns>Returns nullable float representing the TotalFlow field</returns>
-        public float? GetTotalFlow()
-        {
-            Object val = GetFieldValue(85, 0, Fit.SubfieldIndexMainField);
-            if(val == null)
-            {
-                return null;
-            }
-
-            return (Convert.ToSingle(val));
-            
-        }
-
-        /// <summary>
-        /// Set TotalFlow field
-        /// Units: Flow
-        /// Comment: The flow score estimates how long distance wise a cyclist deaccelerates over intervals where deacceleration is unnecessary such as smooth turns or small grade angle intervals.</summary>
-        /// <param name="totalFlow_">Nullable field value to be set</param>
-        public void SetTotalFlow(float? totalFlow_)
-        {
-            SetFieldValue(85, 0, totalFlow_, Fit.SubfieldIndexMainField);
-        }
-        
-        ///<summary>
-        /// Retrieves the AvgGrit field
-        /// Units: kGrit
-        /// Comment: The grit score estimates how challenging a route could be for a cyclist in terms of time spent going over sharp turns or large grade slopes.</summary>
-        /// <returns>Returns nullable float representing the AvgGrit field</returns>
-        public float? GetAvgGrit()
-        {
-            Object val = GetFieldValue(86, 0, Fit.SubfieldIndexMainField);
-            if(val == null)
-            {
-                return null;
-            }
-
-            return (Convert.ToSingle(val));
-            
-        }
-
-        /// <summary>
-        /// Set AvgGrit field
-        /// Units: kGrit
-        /// Comment: The grit score estimates how challenging a route could be for a cyclist in terms of time spent going over sharp turns or large grade slopes.</summary>
-        /// <param name="avgGrit_">Nullable field value to be set</param>
-        public void SetAvgGrit(float? avgGrit_)
-        {
-            SetFieldValue(86, 0, avgGrit_, Fit.SubfieldIndexMainField);
-        }
-        
-        ///<summary>
-        /// Retrieves the AvgFlow field
-        /// Units: Flow
-        /// Comment: The flow score estimates how long distance wise a cyclist deaccelerates over intervals where deacceleration is unnecessary such as smooth turns or small grade angle intervals.</summary>
-        /// <returns>Returns nullable float representing the AvgFlow field</returns>
-        public float? GetAvgFlow()
-        {
-            Object val = GetFieldValue(87, 0, Fit.SubfieldIndexMainField);
-            if(val == null)
-            {
-                return null;
-            }
-
-            return (Convert.ToSingle(val));
-            
-        }
-
-        /// <summary>
-        /// Set AvgFlow field
-        /// Units: Flow
-        /// Comment: The flow score estimates how long distance wise a cyclist deaccelerates over intervals where deacceleration is unnecessary such as smooth turns or small grade angle intervals.</summary>
-        /// <param name="avgFlow_">Nullable field value to be set</param>
-        public void SetAvgFlow(float? avgFlow_)
-        {
-            SetFieldValue(87, 0, avgFlow_, Fit.SubfieldIndexMainField);
-        }
-        
-        ///<summary>
-        /// Retrieves the TotalFractionalAscent field
-        /// Units: m
-        /// Comment: fractional part of total_ascent</summary>
-        /// <returns>Returns nullable float representing the TotalFractionalAscent field</returns>
-        public float? GetTotalFractionalAscent()
-        {
-            Object val = GetFieldValue(89, 0, Fit.SubfieldIndexMainField);
-            if(val == null)
-            {
-                return null;
-            }
-
-            return (Convert.ToSingle(val));
-            
-        }
-
-        /// <summary>
-        /// Set TotalFractionalAscent field
-        /// Units: m
-        /// Comment: fractional part of total_ascent</summary>
-        /// <param name="totalFractionalAscent_">Nullable field value to be set</param>
-        public void SetTotalFractionalAscent(float? totalFractionalAscent_)
-        {
-            SetFieldValue(89, 0, totalFractionalAscent_, Fit.SubfieldIndexMainField);
-        }
-        
-        ///<summary>
-        /// Retrieves the TotalFractionalDescent field
-        /// Units: m
-        /// Comment: fractional part of total_descent</summary>
-        /// <returns>Returns nullable float representing the TotalFractionalDescent field</returns>
-        public float? GetTotalFractionalDescent()
-        {
-            Object val = GetFieldValue(90, 0, Fit.SubfieldIndexMainField);
-            if(val == null)
-            {
-                return null;
-            }
-
-            return (Convert.ToSingle(val));
-            
-        }
-
-        /// <summary>
-        /// Set TotalFractionalDescent field
-        /// Units: m
-        /// Comment: fractional part of total_descent</summary>
-        /// <param name="totalFractionalDescent_">Nullable field value to be set</param>
-        public void SetTotalFractionalDescent(float? totalFractionalDescent_)
-        {
-            SetFieldValue(90, 0, totalFractionalDescent_, Fit.SubfieldIndexMainField);
-        }
-        
-        ///<summary>
-        /// Retrieves the EnhancedAvgAltitude field
-        /// Units: m</summary>
-        /// <returns>Returns nullable float representing the EnhancedAvgAltitude field</returns>
-        public float? GetEnhancedAvgAltitude()
-        {
-            Object val = GetFieldValue(91, 0, Fit.SubfieldIndexMainField);
-            if(val == null)
-            {
-                return null;
-            }
-
-            return (Convert.ToSingle(val));
-            
-        }
-
-        /// <summary>
-        /// Set EnhancedAvgAltitude field
-        /// Units: m</summary>
-        /// <param name="enhancedAvgAltitude_">Nullable field value to be set</param>
-        public void SetEnhancedAvgAltitude(float? enhancedAvgAltitude_)
-        {
-            SetFieldValue(91, 0, enhancedAvgAltitude_, Fit.SubfieldIndexMainField);
-        }
-        
-        ///<summary>
-        /// Retrieves the EnhancedMaxAltitude field
-        /// Units: m</summary>
-        /// <returns>Returns nullable float representing the EnhancedMaxAltitude field</returns>
-        public float? GetEnhancedMaxAltitude()
-        {
-            Object val = GetFieldValue(92, 0, Fit.SubfieldIndexMainField);
-            if(val == null)
-            {
-                return null;
-            }
-
-            return (Convert.ToSingle(val));
-            
-        }
-
-        /// <summary>
-        /// Set EnhancedMaxAltitude field
-        /// Units: m</summary>
-        /// <param name="enhancedMaxAltitude_">Nullable field value to be set</param>
-        public void SetEnhancedMaxAltitude(float? enhancedMaxAltitude_)
-        {
-            SetFieldValue(92, 0, enhancedMaxAltitude_, Fit.SubfieldIndexMainField);
-        }
-        
-        ///<summary>
-        /// Retrieves the EnhancedMinAltitude field
-        /// Units: m</summary>
-        /// <returns>Returns nullable float representing the EnhancedMinAltitude field</returns>
-        public float? GetEnhancedMinAltitude()
-        {
-            Object val = GetFieldValue(93, 0, Fit.SubfieldIndexMainField);
-            if(val == null)
-            {
-                return null;
-            }
-
-            return (Convert.ToSingle(val));
-            
-        }
-
-        /// <summary>
-        /// Set EnhancedMinAltitude field
-        /// Units: m</summary>
-        /// <param name="enhancedMinAltitude_">Nullable field value to be set</param>
-        public void SetEnhancedMinAltitude(float? enhancedMinAltitude_)
-        {
-            SetFieldValue(93, 0, enhancedMinAltitude_, Fit.SubfieldIndexMainField);
-        }
-        
-        #endregion // Methods
-    } // Class
+	/// <summary>
+	/// Implements the SegmentLap profile message.
+	/// </summary>
+	public class SegmentLapMesg : Mesg
+	{
+		#region Fields
+		static class TotalCyclesSubfield
+		{
+			public static ushort TotalStrokes = 0;
+			public static ushort Subfields = 1;
+			public static ushort Active = Fit.SubfieldIndexActiveSubfield;
+			public static ushort MainField = Fit.SubfieldIndexMainField;
+		}
+		#endregion
+
+		/// <summary>
+		/// Field Numbers for <see cref="SegmentLapMesg"/>
+		/// </summary>
+		public sealed class FieldDefNum
+		{
+			public const byte MessageIndex = 254;
+			public const byte Timestamp = 253;
+			public const byte Event = 0;
+			public const byte EventType = 1;
+			public const byte StartTime = 2;
+			public const byte StartPositionLat = 3;
+			public const byte StartPositionLong = 4;
+			public const byte EndPositionLat = 5;
+			public const byte EndPositionLong = 6;
+			public const byte TotalElapsedTime = 7;
+			public const byte TotalTimerTime = 8;
+			public const byte TotalDistance = 9;
+			public const byte TotalCycles = 10;
+			public const byte TotalCalories = 11;
+			public const byte TotalFatCalories = 12;
+			public const byte AvgSpeed = 13;
+			public const byte MaxSpeed = 14;
+			public const byte AvgHeartRate = 15;
+			public const byte MaxHeartRate = 16;
+			public const byte AvgCadence = 17;
+			public const byte MaxCadence = 18;
+			public const byte AvgPower = 19;
+			public const byte MaxPower = 20;
+			public const byte TotalAscent = 21;
+			public const byte TotalDescent = 22;
+			public const byte Sport = 23;
+			public const byte EventGroup = 24;
+			public const byte NecLat = 25;
+			public const byte NecLong = 26;
+			public const byte SwcLat = 27;
+			public const byte SwcLong = 28;
+			public const byte Name = 29;
+			public const byte NormalizedPower = 30;
+			public const byte LeftRightBalance = 31;
+			public const byte SubSport = 32;
+			public const byte TotalWork = 33;
+			public const byte AvgAltitude = 34;
+			public const byte MaxAltitude = 35;
+			public const byte GpsAccuracy = 36;
+			public const byte AvgGrade = 37;
+			public const byte AvgPosGrade = 38;
+			public const byte AvgNegGrade = 39;
+			public const byte MaxPosGrade = 40;
+			public const byte MaxNegGrade = 41;
+			public const byte AvgTemperature = 42;
+			public const byte MaxTemperature = 43;
+			public const byte TotalMovingTime = 44;
+			public const byte AvgPosVerticalSpeed = 45;
+			public const byte AvgNegVerticalSpeed = 46;
+			public const byte MaxPosVerticalSpeed = 47;
+			public const byte MaxNegVerticalSpeed = 48;
+			public const byte TimeInHrZone = 49;
+			public const byte TimeInSpeedZone = 50;
+			public const byte TimeInCadenceZone = 51;
+			public const byte TimeInPowerZone = 52;
+			public const byte RepetitionNum = 53;
+			public const byte MinAltitude = 54;
+			public const byte MinHeartRate = 55;
+			public const byte ActiveTime = 56;
+			public const byte WktStepIndex = 57;
+			public const byte SportEvent = 58;
+			public const byte AvgLeftTorqueEffectiveness = 59;
+			public const byte AvgRightTorqueEffectiveness = 60;
+			public const byte AvgLeftPedalSmoothness = 61;
+			public const byte AvgRightPedalSmoothness = 62;
+			public const byte AvgCombinedPedalSmoothness = 63;
+			public const byte Status = 64;
+			public const byte Uuid = 65;
+			public const byte AvgFractionalCadence = 66;
+			public const byte MaxFractionalCadence = 67;
+			public const byte TotalFractionalCycles = 68;
+			public const byte FrontGearShiftCount = 69;
+			public const byte RearGearShiftCount = 70;
+			public const byte TimeStanding = 71;
+			public const byte StandCount = 72;
+			public const byte AvgLeftPco = 73;
+			public const byte AvgRightPco = 74;
+			public const byte AvgLeftPowerPhase = 75;
+			public const byte AvgLeftPowerPhasePeak = 76;
+			public const byte AvgRightPowerPhase = 77;
+			public const byte AvgRightPowerPhasePeak = 78;
+			public const byte AvgPowerPosition = 79;
+			public const byte MaxPowerPosition = 80;
+			public const byte AvgCadencePosition = 81;
+			public const byte MaxCadencePosition = 82;
+			public const byte Manufacturer = 83;
+			public const byte TotalGrit = 84;
+			public const byte TotalFlow = 85;
+			public const byte AvgGrit = 86;
+			public const byte AvgFlow = 87;
+			public const byte TotalFractionalAscent = 89;
+			public const byte TotalFractionalDescent = 90;
+			public const byte EnhancedAvgAltitude = 91;
+			public const byte EnhancedMaxAltitude = 92;
+			public const byte EnhancedMinAltitude = 93;
+			public const byte Invalid = Fit.FieldNumInvalid;
+		}
+
+		#region Constructors
+		public SegmentLapMesg() : base(Profile.GetMesg(MesgNum.SegmentLap))
+		{
+		}
+
+		public SegmentLapMesg(Mesg mesg) : base(mesg)
+		{
+		}
+		#endregion // Constructors
+
+		#region Methods
+		///<summary>
+		/// Retrieves the MessageIndex field</summary>
+		/// <returns>Returns nullable ushort representing the MessageIndex field</returns>
+		public ushort? MessageIndex
+		{
+			get
+			{
+				Object val = GetFieldValue(254, 0, Fit.SubfieldIndexMainField);
+				if (val == null)
+				{
+					return null;
+				}
+
+				return (Convert.ToUInt16(val));
+
+			}
+			set
+			{
+				SetFieldValue(254, 0, value, Fit.SubfieldIndexMainField);
+			}
+		}
+
+		///<summary>
+		/// Retrieves the Timestamp field
+		/// Units: s
+		/// Comment: Lap end time.</summary>
+		/// <returns>Returns DateTime representing the Timestamp field</returns>
+		public DateTime Timestamp
+		{
+			get
+			{
+				Object val = GetFieldValue(253, 0, Fit.SubfieldIndexMainField);
+				if (val == null)
+				{
+					return null;
+				}
+
+				return TimestampToDateTime(Convert.ToUInt32(val));
+
+			}
+			set
+			{
+				SetFieldValue(253, 0, value.GetTimeStamp(), Fit.SubfieldIndexMainField);
+			}
+		}
+
+		///<summary>
+		/// Retrieves the Event field</summary>
+		/// <returns>Returns nullable Event enum representing the Event field</returns>
+		public Event? Event
+		{
+			get
+			{
+				object obj = GetFieldValue(0, 0, Fit.SubfieldIndexMainField);
+				Event? value = obj == null ? (Event?)null : (Event)obj;
+				return value;
+			}
+			set
+			{
+				SetFieldValue(0, 0, value, Fit.SubfieldIndexMainField);
+			}
+		}
+
+		///<summary>
+		/// Retrieves the EventType field</summary>
+		/// <returns>Returns nullable EventType enum representing the EventType field</returns>
+		public EventType? EventType
+		{
+			get
+			{
+				object obj = GetFieldValue(1, 0, Fit.SubfieldIndexMainField);
+				EventType? value = obj == null ? (EventType?)null : (EventType)obj;
+				return value;
+			}
+			set
+			{
+				SetFieldValue(1, 0, value, Fit.SubfieldIndexMainField);
+			}
+		}
+
+		///<summary>
+		/// Retrieves the StartTime field</summary>
+		/// <returns>Returns DateTime representing the StartTime field</returns>
+		public DateTime StartTime
+		{
+			get
+			{
+				Object val = GetFieldValue(2, 0, Fit.SubfieldIndexMainField);
+				if (val == null)
+				{
+					return null;
+				}
+
+				return TimestampToDateTime(Convert.ToUInt32(val));
+
+			}
+			set
+			{
+				SetFieldValue(2, 0, value.GetTimeStamp(), Fit.SubfieldIndexMainField);
+			}
+		}
+
+		///<summary>
+		/// Retrieves the StartPositionLat field
+		/// Units: semicircles</summary>
+		/// <returns>Returns nullable int representing the StartPositionLat field</returns>
+		public int? StartPositionLat
+		{
+			get
+			{
+				Object val = GetFieldValue(3, 0, Fit.SubfieldIndexMainField);
+				if (val == null)
+				{
+					return null;
+				}
+
+				return (Convert.ToInt32(val));
+
+			}
+			set
+			{
+				SetFieldValue(3, 0, value, Fit.SubfieldIndexMainField);
+			}
+		}
+
+		///<summary>
+		/// Retrieves the StartPositionLong field
+		/// Units: semicircles</summary>
+		/// <returns>Returns nullable int representing the StartPositionLong field</returns>
+		public int? StartPositionLong
+		{
+			get
+			{
+				Object val = GetFieldValue(4, 0, Fit.SubfieldIndexMainField);
+				if (val == null)
+				{
+					return null;
+				}
+
+				return (Convert.ToInt32(val));
+
+			}
+			set
+			{
+				SetFieldValue(4, 0, value, Fit.SubfieldIndexMainField);
+			}
+		}
+
+		///<summary>
+		/// Retrieves the EndPositionLat field
+		/// Units: semicircles</summary>
+		/// <returns>Returns nullable int representing the EndPositionLat field</returns>
+		public int? EndPositionLat
+		{
+			get
+			{
+				Object val = GetFieldValue(5, 0, Fit.SubfieldIndexMainField);
+				if (val == null)
+				{
+					return null;
+				}
+
+				return (Convert.ToInt32(val));
+
+			}
+			set
+			{
+				SetFieldValue(5, 0, value, Fit.SubfieldIndexMainField);
+			}
+		}
+
+		///<summary>
+		/// Retrieves the EndPositionLong field
+		/// Units: semicircles</summary>
+		/// <returns>Returns nullable int representing the EndPositionLong field</returns>
+		public int? EndPositionLong
+		{
+			get
+			{
+				Object val = GetFieldValue(6, 0, Fit.SubfieldIndexMainField);
+				if (val == null)
+				{
+					return null;
+				}
+
+				return (Convert.ToInt32(val));
+
+			}
+			set
+			{
+				SetFieldValue(6, 0, value, Fit.SubfieldIndexMainField);
+			}
+		}
+
+		///<summary>
+		/// Retrieves the TotalElapsedTime field
+		/// Units: s
+		/// Comment: Time (includes pauses)</summary>
+		/// <returns>Returns nullable float representing the TotalElapsedTime field</returns>
+		public float? TotalElapsedTime
+		{
+			get
+			{
+				Object val = GetFieldValue(7, 0, Fit.SubfieldIndexMainField);
+				if (val == null)
+				{
+					return null;
+				}
+
+				return (Convert.ToSingle(val));
+
+			}
+			set
+			{
+				SetFieldValue(7, 0, value, Fit.SubfieldIndexMainField);
+			}
+		}
+
+		///<summary>
+		/// Retrieves the TotalTimerTime field
+		/// Units: s
+		/// Comment: Timer Time (excludes pauses)</summary>
+		/// <returns>Returns nullable float representing the TotalTimerTime field</returns>
+		public float? TotalTimerTime
+		{
+			get
+			{
+				Object val = GetFieldValue(8, 0, Fit.SubfieldIndexMainField);
+				if (val == null)
+				{
+					return null;
+				}
+
+				return (Convert.ToSingle(val));
+
+			}
+			set
+			{
+				SetFieldValue(8, 0, value, Fit.SubfieldIndexMainField);
+			}
+		}
+
+		///<summary>
+		/// Retrieves the TotalDistance field
+		/// Units: m</summary>
+		/// <returns>Returns nullable float representing the TotalDistance field</returns>
+		public float? TotalDistance
+		{
+			get
+			{
+				Object val = GetFieldValue(9, 0, Fit.SubfieldIndexMainField);
+				if (val == null)
+				{
+					return null;
+				}
+
+				return (Convert.ToSingle(val));
+
+			}
+			set
+			{
+				SetFieldValue(9, 0, value, Fit.SubfieldIndexMainField);
+			}
+		}
+
+		///<summary>
+		/// Retrieves the TotalCycles field
+		/// Units: cycles</summary>
+		/// <returns>Returns nullable uint representing the TotalCycles field</returns>
+		public uint? TotalCycles
+		{
+			get
+			{
+				Object val = GetFieldValue(10, 0, Fit.SubfieldIndexMainField);
+				if (val == null)
+				{
+					return null;
+				}
+
+				return (Convert.ToUInt32(val));
+
+			}
+			set
+			{
+				SetFieldValue(10, 0, value, Fit.SubfieldIndexMainField);
+			}
+		}
+
+
+		/// <summary>
+		/// Retrieves the TotalStrokes subfield
+		/// Units: strokes</summary>
+		/// <returns>Nullable uint representing the TotalStrokes subfield</returns>
+		public uint? TotalStrokes
+		{
+			get
+			{
+				Object val = GetFieldValue(10, 0, TotalCyclesSubfield.TotalStrokes);
+				if (val == null)
+				{
+					return null;
+				}
+
+				return (Convert.ToUInt32(val));
+
+			}
+			set
+			{
+				SetFieldValue(10, 0, value, TotalCyclesSubfield.TotalStrokes);
+			}
+		}
+		///<summary>
+		/// Retrieves the TotalCalories field
+		/// Units: kcal</summary>
+		/// <returns>Returns nullable ushort representing the TotalCalories field</returns>
+		public ushort? TotalCalories
+		{
+			get
+			{
+				Object val = GetFieldValue(11, 0, Fit.SubfieldIndexMainField);
+				if (val == null)
+				{
+					return null;
+				}
+
+				return (Convert.ToUInt16(val));
+
+			}
+			set
+			{
+				SetFieldValue(11, 0, value, Fit.SubfieldIndexMainField);
+			}
+		}
+
+		///<summary>
+		/// Retrieves the TotalFatCalories field
+		/// Units: kcal
+		/// Comment: If New Leaf</summary>
+		/// <returns>Returns nullable ushort representing the TotalFatCalories field</returns>
+		public ushort? TotalFatCalories
+		{
+			get
+			{
+				Object val = GetFieldValue(12, 0, Fit.SubfieldIndexMainField);
+				if (val == null)
+				{
+					return null;
+				}
+
+				return (Convert.ToUInt16(val));
+
+			}
+			set
+			{
+				SetFieldValue(12, 0, value, Fit.SubfieldIndexMainField);
+			}
+		}
+
+		///<summary>
+		/// Retrieves the AvgSpeed field
+		/// Units: m/s</summary>
+		/// <returns>Returns nullable float representing the AvgSpeed field</returns>
+		public float? AvgSpeed
+		{
+			get
+			{
+				Object val = GetFieldValue(13, 0, Fit.SubfieldIndexMainField);
+				if (val == null)
+				{
+					return null;
+				}
+
+				return (Convert.ToSingle(val));
+
+			}
+			set
+			{
+				SetFieldValue(13, 0, value, Fit.SubfieldIndexMainField);
+			}
+		}
+
+		///<summary>
+		/// Retrieves the MaxSpeed field
+		/// Units: m/s</summary>
+		/// <returns>Returns nullable float representing the MaxSpeed field</returns>
+		public float? MaxSpeed
+		{
+			get
+			{
+				Object val = GetFieldValue(14, 0, Fit.SubfieldIndexMainField);
+				if (val == null)
+				{
+					return null;
+				}
+
+				return (Convert.ToSingle(val));
+
+			}
+			set
+			{
+				SetFieldValue(14, 0, value, Fit.SubfieldIndexMainField);
+			}
+		}
+
+		///<summary>
+		/// Retrieves the AvgHeartRate field
+		/// Units: bpm</summary>
+		/// <returns>Returns nullable byte representing the AvgHeartRate field</returns>
+		public byte? AvgHeartRate
+		{
+			get
+			{
+				Object val = GetFieldValue(15, 0, Fit.SubfieldIndexMainField);
+				if (val == null)
+				{
+					return null;
+				}
+
+				return (Convert.ToByte(val));
+
+			}
+			set
+			{
+				SetFieldValue(15, 0, value, Fit.SubfieldIndexMainField);
+			}
+		}
+
+		///<summary>
+		/// Retrieves the MaxHeartRate field
+		/// Units: bpm</summary>
+		/// <returns>Returns nullable byte representing the MaxHeartRate field</returns>
+		public byte? MaxHeartRate
+		{
+			get
+			{
+				Object val = GetFieldValue(16, 0, Fit.SubfieldIndexMainField);
+				if (val == null)
+				{
+					return null;
+				}
+
+				return (Convert.ToByte(val));
+
+			}
+			set
+			{
+				SetFieldValue(16, 0, value, Fit.SubfieldIndexMainField);
+			}
+		}
+
+		///<summary>
+		/// Retrieves the AvgCadence field
+		/// Units: rpm
+		/// Comment: total_cycles / total_timer_time if non_zero_avg_cadence otherwise total_cycles / total_elapsed_time</summary>
+		/// <returns>Returns nullable byte representing the AvgCadence field</returns>
+		public byte? AvgCadence
+		{
+			get
+			{
+				Object val = GetFieldValue(17, 0, Fit.SubfieldIndexMainField);
+				if (val == null)
+				{
+					return null;
+				}
+
+				return (Convert.ToByte(val));
+
+			}
+			set
+			{
+				SetFieldValue(17, 0, value, Fit.SubfieldIndexMainField);
+			}
+		}
+
+		///<summary>
+		/// Retrieves the MaxCadence field
+		/// Units: rpm</summary>
+		/// <returns>Returns nullable byte representing the MaxCadence field</returns>
+		public byte? MaxCadence
+		{
+			get
+			{
+				Object val = GetFieldValue(18, 0, Fit.SubfieldIndexMainField);
+				if (val == null)
+				{
+					return null;
+				}
+
+				return (Convert.ToByte(val));
+
+			}
+			set
+			{
+				SetFieldValue(18, 0, value, Fit.SubfieldIndexMainField);
+			}
+		}
+
+		///<summary>
+		/// Retrieves the AvgPower field
+		/// Units: watts
+		/// Comment: total_power / total_timer_time if non_zero_avg_power otherwise total_power / total_elapsed_time</summary>
+		/// <returns>Returns nullable ushort representing the AvgPower field</returns>
+		public ushort? AvgPower
+		{
+			get
+			{
+				Object val = GetFieldValue(19, 0, Fit.SubfieldIndexMainField);
+				if (val == null)
+				{
+					return null;
+				}
+
+				return (Convert.ToUInt16(val));
+
+			}
+			set
+			{
+				SetFieldValue(19, 0, value, Fit.SubfieldIndexMainField);
+			}
+		}
+
+		///<summary>
+		/// Retrieves the MaxPower field
+		/// Units: watts</summary>
+		/// <returns>Returns nullable ushort representing the MaxPower field</returns>
+		public ushort? MaxPower
+		{
+			get
+			{
+				Object val = GetFieldValue(20, 0, Fit.SubfieldIndexMainField);
+				if (val == null)
+				{
+					return null;
+				}
+
+				return (Convert.ToUInt16(val));
+
+			}
+			set
+			{
+				SetFieldValue(20, 0, value, Fit.SubfieldIndexMainField);
+			}
+		}
+
+		///<summary>
+		/// Retrieves the TotalAscent field
+		/// Units: m</summary>
+		/// <returns>Returns nullable ushort representing the TotalAscent field</returns>
+		public ushort? TotalAscent
+		{
+			get
+			{
+				Object val = GetFieldValue(21, 0, Fit.SubfieldIndexMainField);
+				if (val == null)
+				{
+					return null;
+				}
+
+				return (Convert.ToUInt16(val));
+
+			}
+			set
+			{
+				SetFieldValue(21, 0, value, Fit.SubfieldIndexMainField);
+			}
+		}
+
+		///<summary>
+		/// Retrieves the TotalDescent field
+		/// Units: m</summary>
+		/// <returns>Returns nullable ushort representing the TotalDescent field</returns>
+		public ushort? TotalDescent
+		{
+			get
+			{
+				Object val = GetFieldValue(22, 0, Fit.SubfieldIndexMainField);
+				if (val == null)
+				{
+					return null;
+				}
+
+				return (Convert.ToUInt16(val));
+
+			}
+			set
+			{
+				SetFieldValue(22, 0, value, Fit.SubfieldIndexMainField);
+			}
+		}
+
+		///<summary>
+		/// Retrieves the Sport field</summary>
+		/// <returns>Returns nullable Sport enum representing the Sport field</returns>
+		public Sport? Sport
+		{
+			get
+			{
+				object obj = GetFieldValue(23, 0, Fit.SubfieldIndexMainField);
+				Sport? value = obj == null ? (Sport?)null : (Sport)obj;
+				return value;
+			}
+			set
+			{
+				SetFieldValue(23, 0, value, Fit.SubfieldIndexMainField);
+			}
+		}
+
+		///<summary>
+		/// Retrieves the EventGroup field</summary>
+		/// <returns>Returns nullable byte representing the EventGroup field</returns>
+		public byte? EventGroup
+		{
+			get
+			{
+				Object val = GetFieldValue(24, 0, Fit.SubfieldIndexMainField);
+				if (val == null)
+				{
+					return null;
+				}
+
+				return (Convert.ToByte(val));
+
+			}
+			set
+			{
+				SetFieldValue(24, 0, value, Fit.SubfieldIndexMainField);
+			}
+		}
+
+		///<summary>
+		/// Retrieves the NecLat field
+		/// Units: semicircles
+		/// Comment: North east corner latitude.</summary>
+		/// <returns>Returns nullable int representing the NecLat field</returns>
+		public int? NecLat
+		{
+			get
+			{
+				Object val = GetFieldValue(25, 0, Fit.SubfieldIndexMainField);
+				if (val == null)
+				{
+					return null;
+				}
+
+				return (Convert.ToInt32(val));
+
+			}
+			set
+			{
+				SetFieldValue(25, 0, value, Fit.SubfieldIndexMainField);
+			}
+		}
+
+		///<summary>
+		/// Retrieves the NecLong field
+		/// Units: semicircles
+		/// Comment: North east corner longitude.</summary>
+		/// <returns>Returns nullable int representing the NecLong field</returns>
+		public int? NecLong
+		{
+			get
+			{
+				Object val = GetFieldValue(26, 0, Fit.SubfieldIndexMainField);
+				if (val == null)
+				{
+					return null;
+				}
+
+				return (Convert.ToInt32(val));
+
+			}
+			set
+			{
+				SetFieldValue(26, 0, value, Fit.SubfieldIndexMainField);
+			}
+		}
+
+		///<summary>
+		/// Retrieves the SwcLat field
+		/// Units: semicircles
+		/// Comment: South west corner latitude.</summary>
+		/// <returns>Returns nullable int representing the SwcLat field</returns>
+		public int? SwcLat
+		{
+			get
+			{
+				Object val = GetFieldValue(27, 0, Fit.SubfieldIndexMainField);
+				if (val == null)
+				{
+					return null;
+				}
+
+				return (Convert.ToInt32(val));
+
+			}
+			set
+			{
+				SetFieldValue(27, 0, value, Fit.SubfieldIndexMainField);
+			}
+		}
+
+		///<summary>
+		/// Retrieves the SwcLong field
+		/// Units: semicircles
+		/// Comment: South west corner latitude.</summary>
+		/// <returns>Returns nullable int representing the SwcLong field</returns>
+		public int? SwcLong
+		{
+			get
+			{
+				Object val = GetFieldValue(28, 0, Fit.SubfieldIndexMainField);
+				if (val == null)
+				{
+					return null;
+				}
+
+				return (Convert.ToInt32(val));
+
+			}
+			set
+			{
+				SetFieldValue(28, 0, value, Fit.SubfieldIndexMainField);
+			}
+		}
+
+		///<summary>
+		/// Retrieves the Name field</summary>
+		/// <returns>Returns byte[] representing the Name field</returns>
+		public byte[] Name
+		{
+			get
+			{
+				byte[] data = (byte[])GetFieldValue(29, 0, Fit.SubfieldIndexMainField);
+				return data.Take(data.Length - 1).ToArray();
+			}
+			set
+			{
+				SetFieldValue(29, 0, value, Fit.SubfieldIndexMainField);
+			}
+		}
+
+		///<summary>
+		/// Retrieves the Name field</summary>
+		/// <returns>Returns String representing the Name field</returns>
+		public String GetNameAsString()
+		{
+			byte[] data = (byte[])GetFieldValue(29, 0, Fit.SubfieldIndexMainField);
+			return data != null ? Encoding.UTF8.GetString(data, 0, data.Length - 1) : null;
+		}
+
+		///<summary>
+		/// Set Name field</summary>
+		/// <param name="name_"> field value to be set</param>
+		public void SetName(String name_)
+		{
+			byte[] data = Encoding.UTF8.GetBytes(name_);
+			byte[] zdata = new byte[data.Length + 1];
+			data.CopyTo(zdata, 0);
+			SetFieldValue(29, 0, zdata, Fit.SubfieldIndexMainField);
+		}
+
+		///<summary>
+		/// Retrieves the NormalizedPower field
+		/// Units: watts</summary>
+		/// <returns>Returns nullable ushort representing the NormalizedPower field</returns>
+		public ushort? NormalizedPower
+		{
+			get
+			{
+				Object val = GetFieldValue(30, 0, Fit.SubfieldIndexMainField);
+				if (val == null)
+				{
+					return null;
+				}
+
+				return (Convert.ToUInt16(val));
+
+			}
+			set
+			{
+				SetFieldValue(30, 0, value, Fit.SubfieldIndexMainField);
+			}
+		}
+
+		///<summary>
+		/// Retrieves the LeftRightBalance field</summary>
+		/// <returns>Returns nullable ushort representing the LeftRightBalance field</returns>
+		public ushort? LeftRightBalance
+		{
+			get
+			{
+				Object val = GetFieldValue(31, 0, Fit.SubfieldIndexMainField);
+				if (val == null)
+				{
+					return null;
+				}
+
+				return (Convert.ToUInt16(val));
+
+			}
+			set
+			{
+				SetFieldValue(31, 0, value, Fit.SubfieldIndexMainField);
+			}
+		}
+
+		///<summary>
+		/// Retrieves the SubSport field</summary>
+		/// <returns>Returns nullable SubSport enum representing the SubSport field</returns>
+		public SubSport? SubSport
+		{
+			get
+			{
+				object obj = GetFieldValue(32, 0, Fit.SubfieldIndexMainField);
+				SubSport? value = obj == null ? (SubSport?)null : (SubSport)obj;
+				return value;
+			}
+			set
+			{
+				SetFieldValue(32, 0, value, Fit.SubfieldIndexMainField);
+			}
+		}
+
+		///<summary>
+		/// Retrieves the TotalWork field
+		/// Units: J</summary>
+		/// <returns>Returns nullable uint representing the TotalWork field</returns>
+		public uint? TotalWork
+		{
+			get
+			{
+				Object val = GetFieldValue(33, 0, Fit.SubfieldIndexMainField);
+				if (val == null)
+				{
+					return null;
+				}
+
+				return (Convert.ToUInt32(val));
+
+			}
+			set
+			{
+				SetFieldValue(33, 0, value, Fit.SubfieldIndexMainField);
+			}
+		}
+
+		///<summary>
+		/// Retrieves the AvgAltitude field
+		/// Units: m</summary>
+		/// <returns>Returns nullable float representing the AvgAltitude field</returns>
+		public float? AvgAltitude
+		{
+			get
+			{
+				Object val = GetFieldValue(34, 0, Fit.SubfieldIndexMainField);
+				if (val == null)
+				{
+					return null;
+				}
+
+				return (Convert.ToSingle(val));
+
+			}
+			set
+			{
+				SetFieldValue(34, 0, value, Fit.SubfieldIndexMainField);
+			}
+		}
+
+		///<summary>
+		/// Retrieves the MaxAltitude field
+		/// Units: m</summary>
+		/// <returns>Returns nullable float representing the MaxAltitude field</returns>
+		public float? MaxAltitude
+		{
+			get
+			{
+				Object val = GetFieldValue(35, 0, Fit.SubfieldIndexMainField);
+				if (val == null)
+				{
+					return null;
+				}
+
+				return (Convert.ToSingle(val));
+
+			}
+			set
+			{
+				SetFieldValue(35, 0, value, Fit.SubfieldIndexMainField);
+			}
+		}
+
+		///<summary>
+		/// Retrieves the GpsAccuracy field
+		/// Units: m</summary>
+		/// <returns>Returns nullable byte representing the GpsAccuracy field</returns>
+		public byte? GpsAccuracy
+		{
+			get
+			{
+				Object val = GetFieldValue(36, 0, Fit.SubfieldIndexMainField);
+				if (val == null)
+				{
+					return null;
+				}
+
+				return (Convert.ToByte(val));
+
+			}
+			set
+			{
+				SetFieldValue(36, 0, value, Fit.SubfieldIndexMainField);
+			}
+		}
+
+		///<summary>
+		/// Retrieves the AvgGrade field
+		/// Units: %</summary>
+		/// <returns>Returns nullable float representing the AvgGrade field</returns>
+		public float? AvgGrade
+		{
+			get
+			{
+				Object val = GetFieldValue(37, 0, Fit.SubfieldIndexMainField);
+				if (val == null)
+				{
+					return null;
+				}
+
+				return (Convert.ToSingle(val));
+
+			}
+			set
+			{
+				SetFieldValue(37, 0, value, Fit.SubfieldIndexMainField);
+			}
+		}
+
+		///<summary>
+		/// Retrieves the AvgPosGrade field
+		/// Units: %</summary>
+		/// <returns>Returns nullable float representing the AvgPosGrade field</returns>
+		public float? AvgPosGrade
+		{
+			get
+			{
+				Object val = GetFieldValue(38, 0, Fit.SubfieldIndexMainField);
+				if (val == null)
+				{
+					return null;
+				}
+
+				return (Convert.ToSingle(val));
+
+			}
+			set
+			{
+				SetFieldValue(38, 0, value, Fit.SubfieldIndexMainField);
+			}
+		}
+
+		///<summary>
+		/// Retrieves the AvgNegGrade field
+		/// Units: %</summary>
+		/// <returns>Returns nullable float representing the AvgNegGrade field</returns>
+		public float? AvgNegGrade
+		{
+			get
+			{
+				Object val = GetFieldValue(39, 0, Fit.SubfieldIndexMainField);
+				if (val == null)
+				{
+					return null;
+				}
+
+				return (Convert.ToSingle(val));
+
+			}
+			set
+			{
+				SetFieldValue(39, 0, value, Fit.SubfieldIndexMainField);
+			}
+		}
+
+		///<summary>
+		/// Retrieves the MaxPosGrade field
+		/// Units: %</summary>
+		/// <returns>Returns nullable float representing the MaxPosGrade field</returns>
+		public float? MaxPosGrade
+		{
+			get
+			{
+				Object val = GetFieldValue(40, 0, Fit.SubfieldIndexMainField);
+				if (val == null)
+				{
+					return null;
+				}
+
+				return (Convert.ToSingle(val));
+
+			}
+			set
+			{
+				SetFieldValue(40, 0, value, Fit.SubfieldIndexMainField);
+			}
+		}
+
+		///<summary>
+		/// Retrieves the MaxNegGrade field
+		/// Units: %</summary>
+		/// <returns>Returns nullable float representing the MaxNegGrade field</returns>
+		public float? MaxNegGrade
+		{
+			get
+			{
+				Object val = GetFieldValue(41, 0, Fit.SubfieldIndexMainField);
+				if (val == null)
+				{
+					return null;
+				}
+
+				return (Convert.ToSingle(val));
+
+			}
+			set
+			{
+				SetFieldValue(41, 0, value, Fit.SubfieldIndexMainField);
+			}
+		}
+
+		///<summary>
+		/// Retrieves the AvgTemperature field
+		/// Units: C</summary>
+		/// <returns>Returns nullable sbyte representing the AvgTemperature field</returns>
+		public sbyte? AvgTemperature
+		{
+			get
+			{
+				Object val = GetFieldValue(42, 0, Fit.SubfieldIndexMainField);
+				if (val == null)
+				{
+					return null;
+				}
+
+				return (Convert.ToSByte(val));
+
+			}
+			set
+			{
+				SetFieldValue(42, 0, value, Fit.SubfieldIndexMainField);
+			}
+		}
+
+		///<summary>
+		/// Retrieves the MaxTemperature field
+		/// Units: C</summary>
+		/// <returns>Returns nullable sbyte representing the MaxTemperature field</returns>
+		public sbyte? MaxTemperature
+		{
+			get
+			{
+				Object val = GetFieldValue(43, 0, Fit.SubfieldIndexMainField);
+				if (val == null)
+				{
+					return null;
+				}
+
+				return (Convert.ToSByte(val));
+
+			}
+			set
+			{
+				SetFieldValue(43, 0, value, Fit.SubfieldIndexMainField);
+			}
+		}
+
+		///<summary>
+		/// Retrieves the TotalMovingTime field
+		/// Units: s</summary>
+		/// <returns>Returns nullable float representing the TotalMovingTime field</returns>
+		public float? TotalMovingTime
+		{
+			get
+			{
+				Object val = GetFieldValue(44, 0, Fit.SubfieldIndexMainField);
+				if (val == null)
+				{
+					return null;
+				}
+
+				return (Convert.ToSingle(val));
+
+			}
+			set
+			{
+				SetFieldValue(44, 0, value, Fit.SubfieldIndexMainField);
+			}
+		}
+
+		///<summary>
+		/// Retrieves the AvgPosVerticalSpeed field
+		/// Units: m/s</summary>
+		/// <returns>Returns nullable float representing the AvgPosVerticalSpeed field</returns>
+		public float? AvgPosVerticalSpeed
+		{
+			get
+			{
+				Object val = GetFieldValue(45, 0, Fit.SubfieldIndexMainField);
+				if (val == null)
+				{
+					return null;
+				}
+
+				return (Convert.ToSingle(val));
+
+			}
+			set
+			{
+				SetFieldValue(45, 0, value, Fit.SubfieldIndexMainField);
+			}
+		}
+
+		///<summary>
+		/// Retrieves the AvgNegVerticalSpeed field
+		/// Units: m/s</summary>
+		/// <returns>Returns nullable float representing the AvgNegVerticalSpeed field</returns>
+		public float? AvgNegVerticalSpeed
+		{
+			get
+			{
+				Object val = GetFieldValue(46, 0, Fit.SubfieldIndexMainField);
+				if (val == null)
+				{
+					return null;
+				}
+
+				return (Convert.ToSingle(val));
+
+			}
+			set
+			{
+				SetFieldValue(46, 0, value, Fit.SubfieldIndexMainField);
+			}
+		}
+
+		///<summary>
+		/// Retrieves the MaxPosVerticalSpeed field
+		/// Units: m/s</summary>
+		/// <returns>Returns nullable float representing the MaxPosVerticalSpeed field</returns>
+		public float? MaxPosVerticalSpeed
+		{
+			get
+			{
+				Object val = GetFieldValue(47, 0, Fit.SubfieldIndexMainField);
+				if (val == null)
+				{
+					return null;
+				}
+
+				return (Convert.ToSingle(val));
+
+			}
+			set
+			{
+				SetFieldValue(47, 0, value, Fit.SubfieldIndexMainField);
+			}
+		}
+
+		///<summary>
+		/// Retrieves the MaxNegVerticalSpeed field
+		/// Units: m/s</summary>
+		/// <returns>Returns nullable float representing the MaxNegVerticalSpeed field</returns>
+		public float? MaxNegVerticalSpeed
+		{
+			get
+			{
+				Object val = GetFieldValue(48, 0, Fit.SubfieldIndexMainField);
+				if (val == null)
+				{
+					return null;
+				}
+
+				return (Convert.ToSingle(val));
+
+			}
+			set
+			{
+				SetFieldValue(48, 0, value, Fit.SubfieldIndexMainField);
+			}
+		}
+
+
+		/// <summary>
+		///
+		/// </summary>
+		/// <returns>returns number of elements in field TimeInHrZone</returns>
+		public int GetNumTimeInHrZone()
+		{
+			return GetNumFieldValues(49, Fit.SubfieldIndexMainField);
+		}
+
+		///<summary>
+		/// Retrieves the TimeInHrZone field
+		/// Units: s</summary>
+		/// <param name="index">0 based index of TimeInHrZone element to retrieve</param>
+		/// <returns>Returns nullable float representing the TimeInHrZone field</returns>
+		public float? GetTimeInHrZone(int index)
+		{
+			Object val = GetFieldValue(49, index, Fit.SubfieldIndexMainField);
+			if (val == null)
+			{
+				return null;
+			}
+
+			return (Convert.ToSingle(val));
+
+		}
+
+		/// <summary>
+		/// Set TimeInHrZone field
+		/// Units: s</summary>
+		/// <param name="index">0 based index of time_in_hr_zone</param>
+		/// <param name="timeInHrZone_">Nullable field value to be set</param>
+		public void SetTimeInHrZone(int index, float? timeInHrZone_)
+		{
+			SetFieldValue(49, index, timeInHrZone_, Fit.SubfieldIndexMainField);
+		}
+
+
+		/// <summary>
+		///
+		/// </summary>
+		/// <returns>returns number of elements in field TimeInSpeedZone</returns>
+		public int GetNumTimeInSpeedZone()
+		{
+			return GetNumFieldValues(50, Fit.SubfieldIndexMainField);
+		}
+
+		///<summary>
+		/// Retrieves the TimeInSpeedZone field
+		/// Units: s</summary>
+		/// <param name="index">0 based index of TimeInSpeedZone element to retrieve</param>
+		/// <returns>Returns nullable float representing the TimeInSpeedZone field</returns>
+		public float? GetTimeInSpeedZone(int index)
+		{
+			Object val = GetFieldValue(50, index, Fit.SubfieldIndexMainField);
+			if (val == null)
+			{
+				return null;
+			}
+
+			return (Convert.ToSingle(val));
+
+		}
+
+		/// <summary>
+		/// Set TimeInSpeedZone field
+		/// Units: s</summary>
+		/// <param name="index">0 based index of time_in_speed_zone</param>
+		/// <param name="timeInSpeedZone_">Nullable field value to be set</param>
+		public void SetTimeInSpeedZone(int index, float? timeInSpeedZone_)
+		{
+			SetFieldValue(50, index, timeInSpeedZone_, Fit.SubfieldIndexMainField);
+		}
+
+
+		/// <summary>
+		///
+		/// </summary>
+		/// <returns>returns number of elements in field TimeInCadenceZone</returns>
+		public int GetNumTimeInCadenceZone()
+		{
+			return GetNumFieldValues(51, Fit.SubfieldIndexMainField);
+		}
+
+		///<summary>
+		/// Retrieves the TimeInCadenceZone field
+		/// Units: s</summary>
+		/// <param name="index">0 based index of TimeInCadenceZone element to retrieve</param>
+		/// <returns>Returns nullable float representing the TimeInCadenceZone field</returns>
+		public float? GetTimeInCadenceZone(int index)
+		{
+			Object val = GetFieldValue(51, index, Fit.SubfieldIndexMainField);
+			if (val == null)
+			{
+				return null;
+			}
+
+			return (Convert.ToSingle(val));
+
+		}
+
+		/// <summary>
+		/// Set TimeInCadenceZone field
+		/// Units: s</summary>
+		/// <param name="index">0 based index of time_in_cadence_zone</param>
+		/// <param name="timeInCadenceZone_">Nullable field value to be set</param>
+		public void SetTimeInCadenceZone(int index, float? timeInCadenceZone_)
+		{
+			SetFieldValue(51, index, timeInCadenceZone_, Fit.SubfieldIndexMainField);
+		}
+
+
+		/// <summary>
+		///
+		/// </summary>
+		/// <returns>returns number of elements in field TimeInPowerZone</returns>
+		public int GetNumTimeInPowerZone()
+		{
+			return GetNumFieldValues(52, Fit.SubfieldIndexMainField);
+		}
+
+		///<summary>
+		/// Retrieves the TimeInPowerZone field
+		/// Units: s</summary>
+		/// <param name="index">0 based index of TimeInPowerZone element to retrieve</param>
+		/// <returns>Returns nullable float representing the TimeInPowerZone field</returns>
+		public float? GetTimeInPowerZone(int index)
+		{
+			Object val = GetFieldValue(52, index, Fit.SubfieldIndexMainField);
+			if (val == null)
+			{
+				return null;
+			}
+
+			return (Convert.ToSingle(val));
+
+		}
+
+		/// <summary>
+		/// Set TimeInPowerZone field
+		/// Units: s</summary>
+		/// <param name="index">0 based index of time_in_power_zone</param>
+		/// <param name="timeInPowerZone_">Nullable field value to be set</param>
+		public void SetTimeInPowerZone(int index, float? timeInPowerZone_)
+		{
+			SetFieldValue(52, index, timeInPowerZone_, Fit.SubfieldIndexMainField);
+		}
+
+		///<summary>
+		/// Retrieves the RepetitionNum field</summary>
+		/// <returns>Returns nullable ushort representing the RepetitionNum field</returns>
+		public ushort? RepetitionNum
+		{
+			get
+			{
+				Object val = GetFieldValue(53, 0, Fit.SubfieldIndexMainField);
+				if (val == null)
+				{
+					return null;
+				}
+
+				return (Convert.ToUInt16(val));
+
+			}
+			set
+			{
+				SetFieldValue(53, 0, value, Fit.SubfieldIndexMainField);
+			}
+		}
+
+		///<summary>
+		/// Retrieves the MinAltitude field
+		/// Units: m</summary>
+		/// <returns>Returns nullable float representing the MinAltitude field</returns>
+		public float? MinAltitude
+		{
+			get
+			{
+				Object val = GetFieldValue(54, 0, Fit.SubfieldIndexMainField);
+				if (val == null)
+				{
+					return null;
+				}
+
+				return (Convert.ToSingle(val));
+
+			}
+			set
+			{
+				SetFieldValue(54, 0, value, Fit.SubfieldIndexMainField);
+			}
+		}
+
+		///<summary>
+		/// Retrieves the MinHeartRate field
+		/// Units: bpm</summary>
+		/// <returns>Returns nullable byte representing the MinHeartRate field</returns>
+		public byte? MinHeartRate
+		{
+			get
+			{
+				Object val = GetFieldValue(55, 0, Fit.SubfieldIndexMainField);
+				if (val == null)
+				{
+					return null;
+				}
+
+				return (Convert.ToByte(val));
+
+			}
+			set
+			{
+				SetFieldValue(55, 0, value, Fit.SubfieldIndexMainField);
+			}
+		}
+
+		///<summary>
+		/// Retrieves the ActiveTime field
+		/// Units: s</summary>
+		/// <returns>Returns nullable float representing the ActiveTime field</returns>
+		public float? ActiveTime
+		{
+			get
+			{
+				Object val = GetFieldValue(56, 0, Fit.SubfieldIndexMainField);
+				if (val == null)
+				{
+					return null;
+				}
+
+				return (Convert.ToSingle(val));
+
+			}
+			set
+			{
+				SetFieldValue(56, 0, value, Fit.SubfieldIndexMainField);
+			}
+		}
+
+		///<summary>
+		/// Retrieves the WktStepIndex field</summary>
+		/// <returns>Returns nullable ushort representing the WktStepIndex field</returns>
+		public ushort? WktStepIndex
+		{
+			get
+			{
+				Object val = GetFieldValue(57, 0, Fit.SubfieldIndexMainField);
+				if (val == null)
+				{
+					return null;
+				}
+
+				return (Convert.ToUInt16(val));
+
+			}
+			set
+			{
+				SetFieldValue(57, 0, value, Fit.SubfieldIndexMainField);
+			}
+		}
+
+		///<summary>
+		/// Retrieves the SportEvent field</summary>
+		/// <returns>Returns nullable SportEvent enum representing the SportEvent field</returns>
+		public SportEvent? SportEvent
+		{
+			get
+			{
+				object obj = GetFieldValue(58, 0, Fit.SubfieldIndexMainField);
+				SportEvent? value = obj == null ? (SportEvent?)null : (SportEvent)obj;
+				return value;
+			}
+			set
+			{
+				SetFieldValue(58, 0, value, Fit.SubfieldIndexMainField);
+			}
+		}
+
+		///<summary>
+		/// Retrieves the AvgLeftTorqueEffectiveness field
+		/// Units: percent</summary>
+		/// <returns>Returns nullable float representing the AvgLeftTorqueEffectiveness field</returns>
+		public float? AvgLeftTorqueEffectiveness
+		{
+			get
+			{
+				Object val = GetFieldValue(59, 0, Fit.SubfieldIndexMainField);
+				if (val == null)
+				{
+					return null;
+				}
+
+				return (Convert.ToSingle(val));
+
+			}
+			set
+			{
+				SetFieldValue(59, 0, value, Fit.SubfieldIndexMainField);
+			}
+		}
+
+		///<summary>
+		/// Retrieves the AvgRightTorqueEffectiveness field
+		/// Units: percent</summary>
+		/// <returns>Returns nullable float representing the AvgRightTorqueEffectiveness field</returns>
+		public float? AvgRightTorqueEffectiveness
+		{
+			get
+			{
+				Object val = GetFieldValue(60, 0, Fit.SubfieldIndexMainField);
+				if (val == null)
+				{
+					return null;
+				}
+
+				return (Convert.ToSingle(val));
+
+			}
+			set
+			{
+				SetFieldValue(60, 0, value, Fit.SubfieldIndexMainField);
+			}
+		}
+
+		///<summary>
+		/// Retrieves the AvgLeftPedalSmoothness field
+		/// Units: percent</summary>
+		/// <returns>Returns nullable float representing the AvgLeftPedalSmoothness field</returns>
+		public float? AvgLeftPedalSmoothness
+		{
+			get
+			{
+				Object val = GetFieldValue(61, 0, Fit.SubfieldIndexMainField);
+				if (val == null)
+				{
+					return null;
+				}
+
+				return (Convert.ToSingle(val));
+
+			}
+			set
+			{
+				SetFieldValue(61, 0, value, Fit.SubfieldIndexMainField);
+			}
+		}
+
+		///<summary>
+		/// Retrieves the AvgRightPedalSmoothness field
+		/// Units: percent</summary>
+		/// <returns>Returns nullable float representing the AvgRightPedalSmoothness field</returns>
+		public float? AvgRightPedalSmoothness
+		{
+			get
+			{
+				Object val = GetFieldValue(62, 0, Fit.SubfieldIndexMainField);
+				if (val == null)
+				{
+					return null;
+				}
+
+				return (Convert.ToSingle(val));
+
+			}
+			set
+			{
+				SetFieldValue(62, 0, value, Fit.SubfieldIndexMainField);
+			}
+		}
+
+		///<summary>
+		/// Retrieves the AvgCombinedPedalSmoothness field
+		/// Units: percent</summary>
+		/// <returns>Returns nullable float representing the AvgCombinedPedalSmoothness field</returns>
+		public float? AvgCombinedPedalSmoothness
+		{
+			get
+			{
+				Object val = GetFieldValue(63, 0, Fit.SubfieldIndexMainField);
+				if (val == null)
+				{
+					return null;
+				}
+
+				return (Convert.ToSingle(val));
+
+			}
+			set
+			{
+				SetFieldValue(63, 0, value, Fit.SubfieldIndexMainField);
+			}
+		}
+
+		///<summary>
+		/// Retrieves the Status field</summary>
+		/// <returns>Returns nullable SegmentLapStatus enum representing the Status field</returns>
+		public SegmentLapStatus? Status
+		{
+			get
+			{
+				object obj = GetFieldValue(64, 0, Fit.SubfieldIndexMainField);
+				SegmentLapStatus? value = obj == null ? (SegmentLapStatus?)null : (SegmentLapStatus)obj;
+				return value;
+			}
+			set
+			{
+				SetFieldValue(64, 0, value, Fit.SubfieldIndexMainField);
+			}
+		}
+
+		///<summary>
+		/// Retrieves the Uuid field</summary>
+		/// <returns>Returns byte[] representing the Uuid field</returns>
+		public byte[] Uuid
+		{
+			get
+			{
+				byte[] data = (byte[])GetFieldValue(65, 0, Fit.SubfieldIndexMainField);
+				return data.Take(data.Length - 1).ToArray();
+			}
+			set
+			{
+				SetFieldValue(65, 0, value, Fit.SubfieldIndexMainField);
+			}
+		}
+
+		///<summary>
+		/// Retrieves the Uuid field</summary>
+		/// <returns>Returns String representing the Uuid field</returns>
+		public String GetUuidAsString()
+		{
+			byte[] data = (byte[])GetFieldValue(65, 0, Fit.SubfieldIndexMainField);
+			return data != null ? Encoding.UTF8.GetString(data, 0, data.Length - 1) : null;
+		}
+
+		///<summary>
+		/// Set Uuid field</summary>
+		/// <param name="uuid_"> field value to be set</param>
+		public void SetUuid(String uuid_)
+		{
+			byte[] data = Encoding.UTF8.GetBytes(uuid_);
+			byte[] zdata = new byte[data.Length + 1];
+			data.CopyTo(zdata, 0);
+			SetFieldValue(65, 0, zdata, Fit.SubfieldIndexMainField);
+		}
+
+		///<summary>
+		/// Retrieves the AvgFractionalCadence field
+		/// Units: rpm
+		/// Comment: fractional part of the avg_cadence</summary>
+		/// <returns>Returns nullable float representing the AvgFractionalCadence field</returns>
+		public float? AvgFractionalCadence
+		{
+			get
+			{
+				Object val = GetFieldValue(66, 0, Fit.SubfieldIndexMainField);
+				if (val == null)
+				{
+					return null;
+				}
+
+				return (Convert.ToSingle(val));
+
+			}
+			set
+			{
+				SetFieldValue(66, 0, value, Fit.SubfieldIndexMainField);
+			}
+		}
+
+		///<summary>
+		/// Retrieves the MaxFractionalCadence field
+		/// Units: rpm
+		/// Comment: fractional part of the max_cadence</summary>
+		/// <returns>Returns nullable float representing the MaxFractionalCadence field</returns>
+		public float? MaxFractionalCadence
+		{
+			get
+			{
+				Object val = GetFieldValue(67, 0, Fit.SubfieldIndexMainField);
+				if (val == null)
+				{
+					return null;
+				}
+
+				return (Convert.ToSingle(val));
+
+			}
+			set
+			{
+				SetFieldValue(67, 0, value, Fit.SubfieldIndexMainField);
+			}
+		}
+
+		///<summary>
+		/// Retrieves the TotalFractionalCycles field
+		/// Units: cycles
+		/// Comment: fractional part of the total_cycles</summary>
+		/// <returns>Returns nullable float representing the TotalFractionalCycles field</returns>
+		public float? TotalFractionalCycles
+		{
+			get
+			{
+				Object val = GetFieldValue(68, 0, Fit.SubfieldIndexMainField);
+				if (val == null)
+				{
+					return null;
+				}
+
+				return (Convert.ToSingle(val));
+
+			}
+			set
+			{
+				SetFieldValue(68, 0, value, Fit.SubfieldIndexMainField);
+			}
+		}
+
+		///<summary>
+		/// Retrieves the FrontGearShiftCount field</summary>
+		/// <returns>Returns nullable ushort representing the FrontGearShiftCount field</returns>
+		public ushort? FrontGearShiftCount
+		{
+			get
+			{
+				Object val = GetFieldValue(69, 0, Fit.SubfieldIndexMainField);
+				if (val == null)
+				{
+					return null;
+				}
+
+				return (Convert.ToUInt16(val));
+
+			}
+			set
+			{
+				SetFieldValue(69, 0, value, Fit.SubfieldIndexMainField);
+			}
+		}
+
+		///<summary>
+		/// Retrieves the RearGearShiftCount field</summary>
+		/// <returns>Returns nullable ushort representing the RearGearShiftCount field</returns>
+		public ushort? RearGearShiftCount
+		{
+			get
+			{
+				Object val = GetFieldValue(70, 0, Fit.SubfieldIndexMainField);
+				if (val == null)
+				{
+					return null;
+				}
+
+				return (Convert.ToUInt16(val));
+
+			}
+			set
+			{
+				SetFieldValue(70, 0, value, Fit.SubfieldIndexMainField);
+			}
+		}
+
+		///<summary>
+		/// Retrieves the TimeStanding field
+		/// Units: s
+		/// Comment: Total time spent in the standing position</summary>
+		/// <returns>Returns nullable float representing the TimeStanding field</returns>
+		public float? TimeStanding
+		{
+			get
+			{
+				Object val = GetFieldValue(71, 0, Fit.SubfieldIndexMainField);
+				if (val == null)
+				{
+					return null;
+				}
+
+				return (Convert.ToSingle(val));
+
+			}
+			set
+			{
+				SetFieldValue(71, 0, value, Fit.SubfieldIndexMainField);
+			}
+		}
+
+		///<summary>
+		/// Retrieves the StandCount field
+		/// Comment: Number of transitions to the standing state</summary>
+		/// <returns>Returns nullable ushort representing the StandCount field</returns>
+		public ushort? StandCount
+		{
+			get
+			{
+				Object val = GetFieldValue(72, 0, Fit.SubfieldIndexMainField);
+				if (val == null)
+				{
+					return null;
+				}
+
+				return (Convert.ToUInt16(val));
+
+			}
+			set
+			{
+				SetFieldValue(72, 0, value, Fit.SubfieldIndexMainField);
+			}
+		}
+
+		///<summary>
+		/// Retrieves the AvgLeftPco field
+		/// Units: mm
+		/// Comment: Average left platform center offset</summary>
+		/// <returns>Returns nullable sbyte representing the AvgLeftPco field</returns>
+		public sbyte? AvgLeftPco
+		{
+			get
+			{
+				Object val = GetFieldValue(73, 0, Fit.SubfieldIndexMainField);
+				if (val == null)
+				{
+					return null;
+				}
+
+				return (Convert.ToSByte(val));
+
+			}
+			set
+			{
+				SetFieldValue(73, 0, value, Fit.SubfieldIndexMainField);
+			}
+		}
+
+		///<summary>
+		/// Retrieves the AvgRightPco field
+		/// Units: mm
+		/// Comment: Average right platform center offset</summary>
+		/// <returns>Returns nullable sbyte representing the AvgRightPco field</returns>
+		public sbyte? AvgRightPco
+		{
+			get
+			{
+				Object val = GetFieldValue(74, 0, Fit.SubfieldIndexMainField);
+				if (val == null)
+				{
+					return null;
+				}
+
+				return (Convert.ToSByte(val));
+
+			}
+			set
+			{
+				SetFieldValue(74, 0, value, Fit.SubfieldIndexMainField);
+			}
+		}
+
+
+		/// <summary>
+		///
+		/// </summary>
+		/// <returns>returns number of elements in field AvgLeftPowerPhase</returns>
+		public int GetNumAvgLeftPowerPhase()
+		{
+			return GetNumFieldValues(75, Fit.SubfieldIndexMainField);
+		}
+
+		///<summary>
+		/// Retrieves the AvgLeftPowerPhase field
+		/// Units: degrees
+		/// Comment: Average left power phase angles. Data value indexes defined by power_phase_type.</summary>
+		/// <param name="index">0 based index of AvgLeftPowerPhase element to retrieve</param>
+		/// <returns>Returns nullable float representing the AvgLeftPowerPhase field</returns>
+		public float? GetAvgLeftPowerPhase(int index)
+		{
+			Object val = GetFieldValue(75, index, Fit.SubfieldIndexMainField);
+			if (val == null)
+			{
+				return null;
+			}
+
+			return (Convert.ToSingle(val));
+
+		}
+
+		/// <summary>
+		/// Set AvgLeftPowerPhase field
+		/// Units: degrees
+		/// Comment: Average left power phase angles. Data value indexes defined by power_phase_type.</summary>
+		/// <param name="index">0 based index of avg_left_power_phase</param>
+		/// <param name="avgLeftPowerPhase_">Nullable field value to be set</param>
+		public void SetAvgLeftPowerPhase(int index, float? avgLeftPowerPhase_)
+		{
+			SetFieldValue(75, index, avgLeftPowerPhase_, Fit.SubfieldIndexMainField);
+		}
+
+
+		/// <summary>
+		///
+		/// </summary>
+		/// <returns>returns number of elements in field AvgLeftPowerPhasePeak</returns>
+		public int GetNumAvgLeftPowerPhasePeak()
+		{
+			return GetNumFieldValues(76, Fit.SubfieldIndexMainField);
+		}
+
+		///<summary>
+		/// Retrieves the AvgLeftPowerPhasePeak field
+		/// Units: degrees
+		/// Comment: Average left power phase peak angles. Data value indexes defined by power_phase_type.</summary>
+		/// <param name="index">0 based index of AvgLeftPowerPhasePeak element to retrieve</param>
+		/// <returns>Returns nullable float representing the AvgLeftPowerPhasePeak field</returns>
+		public float? GetAvgLeftPowerPhasePeak(int index)
+		{
+			Object val = GetFieldValue(76, index, Fit.SubfieldIndexMainField);
+			if (val == null)
+			{
+				return null;
+			}
+
+			return (Convert.ToSingle(val));
+
+		}
+
+		/// <summary>
+		/// Set AvgLeftPowerPhasePeak field
+		/// Units: degrees
+		/// Comment: Average left power phase peak angles. Data value indexes defined by power_phase_type.</summary>
+		/// <param name="index">0 based index of avg_left_power_phase_peak</param>
+		/// <param name="avgLeftPowerPhasePeak_">Nullable field value to be set</param>
+		public void SetAvgLeftPowerPhasePeak(int index, float? avgLeftPowerPhasePeak_)
+		{
+			SetFieldValue(76, index, avgLeftPowerPhasePeak_, Fit.SubfieldIndexMainField);
+		}
+
+
+		/// <summary>
+		///
+		/// </summary>
+		/// <returns>returns number of elements in field AvgRightPowerPhase</returns>
+		public int GetNumAvgRightPowerPhase()
+		{
+			return GetNumFieldValues(77, Fit.SubfieldIndexMainField);
+		}
+
+		///<summary>
+		/// Retrieves the AvgRightPowerPhase field
+		/// Units: degrees
+		/// Comment: Average right power phase angles. Data value indexes defined by power_phase_type.</summary>
+		/// <param name="index">0 based index of AvgRightPowerPhase element to retrieve</param>
+		/// <returns>Returns nullable float representing the AvgRightPowerPhase field</returns>
+		public float? GetAvgRightPowerPhase(int index)
+		{
+			Object val = GetFieldValue(77, index, Fit.SubfieldIndexMainField);
+			if (val == null)
+			{
+				return null;
+			}
+
+			return (Convert.ToSingle(val));
+
+		}
+
+		/// <summary>
+		/// Set AvgRightPowerPhase field
+		/// Units: degrees
+		/// Comment: Average right power phase angles. Data value indexes defined by power_phase_type.</summary>
+		/// <param name="index">0 based index of avg_right_power_phase</param>
+		/// <param name="avgRightPowerPhase_">Nullable field value to be set</param>
+		public void SetAvgRightPowerPhase(int index, float? avgRightPowerPhase_)
+		{
+			SetFieldValue(77, index, avgRightPowerPhase_, Fit.SubfieldIndexMainField);
+		}
+
+
+		/// <summary>
+		///
+		/// </summary>
+		/// <returns>returns number of elements in field AvgRightPowerPhasePeak</returns>
+		public int GetNumAvgRightPowerPhasePeak()
+		{
+			return GetNumFieldValues(78, Fit.SubfieldIndexMainField);
+		}
+
+		///<summary>
+		/// Retrieves the AvgRightPowerPhasePeak field
+		/// Units: degrees
+		/// Comment: Average right power phase peak angles. Data value indexes defined by power_phase_type.</summary>
+		/// <param name="index">0 based index of AvgRightPowerPhasePeak element to retrieve</param>
+		/// <returns>Returns nullable float representing the AvgRightPowerPhasePeak field</returns>
+		public float? GetAvgRightPowerPhasePeak(int index)
+		{
+			Object val = GetFieldValue(78, index, Fit.SubfieldIndexMainField);
+			if (val == null)
+			{
+				return null;
+			}
+
+			return (Convert.ToSingle(val));
+
+		}
+
+		/// <summary>
+		/// Set AvgRightPowerPhasePeak field
+		/// Units: degrees
+		/// Comment: Average right power phase peak angles. Data value indexes defined by power_phase_type.</summary>
+		/// <param name="index">0 based index of avg_right_power_phase_peak</param>
+		/// <param name="avgRightPowerPhasePeak_">Nullable field value to be set</param>
+		public void SetAvgRightPowerPhasePeak(int index, float? avgRightPowerPhasePeak_)
+		{
+			SetFieldValue(78, index, avgRightPowerPhasePeak_, Fit.SubfieldIndexMainField);
+		}
+
+
+		/// <summary>
+		///
+		/// </summary>
+		/// <returns>returns number of elements in field AvgPowerPosition</returns>
+		public int GetNumAvgPowerPosition()
+		{
+			return GetNumFieldValues(79, Fit.SubfieldIndexMainField);
+		}
+
+		///<summary>
+		/// Retrieves the AvgPowerPosition field
+		/// Units: watts
+		/// Comment: Average power by position. Data value indexes defined by rider_position_type.</summary>
+		/// <param name="index">0 based index of AvgPowerPosition element to retrieve</param>
+		/// <returns>Returns nullable ushort representing the AvgPowerPosition field</returns>
+		public ushort? GetAvgPowerPosition(int index)
+		{
+			Object val = GetFieldValue(79, index, Fit.SubfieldIndexMainField);
+			if (val == null)
+			{
+				return null;
+			}
+
+			return (Convert.ToUInt16(val));
+
+		}
+
+		/// <summary>
+		/// Set AvgPowerPosition field
+		/// Units: watts
+		/// Comment: Average power by position. Data value indexes defined by rider_position_type.</summary>
+		/// <param name="index">0 based index of avg_power_position</param>
+		/// <param name="avgPowerPosition_">Nullable field value to be set</param>
+		public void SetAvgPowerPosition(int index, ushort? avgPowerPosition_)
+		{
+			SetFieldValue(79, index, avgPowerPosition_, Fit.SubfieldIndexMainField);
+		}
+
+
+		/// <summary>
+		///
+		/// </summary>
+		/// <returns>returns number of elements in field MaxPowerPosition</returns>
+		public int GetNumMaxPowerPosition()
+		{
+			return GetNumFieldValues(80, Fit.SubfieldIndexMainField);
+		}
+
+		///<summary>
+		/// Retrieves the MaxPowerPosition field
+		/// Units: watts
+		/// Comment: Maximum power by position. Data value indexes defined by rider_position_type.</summary>
+		/// <param name="index">0 based index of MaxPowerPosition element to retrieve</param>
+		/// <returns>Returns nullable ushort representing the MaxPowerPosition field</returns>
+		public ushort? GetMaxPowerPosition(int index)
+		{
+			Object val = GetFieldValue(80, index, Fit.SubfieldIndexMainField);
+			if (val == null)
+			{
+				return null;
+			}
+
+			return (Convert.ToUInt16(val));
+
+		}
+
+		/// <summary>
+		/// Set MaxPowerPosition field
+		/// Units: watts
+		/// Comment: Maximum power by position. Data value indexes defined by rider_position_type.</summary>
+		/// <param name="index">0 based index of max_power_position</param>
+		/// <param name="maxPowerPosition_">Nullable field value to be set</param>
+		public void SetMaxPowerPosition(int index, ushort? maxPowerPosition_)
+		{
+			SetFieldValue(80, index, maxPowerPosition_, Fit.SubfieldIndexMainField);
+		}
+
+
+		/// <summary>
+		///
+		/// </summary>
+		/// <returns>returns number of elements in field AvgCadencePosition</returns>
+		public int GetNumAvgCadencePosition()
+		{
+			return GetNumFieldValues(81, Fit.SubfieldIndexMainField);
+		}
+
+		///<summary>
+		/// Retrieves the AvgCadencePosition field
+		/// Units: rpm
+		/// Comment: Average cadence by position. Data value indexes defined by rider_position_type.</summary>
+		/// <param name="index">0 based index of AvgCadencePosition element to retrieve</param>
+		/// <returns>Returns nullable byte representing the AvgCadencePosition field</returns>
+		public byte? GetAvgCadencePosition(int index)
+		{
+			Object val = GetFieldValue(81, index, Fit.SubfieldIndexMainField);
+			if (val == null)
+			{
+				return null;
+			}
+
+			return (Convert.ToByte(val));
+
+		}
+
+		/// <summary>
+		/// Set AvgCadencePosition field
+		/// Units: rpm
+		/// Comment: Average cadence by position. Data value indexes defined by rider_position_type.</summary>
+		/// <param name="index">0 based index of avg_cadence_position</param>
+		/// <param name="avgCadencePosition_">Nullable field value to be set</param>
+		public void SetAvgCadencePosition(int index, byte? avgCadencePosition_)
+		{
+			SetFieldValue(81, index, avgCadencePosition_, Fit.SubfieldIndexMainField);
+		}
+
+
+		/// <summary>
+		///
+		/// </summary>
+		/// <returns>returns number of elements in field MaxCadencePosition</returns>
+		public int GetNumMaxCadencePosition()
+		{
+			return GetNumFieldValues(82, Fit.SubfieldIndexMainField);
+		}
+
+		///<summary>
+		/// Retrieves the MaxCadencePosition field
+		/// Units: rpm
+		/// Comment: Maximum cadence by position. Data value indexes defined by rider_position_type.</summary>
+		/// <param name="index">0 based index of MaxCadencePosition element to retrieve</param>
+		/// <returns>Returns nullable byte representing the MaxCadencePosition field</returns>
+		public byte? GetMaxCadencePosition(int index)
+		{
+			Object val = GetFieldValue(82, index, Fit.SubfieldIndexMainField);
+			if (val == null)
+			{
+				return null;
+			}
+
+			return (Convert.ToByte(val));
+
+		}
+
+		/// <summary>
+		/// Set MaxCadencePosition field
+		/// Units: rpm
+		/// Comment: Maximum cadence by position. Data value indexes defined by rider_position_type.</summary>
+		/// <param name="index">0 based index of max_cadence_position</param>
+		/// <param name="maxCadencePosition_">Nullable field value to be set</param>
+		public void SetMaxCadencePosition(int index, byte? maxCadencePosition_)
+		{
+			SetFieldValue(82, index, maxCadencePosition_, Fit.SubfieldIndexMainField);
+		}
+
+		///<summary>
+		/// Retrieves the Manufacturer field
+		/// Comment: Manufacturer that produced the segment</summary>
+		/// <returns>Returns nullable ushort representing the Manufacturer field</returns>
+		public ushort? Manufacturer
+		{
+			get
+			{
+				Object val = GetFieldValue(83, 0, Fit.SubfieldIndexMainField);
+				if (val == null)
+				{
+					return null;
+				}
+
+				return (Convert.ToUInt16(val));
+
+			}
+			set
+			{
+				SetFieldValue(83, 0, value, Fit.SubfieldIndexMainField);
+			}
+		}
+
+		///<summary>
+		/// Retrieves the TotalGrit field
+		/// Units: kGrit
+		/// Comment: The grit score estimates how challenging a route could be for a cyclist in terms of time spent going over sharp turns or large grade slopes.</summary>
+		/// <returns>Returns nullable float representing the TotalGrit field</returns>
+		public float? TotalGrit
+		{
+			get
+			{
+				Object val = GetFieldValue(84, 0, Fit.SubfieldIndexMainField);
+				if (val == null)
+				{
+					return null;
+				}
+
+				return (Convert.ToSingle(val));
+
+			}
+			set
+			{
+				SetFieldValue(84, 0, value, Fit.SubfieldIndexMainField);
+			}
+		}
+
+		///<summary>
+		/// Retrieves the TotalFlow field
+		/// Units: Flow
+		/// Comment: The flow score estimates how long distance wise a cyclist deaccelerates over intervals where deacceleration is unnecessary such as smooth turns or small grade angle intervals.</summary>
+		/// <returns>Returns nullable float representing the TotalFlow field</returns>
+		public float? TotalFlow
+		{
+			get
+			{
+				Object val = GetFieldValue(85, 0, Fit.SubfieldIndexMainField);
+				if (val == null)
+				{
+					return null;
+				}
+
+				return (Convert.ToSingle(val));
+
+			}
+			set
+			{
+				SetFieldValue(85, 0, value, Fit.SubfieldIndexMainField);
+			}
+		}
+
+		///<summary>
+		/// Retrieves the AvgGrit field
+		/// Units: kGrit
+		/// Comment: The grit score estimates how challenging a route could be for a cyclist in terms of time spent going over sharp turns or large grade slopes.</summary>
+		/// <returns>Returns nullable float representing the AvgGrit field</returns>
+		public float? AvgGrit
+		{
+			get
+			{
+				Object val = GetFieldValue(86, 0, Fit.SubfieldIndexMainField);
+				if (val == null)
+				{
+					return null;
+				}
+
+				return (Convert.ToSingle(val));
+
+			}
+			set
+			{
+				SetFieldValue(86, 0, value, Fit.SubfieldIndexMainField);
+			}
+		}
+
+		///<summary>
+		/// Retrieves the AvgFlow field
+		/// Units: Flow
+		/// Comment: The flow score estimates how long distance wise a cyclist deaccelerates over intervals where deacceleration is unnecessary such as smooth turns or small grade angle intervals.</summary>
+		/// <returns>Returns nullable float representing the AvgFlow field</returns>
+		public float? AvgFlow
+		{
+			get
+			{
+				Object val = GetFieldValue(87, 0, Fit.SubfieldIndexMainField);
+				if (val == null)
+				{
+					return null;
+				}
+
+				return (Convert.ToSingle(val));
+
+			}
+			set
+			{
+				SetFieldValue(87, 0, value, Fit.SubfieldIndexMainField);
+			}
+		}
+
+		///<summary>
+		/// Retrieves the TotalFractionalAscent field
+		/// Units: m
+		/// Comment: fractional part of total_ascent</summary>
+		/// <returns>Returns nullable float representing the TotalFractionalAscent field</returns>
+		public float? TotalFractionalAscent
+		{
+			get
+			{
+				Object val = GetFieldValue(89, 0, Fit.SubfieldIndexMainField);
+				if (val == null)
+				{
+					return null;
+				}
+
+				return (Convert.ToSingle(val));
+
+			}
+			set
+			{
+				SetFieldValue(89, 0, value, Fit.SubfieldIndexMainField);
+			}
+		}
+
+		///<summary>
+		/// Retrieves the TotalFractionalDescent field
+		/// Units: m
+		/// Comment: fractional part of total_descent</summary>
+		/// <returns>Returns nullable float representing the TotalFractionalDescent field</returns>
+		public float? TotalFractionalDescent
+		{
+			get
+			{
+				Object val = GetFieldValue(90, 0, Fit.SubfieldIndexMainField);
+				if (val == null)
+				{
+					return null;
+				}
+
+				return (Convert.ToSingle(val));
+
+			}
+			set
+			{
+				SetFieldValue(90, 0, value, Fit.SubfieldIndexMainField);
+			}
+		}
+
+		///<summary>
+		/// Retrieves the EnhancedAvgAltitude field
+		/// Units: m</summary>
+		/// <returns>Returns nullable float representing the EnhancedAvgAltitude field</returns>
+		public float? EnhancedAvgAltitude
+		{
+			get
+			{
+				Object val = GetFieldValue(91, 0, Fit.SubfieldIndexMainField);
+				if (val == null)
+				{
+					return null;
+				}
+
+				return (Convert.ToSingle(val));
+
+			}
+			set
+			{
+				SetFieldValue(91, 0, value, Fit.SubfieldIndexMainField);
+			}
+		}
+
+		///<summary>
+		/// Retrieves the EnhancedMaxAltitude field
+		/// Units: m</summary>
+		/// <returns>Returns nullable float representing the EnhancedMaxAltitude field</returns>
+		public float? EnhancedMaxAltitude
+		{
+			get
+			{
+				Object val = GetFieldValue(92, 0, Fit.SubfieldIndexMainField);
+				if (val == null)
+				{
+					return null;
+				}
+
+				return (Convert.ToSingle(val));
+
+			}
+			set
+			{
+				SetFieldValue(92, 0, value, Fit.SubfieldIndexMainField);
+			}
+		}
+
+		///<summary>
+		/// Retrieves the EnhancedMinAltitude field
+		/// Units: m</summary>
+		/// <returns>Returns nullable float representing the EnhancedMinAltitude field</returns>
+		public float? EnhancedMinAltitude
+		{
+			get
+			{
+				Object val = GetFieldValue(93, 0, Fit.SubfieldIndexMainField);
+				if (val == null)
+				{
+					return null;
+				}
+
+				return (Convert.ToSingle(val));
+
+			}
+			set
+			{
+				SetFieldValue(93, 0, value, Fit.SubfieldIndexMainField);
+			}
+		}
+
+		#endregion // Methods
+	} // Class
 } // namespace

--- a/Dynastream/Fit/Profile/Mesgs/SegmentLeaderboardEntryMesg.cs
+++ b/Dynastream/Fit/Profile/Mesgs/SegmentLeaderboardEntryMesg.cs
@@ -21,244 +21,228 @@ using System.Linq;
 
 namespace Dynastream.Fit
 {
-    /// <summary>
-    /// Implements the SegmentLeaderboardEntry profile message.
-    /// </summary>
-    public class SegmentLeaderboardEntryMesg : Mesg
-    {
-        #region Fields
-        #endregion
+	/// <summary>
+	/// Implements the SegmentLeaderboardEntry profile message.
+	/// </summary>
+	public class SegmentLeaderboardEntryMesg : Mesg
+	{
+		#region Fields
+		#endregion
 
-        /// <summary>
-        /// Field Numbers for <see cref="SegmentLeaderboardEntryMesg"/>
-        /// </summary>
-        public sealed class FieldDefNum
-        {
-            public const byte MessageIndex = 254;
-            public const byte Name = 0;
-            public const byte Type = 1;
-            public const byte GroupPrimaryKey = 2;
-            public const byte ActivityId = 3;
-            public const byte SegmentTime = 4;
-            public const byte ActivityIdString = 5;
-            public const byte Invalid = Fit.FieldNumInvalid;
-        }
+		/// <summary>
+		/// Field Numbers for <see cref="SegmentLeaderboardEntryMesg"/>
+		/// </summary>
+		public sealed class FieldDefNum
+		{
+			public const byte MessageIndex = 254;
+			public const byte Name = 0;
+			public const byte Type = 1;
+			public const byte GroupPrimaryKey = 2;
+			public const byte ActivityId = 3;
+			public const byte SegmentTime = 4;
+			public const byte ActivityIdString = 5;
+			public const byte Invalid = Fit.FieldNumInvalid;
+		}
 
-        #region Constructors
-        public SegmentLeaderboardEntryMesg() : base(Profile.GetMesg(MesgNum.SegmentLeaderboardEntry))
-        {
-        }
+		#region Constructors
+		public SegmentLeaderboardEntryMesg() : base(Profile.GetMesg(MesgNum.SegmentLeaderboardEntry))
+		{
+		}
 
-        public SegmentLeaderboardEntryMesg(Mesg mesg) : base(mesg)
-        {
-        }
-        #endregion // Constructors
+		public SegmentLeaderboardEntryMesg(Mesg mesg) : base(mesg)
+		{
+		}
+		#endregion // Constructors
 
-        #region Methods
-        ///<summary>
-        /// Retrieves the MessageIndex field</summary>
-        /// <returns>Returns nullable ushort representing the MessageIndex field</returns>
-        public ushort? GetMessageIndex()
-        {
-            Object val = GetFieldValue(254, 0, Fit.SubfieldIndexMainField);
-            if(val == null)
-            {
-                return null;
-            }
+		#region Methods
+		///<summary>
+		/// Retrieves the MessageIndex field</summary>
+		/// <returns>Returns nullable ushort representing the MessageIndex field</returns>
+		public ushort? MessageIndex
+		{
+			get
+			{
+				Object val = GetFieldValue(254, 0, Fit.SubfieldIndexMainField);
+				if (val == null)
+				{
+					return null;
+				}
 
-            return (Convert.ToUInt16(val));
-            
-        }
+				return (Convert.ToUInt16(val));
 
-        /// <summary>
-        /// Set MessageIndex field</summary>
-        /// <param name="messageIndex_">Nullable field value to be set</param>
-        public void SetMessageIndex(ushort? messageIndex_)
-        {
-            SetFieldValue(254, 0, messageIndex_, Fit.SubfieldIndexMainField);
-        }
-        
-        ///<summary>
-        /// Retrieves the Name field
-        /// Comment: Friendly name assigned to leader</summary>
-        /// <returns>Returns byte[] representing the Name field</returns>
-        public byte[] GetName()
-        {
-            byte[] data = (byte[])GetFieldValue(0, 0, Fit.SubfieldIndexMainField);
-            return data.Take(data.Length - 1).ToArray();
-        }
+			}
+			set
+			{
+				SetFieldValue(254, 0, value, Fit.SubfieldIndexMainField);
+			}
+		}
 
-        ///<summary>
-        /// Retrieves the Name field
-        /// Comment: Friendly name assigned to leader</summary>
-        /// <returns>Returns String representing the Name field</returns>
-        public String GetNameAsString()
-        {
-            byte[] data = (byte[])GetFieldValue(0, 0, Fit.SubfieldIndexMainField);
-            return data != null ? Encoding.UTF8.GetString(data, 0, data.Length - 1) : null;
-        }
+		///<summary>
+		/// Retrieves the Name field
+		/// Comment: Friendly name assigned to leader</summary>
+		/// <returns>Returns byte[] representing the Name field</returns>
+		public byte[] Name
+		{
+			get
+			{
+				byte[] data = (byte[])GetFieldValue(0, 0, Fit.SubfieldIndexMainField);
+				return data.Take(data.Length - 1).ToArray();
+			}
+			set
+			{
+				SetFieldValue(0, 0, value, Fit.SubfieldIndexMainField);
+			}
+		}
 
-        ///<summary>
-        /// Set Name field
-        /// Comment: Friendly name assigned to leader</summary>
-        /// <param name="name_"> field value to be set</param>
-        public void SetName(String name_)
-        {
-            byte[] data = Encoding.UTF8.GetBytes(name_);
-            byte[] zdata = new byte[data.Length + 1];
-            data.CopyTo(zdata, 0);
-            SetFieldValue(0, 0, zdata, Fit.SubfieldIndexMainField);
-        }
+		///<summary>
+		/// Retrieves the Name field
+		/// Comment: Friendly name assigned to leader</summary>
+		/// <returns>Returns String representing the Name field</returns>
+		public String GetNameAsString()
+		{
+			byte[] data = (byte[])GetFieldValue(0, 0, Fit.SubfieldIndexMainField);
+			return data != null ? Encoding.UTF8.GetString(data, 0, data.Length - 1) : null;
+		}
 
-        
-        /// <summary>
-        /// Set Name field
-        /// Comment: Friendly name assigned to leader</summary>
-        /// <param name="name_">field value to be set</param>
-        public void SetName(byte[] name_)
-        {
-            SetFieldValue(0, 0, name_, Fit.SubfieldIndexMainField);
-        }
-        
-        ///<summary>
-        /// Retrieves the Type field
-        /// Comment: Leader classification</summary>
-        /// <returns>Returns nullable SegmentLeaderboardType enum representing the Type field</returns>
-        new public SegmentLeaderboardType? GetType()
-        {
-            object obj = GetFieldValue(1, 0, Fit.SubfieldIndexMainField);
-            SegmentLeaderboardType? value = obj == null ? (SegmentLeaderboardType?)null : (SegmentLeaderboardType)obj;
-            return value;
-        }
+		///<summary>
+		/// Set Name field
+		/// Comment: Friendly name assigned to leader</summary>
+		/// <param name="name_"> field value to be set</param>
+		public void SetName(String name_)
+		{
+			byte[] data = Encoding.UTF8.GetBytes(name_);
+			byte[] zdata = new byte[data.Length + 1];
+			data.CopyTo(zdata, 0);
+			SetFieldValue(0, 0, zdata, Fit.SubfieldIndexMainField);
+		}
 
-        /// <summary>
-        /// Set Type field
-        /// Comment: Leader classification</summary>
-        /// <param name="type_">Nullable field value to be set</param>
-        public void SetType(SegmentLeaderboardType? type_)
-        {
-            SetFieldValue(1, 0, type_, Fit.SubfieldIndexMainField);
-        }
-        
-        ///<summary>
-        /// Retrieves the GroupPrimaryKey field
-        /// Comment: Primary user ID of this leader</summary>
-        /// <returns>Returns nullable uint representing the GroupPrimaryKey field</returns>
-        public uint? GetGroupPrimaryKey()
-        {
-            Object val = GetFieldValue(2, 0, Fit.SubfieldIndexMainField);
-            if(val == null)
-            {
-                return null;
-            }
+		///<summary>
+		/// Retrieves the Type field
+		/// Comment: Leader classification</summary>
+		/// <returns>Returns nullable SegmentLeaderboardType enum representing the Type field</returns>
+		public SegmentLeaderboardType? Type
+		{
+			get
+			{
+				object obj = GetFieldValue(1, 0, Fit.SubfieldIndexMainField);
+				SegmentLeaderboardType? value = obj == null ? (SegmentLeaderboardType?)null : (SegmentLeaderboardType)obj;
+				return value;
+			}
+			set
+			{
+				SetFieldValue(1, 0, value, Fit.SubfieldIndexMainField);
+			}
+		}
 
-            return (Convert.ToUInt32(val));
-            
-        }
+		///<summary>
+		/// Retrieves the GroupPrimaryKey field
+		/// Comment: Primary user ID of this leader</summary>
+		/// <returns>Returns nullable uint representing the GroupPrimaryKey field</returns>
+		public uint? GroupPrimaryKey
+		{
+			get
+			{
+				Object val = GetFieldValue(2, 0, Fit.SubfieldIndexMainField);
+				if (val == null)
+				{
+					return null;
+				}
 
-        /// <summary>
-        /// Set GroupPrimaryKey field
-        /// Comment: Primary user ID of this leader</summary>
-        /// <param name="groupPrimaryKey_">Nullable field value to be set</param>
-        public void SetGroupPrimaryKey(uint? groupPrimaryKey_)
-        {
-            SetFieldValue(2, 0, groupPrimaryKey_, Fit.SubfieldIndexMainField);
-        }
-        
-        ///<summary>
-        /// Retrieves the ActivityId field
-        /// Comment: ID of the activity associated with this leader time</summary>
-        /// <returns>Returns nullable uint representing the ActivityId field</returns>
-        public uint? GetActivityId()
-        {
-            Object val = GetFieldValue(3, 0, Fit.SubfieldIndexMainField);
-            if(val == null)
-            {
-                return null;
-            }
+				return (Convert.ToUInt32(val));
 
-            return (Convert.ToUInt32(val));
-            
-        }
+			}
+			set
+			{
+				SetFieldValue(2, 0, value, Fit.SubfieldIndexMainField);
+			}
+		}
 
-        /// <summary>
-        /// Set ActivityId field
-        /// Comment: ID of the activity associated with this leader time</summary>
-        /// <param name="activityId_">Nullable field value to be set</param>
-        public void SetActivityId(uint? activityId_)
-        {
-            SetFieldValue(3, 0, activityId_, Fit.SubfieldIndexMainField);
-        }
-        
-        ///<summary>
-        /// Retrieves the SegmentTime field
-        /// Units: s
-        /// Comment: Segment Time (includes pauses)</summary>
-        /// <returns>Returns nullable float representing the SegmentTime field</returns>
-        public float? GetSegmentTime()
-        {
-            Object val = GetFieldValue(4, 0, Fit.SubfieldIndexMainField);
-            if(val == null)
-            {
-                return null;
-            }
+		///<summary>
+		/// Retrieves the ActivityId field
+		/// Comment: ID of the activity associated with this leader time</summary>
+		/// <returns>Returns nullable uint representing the ActivityId field</returns>
+		public uint? ActivityId
+		{
+			get
+			{
+				Object val = GetFieldValue(3, 0, Fit.SubfieldIndexMainField);
+				if (val == null)
+				{
+					return null;
+				}
 
-            return (Convert.ToSingle(val));
-            
-        }
+				return (Convert.ToUInt32(val));
 
-        /// <summary>
-        /// Set SegmentTime field
-        /// Units: s
-        /// Comment: Segment Time (includes pauses)</summary>
-        /// <param name="segmentTime_">Nullable field value to be set</param>
-        public void SetSegmentTime(float? segmentTime_)
-        {
-            SetFieldValue(4, 0, segmentTime_, Fit.SubfieldIndexMainField);
-        }
-        
-        ///<summary>
-        /// Retrieves the ActivityIdString field
-        /// Comment: String version of the activity_id. 21 characters long, express in decimal</summary>
-        /// <returns>Returns byte[] representing the ActivityIdString field</returns>
-        public byte[] GetActivityIdString()
-        {
-            byte[] data = (byte[])GetFieldValue(5, 0, Fit.SubfieldIndexMainField);
-            return data.Take(data.Length - 1).ToArray();
-        }
+			}
+			set
+			{
+				SetFieldValue(3, 0, value, Fit.SubfieldIndexMainField);
+			}
+		}
 
-        ///<summary>
-        /// Retrieves the ActivityIdString field
-        /// Comment: String version of the activity_id. 21 characters long, express in decimal</summary>
-        /// <returns>Returns String representing the ActivityIdString field</returns>
-        public String GetActivityIdStringAsString()
-        {
-            byte[] data = (byte[])GetFieldValue(5, 0, Fit.SubfieldIndexMainField);
-            return data != null ? Encoding.UTF8.GetString(data, 0, data.Length - 1) : null;
-        }
+		///<summary>
+		/// Retrieves the SegmentTime field
+		/// Units: s
+		/// Comment: Segment Time (includes pauses)</summary>
+		/// <returns>Returns nullable float representing the SegmentTime field</returns>
+		public float? SegmentTime
+		{
+			get
+			{
+				Object val = GetFieldValue(4, 0, Fit.SubfieldIndexMainField);
+				if (val == null)
+				{
+					return null;
+				}
 
-        ///<summary>
-        /// Set ActivityIdString field
-        /// Comment: String version of the activity_id. 21 characters long, express in decimal</summary>
-        /// <param name="activityIdString_"> field value to be set</param>
-        public void SetActivityIdString(String activityIdString_)
-        {
-            byte[] data = Encoding.UTF8.GetBytes(activityIdString_);
-            byte[] zdata = new byte[data.Length + 1];
-            data.CopyTo(zdata, 0);
-            SetFieldValue(5, 0, zdata, Fit.SubfieldIndexMainField);
-        }
+				return (Convert.ToSingle(val));
 
-        
-        /// <summary>
-        /// Set ActivityIdString field
-        /// Comment: String version of the activity_id. 21 characters long, express in decimal</summary>
-        /// <param name="activityIdString_">field value to be set</param>
-        public void SetActivityIdString(byte[] activityIdString_)
-        {
-            SetFieldValue(5, 0, activityIdString_, Fit.SubfieldIndexMainField);
-        }
-        
-        #endregion // Methods
-    } // Class
+			}
+			set
+			{
+				SetFieldValue(4, 0, value, Fit.SubfieldIndexMainField);
+			}
+		}
+
+		///<summary>
+		/// Retrieves the ActivityIdString field
+		/// Comment: String version of the activity_id. 21 characters long, express in decimal</summary>
+		/// <returns>Returns byte[] representing the ActivityIdString field</returns>
+		public byte[] ActivityIdString
+		{
+			get
+			{
+				byte[] data = (byte[])GetFieldValue(5, 0, Fit.SubfieldIndexMainField);
+				return data.Take(data.Length - 1).ToArray();
+			}
+			set
+			{
+				SetFieldValue(5, 0, value, Fit.SubfieldIndexMainField);
+			}
+		}
+
+		///<summary>
+		/// Retrieves the ActivityIdString field
+		/// Comment: String version of the activity_id. 21 characters long, express in decimal</summary>
+		/// <returns>Returns String representing the ActivityIdString field</returns>
+		public String GetActivityIdStringAsString()
+		{
+			byte[] data = (byte[])GetFieldValue(5, 0, Fit.SubfieldIndexMainField);
+			return data != null ? Encoding.UTF8.GetString(data, 0, data.Length - 1) : null;
+		}
+
+		///<summary>
+		/// Set ActivityIdString field
+		/// Comment: String version of the activity_id. 21 characters long, express in decimal</summary>
+		/// <param name="activityIdString_"> field value to be set</param>
+		public void SetActivityIdString(String activityIdString_)
+		{
+			byte[] data = Encoding.UTF8.GetBytes(activityIdString_);
+			byte[] zdata = new byte[data.Length + 1];
+			data.CopyTo(zdata, 0);
+			SetFieldValue(5, 0, zdata, Fit.SubfieldIndexMainField);
+		}
+
+		#endregion // Methods
+	} // Class
 } // namespace

--- a/Dynastream/Fit/Profile/Mesgs/SegmentPointMesg.cs
+++ b/Dynastream/Fit/Profile/Mesgs/SegmentPointMesg.cs
@@ -21,233 +21,219 @@ using System.Linq;
 
 namespace Dynastream.Fit
 {
-    /// <summary>
-    /// Implements the SegmentPoint profile message.
-    /// </summary>
-    public class SegmentPointMesg : Mesg
-    {
-        #region Fields
-        #endregion
+	/// <summary>
+	/// Implements the SegmentPoint profile message.
+	/// </summary>
+	public class SegmentPointMesg : Mesg
+	{
+		#region Fields
+		#endregion
 
-        /// <summary>
-        /// Field Numbers for <see cref="SegmentPointMesg"/>
-        /// </summary>
-        public sealed class FieldDefNum
-        {
-            public const byte MessageIndex = 254;
-            public const byte PositionLat = 1;
-            public const byte PositionLong = 2;
-            public const byte Distance = 3;
-            public const byte Altitude = 4;
-            public const byte LeaderTime = 5;
-            public const byte EnhancedAltitude = 6;
-            public const byte Invalid = Fit.FieldNumInvalid;
-        }
+		/// <summary>
+		/// Field Numbers for <see cref="SegmentPointMesg"/>
+		/// </summary>
+		public sealed class FieldDefNum
+		{
+			public const byte MessageIndex = 254;
+			public const byte PositionLat = 1;
+			public const byte PositionLong = 2;
+			public const byte Distance = 3;
+			public const byte Altitude = 4;
+			public const byte LeaderTime = 5;
+			public const byte EnhancedAltitude = 6;
+			public const byte Invalid = Fit.FieldNumInvalid;
+		}
 
-        #region Constructors
-        public SegmentPointMesg() : base(Profile.GetMesg(MesgNum.SegmentPoint))
-        {
-        }
+		#region Constructors
+		public SegmentPointMesg() : base(Profile.GetMesg(MesgNum.SegmentPoint))
+		{
+		}
 
-        public SegmentPointMesg(Mesg mesg) : base(mesg)
-        {
-        }
-        #endregion // Constructors
+		public SegmentPointMesg(Mesg mesg) : base(mesg)
+		{
+		}
+		#endregion // Constructors
 
-        #region Methods
-        ///<summary>
-        /// Retrieves the MessageIndex field</summary>
-        /// <returns>Returns nullable ushort representing the MessageIndex field</returns>
-        public ushort? GetMessageIndex()
-        {
-            Object val = GetFieldValue(254, 0, Fit.SubfieldIndexMainField);
-            if(val == null)
-            {
-                return null;
-            }
+		#region Methods
+		///<summary>
+		/// Retrieves the MessageIndex field</summary>
+		/// <returns>Returns nullable ushort representing the MessageIndex field</returns>
+		public ushort? MessageIndex
+		{
+			get
+			{
+				Object val = GetFieldValue(254, 0, Fit.SubfieldIndexMainField);
+				if (val == null)
+				{
+					return null;
+				}
 
-            return (Convert.ToUInt16(val));
-            
-        }
+				return (Convert.ToUInt16(val));
 
-        /// <summary>
-        /// Set MessageIndex field</summary>
-        /// <param name="messageIndex_">Nullable field value to be set</param>
-        public void SetMessageIndex(ushort? messageIndex_)
-        {
-            SetFieldValue(254, 0, messageIndex_, Fit.SubfieldIndexMainField);
-        }
-        
-        ///<summary>
-        /// Retrieves the PositionLat field
-        /// Units: semicircles</summary>
-        /// <returns>Returns nullable int representing the PositionLat field</returns>
-        public int? GetPositionLat()
-        {
-            Object val = GetFieldValue(1, 0, Fit.SubfieldIndexMainField);
-            if(val == null)
-            {
-                return null;
-            }
+			}
+			set
+			{
+				SetFieldValue(254, 0, value, Fit.SubfieldIndexMainField);
+			}
+		}
 
-            return (Convert.ToInt32(val));
-            
-        }
+		///<summary>
+		/// Retrieves the PositionLat field
+		/// Units: semicircles</summary>
+		/// <returns>Returns nullable int representing the PositionLat field</returns>
+		public int? PositionLat
+		{
+			get
+			{
+				Object val = GetFieldValue(1, 0, Fit.SubfieldIndexMainField);
+				if (val == null)
+				{
+					return null;
+				}
 
-        /// <summary>
-        /// Set PositionLat field
-        /// Units: semicircles</summary>
-        /// <param name="positionLat_">Nullable field value to be set</param>
-        public void SetPositionLat(int? positionLat_)
-        {
-            SetFieldValue(1, 0, positionLat_, Fit.SubfieldIndexMainField);
-        }
-        
-        ///<summary>
-        /// Retrieves the PositionLong field
-        /// Units: semicircles</summary>
-        /// <returns>Returns nullable int representing the PositionLong field</returns>
-        public int? GetPositionLong()
-        {
-            Object val = GetFieldValue(2, 0, Fit.SubfieldIndexMainField);
-            if(val == null)
-            {
-                return null;
-            }
+				return (Convert.ToInt32(val));
 
-            return (Convert.ToInt32(val));
-            
-        }
+			}
+			set
+			{
+				SetFieldValue(1, 0, value, Fit.SubfieldIndexMainField);
+			}
+		}
 
-        /// <summary>
-        /// Set PositionLong field
-        /// Units: semicircles</summary>
-        /// <param name="positionLong_">Nullable field value to be set</param>
-        public void SetPositionLong(int? positionLong_)
-        {
-            SetFieldValue(2, 0, positionLong_, Fit.SubfieldIndexMainField);
-        }
-        
-        ///<summary>
-        /// Retrieves the Distance field
-        /// Units: m
-        /// Comment: Accumulated distance along the segment at the described point</summary>
-        /// <returns>Returns nullable float representing the Distance field</returns>
-        public float? GetDistance()
-        {
-            Object val = GetFieldValue(3, 0, Fit.SubfieldIndexMainField);
-            if(val == null)
-            {
-                return null;
-            }
+		///<summary>
+		/// Retrieves the PositionLong field
+		/// Units: semicircles</summary>
+		/// <returns>Returns nullable int representing the PositionLong field</returns>
+		public int? PositionLong
+		{
+			get
+			{
+				Object val = GetFieldValue(2, 0, Fit.SubfieldIndexMainField);
+				if (val == null)
+				{
+					return null;
+				}
 
-            return (Convert.ToSingle(val));
-            
-        }
+				return (Convert.ToInt32(val));
 
-        /// <summary>
-        /// Set Distance field
-        /// Units: m
-        /// Comment: Accumulated distance along the segment at the described point</summary>
-        /// <param name="distance_">Nullable field value to be set</param>
-        public void SetDistance(float? distance_)
-        {
-            SetFieldValue(3, 0, distance_, Fit.SubfieldIndexMainField);
-        }
-        
-        ///<summary>
-        /// Retrieves the Altitude field
-        /// Units: m
-        /// Comment: Accumulated altitude along the segment at the described point</summary>
-        /// <returns>Returns nullable float representing the Altitude field</returns>
-        public float? GetAltitude()
-        {
-            Object val = GetFieldValue(4, 0, Fit.SubfieldIndexMainField);
-            if(val == null)
-            {
-                return null;
-            }
+			}
+			set
+			{
+				SetFieldValue(2, 0, value, Fit.SubfieldIndexMainField);
+			}
+		}
 
-            return (Convert.ToSingle(val));
-            
-        }
+		///<summary>
+		/// Retrieves the Distance field
+		/// Units: m
+		/// Comment: Accumulated distance along the segment at the described point</summary>
+		/// <returns>Returns nullable float representing the Distance field</returns>
+		public float? Distance
+		{
+			get
+			{
+				Object val = GetFieldValue(3, 0, Fit.SubfieldIndexMainField);
+				if (val == null)
+				{
+					return null;
+				}
 
-        /// <summary>
-        /// Set Altitude field
-        /// Units: m
-        /// Comment: Accumulated altitude along the segment at the described point</summary>
-        /// <param name="altitude_">Nullable field value to be set</param>
-        public void SetAltitude(float? altitude_)
-        {
-            SetFieldValue(4, 0, altitude_, Fit.SubfieldIndexMainField);
-        }
-        
-        
-        /// <summary>
-        ///
-        /// </summary>
-        /// <returns>returns number of elements in field LeaderTime</returns>
-        public int GetNumLeaderTime()
-        {
-            return GetNumFieldValues(5, Fit.SubfieldIndexMainField);
-        }
+				return (Convert.ToSingle(val));
 
-        ///<summary>
-        /// Retrieves the LeaderTime field
-        /// Units: s
-        /// Comment: Accumualted time each leader board member required to reach the described point. This value is zero for all leader board members at the starting point of the segment.</summary>
-        /// <param name="index">0 based index of LeaderTime element to retrieve</param>
-        /// <returns>Returns nullable float representing the LeaderTime field</returns>
-        public float? GetLeaderTime(int index)
-        {
-            Object val = GetFieldValue(5, index, Fit.SubfieldIndexMainField);
-            if(val == null)
-            {
-                return null;
-            }
+			}
+			set
+			{
+				SetFieldValue(3, 0, value, Fit.SubfieldIndexMainField);
+			}
+		}
 
-            return (Convert.ToSingle(val));
-            
-        }
+		///<summary>
+		/// Retrieves the Altitude field
+		/// Units: m
+		/// Comment: Accumulated altitude along the segment at the described point</summary>
+		/// <returns>Returns nullable float representing the Altitude field</returns>
+		public float? Altitude
+		{
+			get
+			{
+				Object val = GetFieldValue(4, 0, Fit.SubfieldIndexMainField);
+				if (val == null)
+				{
+					return null;
+				}
 
-        /// <summary>
-        /// Set LeaderTime field
-        /// Units: s
-        /// Comment: Accumualted time each leader board member required to reach the described point. This value is zero for all leader board members at the starting point of the segment.</summary>
-        /// <param name="index">0 based index of leader_time</param>
-        /// <param name="leaderTime_">Nullable field value to be set</param>
-        public void SetLeaderTime(int index, float? leaderTime_)
-        {
-            SetFieldValue(5, index, leaderTime_, Fit.SubfieldIndexMainField);
-        }
-        
-        ///<summary>
-        /// Retrieves the EnhancedAltitude field
-        /// Units: m
-        /// Comment: Accumulated altitude along the segment at the described point</summary>
-        /// <returns>Returns nullable float representing the EnhancedAltitude field</returns>
-        public float? GetEnhancedAltitude()
-        {
-            Object val = GetFieldValue(6, 0, Fit.SubfieldIndexMainField);
-            if(val == null)
-            {
-                return null;
-            }
+				return (Convert.ToSingle(val));
 
-            return (Convert.ToSingle(val));
-            
-        }
+			}
+			set
+			{
+				SetFieldValue(4, 0, value, Fit.SubfieldIndexMainField);
+			}
+		}
 
-        /// <summary>
-        /// Set EnhancedAltitude field
-        /// Units: m
-        /// Comment: Accumulated altitude along the segment at the described point</summary>
-        /// <param name="enhancedAltitude_">Nullable field value to be set</param>
-        public void SetEnhancedAltitude(float? enhancedAltitude_)
-        {
-            SetFieldValue(6, 0, enhancedAltitude_, Fit.SubfieldIndexMainField);
-        }
-        
-        #endregion // Methods
-    } // Class
+
+		/// <summary>
+		///
+		/// </summary>
+		/// <returns>returns number of elements in field LeaderTime</returns>
+		public int GetNumLeaderTime()
+		{
+			return GetNumFieldValues(5, Fit.SubfieldIndexMainField);
+		}
+
+		///<summary>
+		/// Retrieves the LeaderTime field
+		/// Units: s
+		/// Comment: Accumualted time each leader board member required to reach the described point. This value is zero for all leader board members at the starting point of the segment.</summary>
+		/// <param name="index">0 based index of LeaderTime element to retrieve</param>
+		/// <returns>Returns nullable float representing the LeaderTime field</returns>
+		public float? GetLeaderTime(int index)
+		{
+			Object val = GetFieldValue(5, index, Fit.SubfieldIndexMainField);
+			if (val == null)
+			{
+				return null;
+			}
+
+			return (Convert.ToSingle(val));
+
+		}
+
+		/// <summary>
+		/// Set LeaderTime field
+		/// Units: s
+		/// Comment: Accumualted time each leader board member required to reach the described point. This value is zero for all leader board members at the starting point of the segment.</summary>
+		/// <param name="index">0 based index of leader_time</param>
+		/// <param name="leaderTime_">Nullable field value to be set</param>
+		public void SetLeaderTime(int index, float? leaderTime_)
+		{
+			SetFieldValue(5, index, leaderTime_, Fit.SubfieldIndexMainField);
+		}
+
+		///<summary>
+		/// Retrieves the EnhancedAltitude field
+		/// Units: m
+		/// Comment: Accumulated altitude along the segment at the described point</summary>
+		/// <returns>Returns nullable float representing the EnhancedAltitude field</returns>
+		public float? EnhancedAltitude
+		{
+			get
+			{
+				Object val = GetFieldValue(6, 0, Fit.SubfieldIndexMainField);
+				if (val == null)
+				{
+					return null;
+				}
+
+				return (Convert.ToSingle(val));
+
+			}
+			set
+			{
+				SetFieldValue(6, 0, value, Fit.SubfieldIndexMainField);
+			}
+		}
+
+		#endregion // Methods
+	} // Class
 } // namespace

--- a/Dynastream/Fit/Profile/Mesgs/SessionMesg.cs
+++ b/Dynastream/Fit/Profile/Mesgs/SessionMesg.cs
@@ -21,4510 +21,4211 @@ using System.Linq;
 
 namespace Dynastream.Fit
 {
-    /// <summary>
-    /// Implements the Session profile message.
-    /// </summary>
-    public class SessionMesg : Mesg
-    {
-        #region Fields
-        static class TotalCyclesSubfield
-        {
-            public static ushort TotalStrides = 0;
-            public static ushort TotalStrokes = 1;
-            public static ushort Subfields = 2;
-            public static ushort Active = Fit.SubfieldIndexActiveSubfield;
-            public static ushort MainField = Fit.SubfieldIndexMainField;
-        }
-        static class AvgCadenceSubfield
-        {
-            public static ushort AvgRunningCadence = 0;
-            public static ushort Subfields = 1;
-            public static ushort Active = Fit.SubfieldIndexActiveSubfield;
-            public static ushort MainField = Fit.SubfieldIndexMainField;
-        }
-        static class MaxCadenceSubfield
-        {
-            public static ushort MaxRunningCadence = 0;
-            public static ushort Subfields = 1;
-            public static ushort Active = Fit.SubfieldIndexActiveSubfield;
-            public static ushort MainField = Fit.SubfieldIndexMainField;
-        }
-        #endregion
-
-        /// <summary>
-        /// Field Numbers for <see cref="SessionMesg"/>
-        /// </summary>
-        public sealed class FieldDefNum
-        {
-            public const byte MessageIndex = 254;
-            public const byte Timestamp = 253;
-            public const byte Event = 0;
-            public const byte EventType = 1;
-            public const byte StartTime = 2;
-            public const byte StartPositionLat = 3;
-            public const byte StartPositionLong = 4;
-            public const byte Sport = 5;
-            public const byte SubSport = 6;
-            public const byte TotalElapsedTime = 7;
-            public const byte TotalTimerTime = 8;
-            public const byte TotalDistance = 9;
-            public const byte TotalCycles = 10;
-            public const byte TotalCalories = 11;
-            public const byte TotalFatCalories = 13;
-            public const byte AvgSpeed = 14;
-            public const byte MaxSpeed = 15;
-            public const byte AvgHeartRate = 16;
-            public const byte MaxHeartRate = 17;
-            public const byte AvgCadence = 18;
-            public const byte MaxCadence = 19;
-            public const byte AvgPower = 20;
-            public const byte MaxPower = 21;
-            public const byte TotalAscent = 22;
-            public const byte TotalDescent = 23;
-            public const byte TotalTrainingEffect = 24;
-            public const byte FirstLapIndex = 25;
-            public const byte NumLaps = 26;
-            public const byte EventGroup = 27;
-            public const byte Trigger = 28;
-            public const byte NecLat = 29;
-            public const byte NecLong = 30;
-            public const byte SwcLat = 31;
-            public const byte SwcLong = 32;
-            public const byte NumLengths = 33;
-            public const byte NormalizedPower = 34;
-            public const byte TrainingStressScore = 35;
-            public const byte IntensityFactor = 36;
-            public const byte LeftRightBalance = 37;
-            public const byte EndPositionLat = 38;
-            public const byte EndPositionLong = 39;
-            public const byte AvgStrokeCount = 41;
-            public const byte AvgStrokeDistance = 42;
-            public const byte SwimStroke = 43;
-            public const byte PoolLength = 44;
-            public const byte ThresholdPower = 45;
-            public const byte PoolLengthUnit = 46;
-            public const byte NumActiveLengths = 47;
-            public const byte TotalWork = 48;
-            public const byte AvgAltitude = 49;
-            public const byte MaxAltitude = 50;
-            public const byte GpsAccuracy = 51;
-            public const byte AvgGrade = 52;
-            public const byte AvgPosGrade = 53;
-            public const byte AvgNegGrade = 54;
-            public const byte MaxPosGrade = 55;
-            public const byte MaxNegGrade = 56;
-            public const byte AvgTemperature = 57;
-            public const byte MaxTemperature = 58;
-            public const byte TotalMovingTime = 59;
-            public const byte AvgPosVerticalSpeed = 60;
-            public const byte AvgNegVerticalSpeed = 61;
-            public const byte MaxPosVerticalSpeed = 62;
-            public const byte MaxNegVerticalSpeed = 63;
-            public const byte MinHeartRate = 64;
-            public const byte TimeInHrZone = 65;
-            public const byte TimeInSpeedZone = 66;
-            public const byte TimeInCadenceZone = 67;
-            public const byte TimeInPowerZone = 68;
-            public const byte AvgLapTime = 69;
-            public const byte BestLapIndex = 70;
-            public const byte MinAltitude = 71;
-            public const byte PlayerScore = 82;
-            public const byte OpponentScore = 83;
-            public const byte OpponentName = 84;
-            public const byte StrokeCount = 85;
-            public const byte ZoneCount = 86;
-            public const byte MaxBallSpeed = 87;
-            public const byte AvgBallSpeed = 88;
-            public const byte AvgVerticalOscillation = 89;
-            public const byte AvgStanceTimePercent = 90;
-            public const byte AvgStanceTime = 91;
-            public const byte AvgFractionalCadence = 92;
-            public const byte MaxFractionalCadence = 93;
-            public const byte TotalFractionalCycles = 94;
-            public const byte AvgTotalHemoglobinConc = 95;
-            public const byte MinTotalHemoglobinConc = 96;
-            public const byte MaxTotalHemoglobinConc = 97;
-            public const byte AvgSaturatedHemoglobinPercent = 98;
-            public const byte MinSaturatedHemoglobinPercent = 99;
-            public const byte MaxSaturatedHemoglobinPercent = 100;
-            public const byte AvgLeftTorqueEffectiveness = 101;
-            public const byte AvgRightTorqueEffectiveness = 102;
-            public const byte AvgLeftPedalSmoothness = 103;
-            public const byte AvgRightPedalSmoothness = 104;
-            public const byte AvgCombinedPedalSmoothness = 105;
-            public const byte SportProfileName = 110;
-            public const byte SportIndex = 111;
-            public const byte TimeStanding = 112;
-            public const byte StandCount = 113;
-            public const byte AvgLeftPco = 114;
-            public const byte AvgRightPco = 115;
-            public const byte AvgLeftPowerPhase = 116;
-            public const byte AvgLeftPowerPhasePeak = 117;
-            public const byte AvgRightPowerPhase = 118;
-            public const byte AvgRightPowerPhasePeak = 119;
-            public const byte AvgPowerPosition = 120;
-            public const byte MaxPowerPosition = 121;
-            public const byte AvgCadencePosition = 122;
-            public const byte MaxCadencePosition = 123;
-            public const byte EnhancedAvgSpeed = 124;
-            public const byte EnhancedMaxSpeed = 125;
-            public const byte EnhancedAvgAltitude = 126;
-            public const byte EnhancedMinAltitude = 127;
-            public const byte EnhancedMaxAltitude = 128;
-            public const byte AvgLevMotorPower = 129;
-            public const byte MaxLevMotorPower = 130;
-            public const byte LevBatteryConsumption = 131;
-            public const byte AvgVerticalRatio = 132;
-            public const byte AvgStanceTimeBalance = 133;
-            public const byte AvgStepLength = 134;
-            public const byte TotalAnaerobicTrainingEffect = 137;
-            public const byte AvgVam = 139;
-            public const byte AvgDepth = 140;
-            public const byte MaxDepth = 141;
-            public const byte SurfaceInterval = 142;
-            public const byte StartCns = 143;
-            public const byte EndCns = 144;
-            public const byte StartN2 = 145;
-            public const byte EndN2 = 146;
-            public const byte AvgRespirationRate = 147;
-            public const byte MaxRespirationRate = 148;
-            public const byte MinRespirationRate = 149;
-            public const byte MinTemperature = 150;
-            public const byte O2Toxicity = 155;
-            public const byte DiveNumber = 156;
-            public const byte TrainingLoadPeak = 168;
-            public const byte EnhancedAvgRespirationRate = 169;
-            public const byte EnhancedMaxRespirationRate = 170;
-            public const byte EnhancedMinRespirationRate = 180;
-            public const byte TotalGrit = 181;
-            public const byte TotalFlow = 182;
-            public const byte JumpCount = 183;
-            public const byte AvgGrit = 186;
-            public const byte AvgFlow = 187;
-            public const byte WorkoutFeel = 192;
-            public const byte WorkoutRpe = 193;
-            public const byte AvgSpo2 = 194;
-            public const byte AvgStress = 195;
-            public const byte SdrrHrv = 197;
-            public const byte RmssdHrv = 198;
-            public const byte TotalFractionalAscent = 199;
-            public const byte TotalFractionalDescent = 200;
-            public const byte AvgCoreTemperature = 208;
-            public const byte MinCoreTemperature = 209;
-            public const byte MaxCoreTemperature = 210;
-            public const byte Invalid = Fit.FieldNumInvalid;
-        }
-
-        #region Constructors
-        public SessionMesg() : base(Profile.GetMesg(MesgNum.Session))
-        {
-        }
-
-        public SessionMesg(Mesg mesg) : base(mesg)
-        {
-        }
-        #endregion // Constructors
-
-        #region Methods
-        ///<summary>
-        /// Retrieves the MessageIndex field
-        /// Comment: Selected bit is set for the current session.</summary>
-        /// <returns>Returns nullable ushort representing the MessageIndex field</returns>
-        public ushort? GetMessageIndex()
-        {
-            Object val = GetFieldValue(254, 0, Fit.SubfieldIndexMainField);
-            if(val == null)
-            {
-                return null;
-            }
-
-            return (Convert.ToUInt16(val));
-            
-        }
-
-        /// <summary>
-        /// Set MessageIndex field
-        /// Comment: Selected bit is set for the current session.</summary>
-        /// <param name="messageIndex_">Nullable field value to be set</param>
-        public void SetMessageIndex(ushort? messageIndex_)
-        {
-            SetFieldValue(254, 0, messageIndex_, Fit.SubfieldIndexMainField);
-        }
-        
-        ///<summary>
-        /// Retrieves the Timestamp field
-        /// Units: s
-        /// Comment: Sesson end time.</summary>
-        /// <returns>Returns DateTime representing the Timestamp field</returns>
-        public DateTime GetTimestamp()
-        {
-            Object val = GetFieldValue(253, 0, Fit.SubfieldIndexMainField);
-            if(val == null)
-            {
-                return null;
-            }
-
-            return TimestampToDateTime(Convert.ToUInt32(val));
-            
-        }
-
-        /// <summary>
-        /// Set Timestamp field
-        /// Units: s
-        /// Comment: Sesson end time.</summary>
-        /// <param name="timestamp_">Nullable field value to be set</param>
-        public void SetTimestamp(DateTime timestamp_)
-        {
-            SetFieldValue(253, 0, timestamp_.GetTimeStamp(), Fit.SubfieldIndexMainField);
-        }
-        
-        ///<summary>
-        /// Retrieves the Event field
-        /// Comment: session</summary>
-        /// <returns>Returns nullable Event enum representing the Event field</returns>
-        public Event? GetEvent()
-        {
-            object obj = GetFieldValue(0, 0, Fit.SubfieldIndexMainField);
-            Event? value = obj == null ? (Event?)null : (Event)obj;
-            return value;
-        }
-
-        /// <summary>
-        /// Set Event field
-        /// Comment: session</summary>
-        /// <param name="event_">Nullable field value to be set</param>
-        public void SetEvent(Event? event_)
-        {
-            SetFieldValue(0, 0, event_, Fit.SubfieldIndexMainField);
-        }
-        
-        ///<summary>
-        /// Retrieves the EventType field
-        /// Comment: stop</summary>
-        /// <returns>Returns nullable EventType enum representing the EventType field</returns>
-        public EventType? GetEventType()
-        {
-            object obj = GetFieldValue(1, 0, Fit.SubfieldIndexMainField);
-            EventType? value = obj == null ? (EventType?)null : (EventType)obj;
-            return value;
-        }
-
-        /// <summary>
-        /// Set EventType field
-        /// Comment: stop</summary>
-        /// <param name="eventType_">Nullable field value to be set</param>
-        public void SetEventType(EventType? eventType_)
-        {
-            SetFieldValue(1, 0, eventType_, Fit.SubfieldIndexMainField);
-        }
-        
-        ///<summary>
-        /// Retrieves the StartTime field</summary>
-        /// <returns>Returns DateTime representing the StartTime field</returns>
-        public DateTime GetStartTime()
-        {
-            Object val = GetFieldValue(2, 0, Fit.SubfieldIndexMainField);
-            if(val == null)
-            {
-                return null;
-            }
-
-            return TimestampToDateTime(Convert.ToUInt32(val));
-            
-        }
-
-        /// <summary>
-        /// Set StartTime field</summary>
-        /// <param name="startTime_">Nullable field value to be set</param>
-        public void SetStartTime(DateTime startTime_)
-        {
-            SetFieldValue(2, 0, startTime_.GetTimeStamp(), Fit.SubfieldIndexMainField);
-        }
-        
-        ///<summary>
-        /// Retrieves the StartPositionLat field
-        /// Units: semicircles</summary>
-        /// <returns>Returns nullable int representing the StartPositionLat field</returns>
-        public int? GetStartPositionLat()
-        {
-            Object val = GetFieldValue(3, 0, Fit.SubfieldIndexMainField);
-            if(val == null)
-            {
-                return null;
-            }
-
-            return (Convert.ToInt32(val));
-            
-        }
-
-        /// <summary>
-        /// Set StartPositionLat field
-        /// Units: semicircles</summary>
-        /// <param name="startPositionLat_">Nullable field value to be set</param>
-        public void SetStartPositionLat(int? startPositionLat_)
-        {
-            SetFieldValue(3, 0, startPositionLat_, Fit.SubfieldIndexMainField);
-        }
-        
-        ///<summary>
-        /// Retrieves the StartPositionLong field
-        /// Units: semicircles</summary>
-        /// <returns>Returns nullable int representing the StartPositionLong field</returns>
-        public int? GetStartPositionLong()
-        {
-            Object val = GetFieldValue(4, 0, Fit.SubfieldIndexMainField);
-            if(val == null)
-            {
-                return null;
-            }
-
-            return (Convert.ToInt32(val));
-            
-        }
-
-        /// <summary>
-        /// Set StartPositionLong field
-        /// Units: semicircles</summary>
-        /// <param name="startPositionLong_">Nullable field value to be set</param>
-        public void SetStartPositionLong(int? startPositionLong_)
-        {
-            SetFieldValue(4, 0, startPositionLong_, Fit.SubfieldIndexMainField);
-        }
-        
-        ///<summary>
-        /// Retrieves the Sport field</summary>
-        /// <returns>Returns nullable Sport enum representing the Sport field</returns>
-        public Sport? GetSport()
-        {
-            object obj = GetFieldValue(5, 0, Fit.SubfieldIndexMainField);
-            Sport? value = obj == null ? (Sport?)null : (Sport)obj;
-            return value;
-        }
-
-        /// <summary>
-        /// Set Sport field</summary>
-        /// <param name="sport_">Nullable field value to be set</param>
-        public void SetSport(Sport? sport_)
-        {
-            SetFieldValue(5, 0, sport_, Fit.SubfieldIndexMainField);
-        }
-        
-        ///<summary>
-        /// Retrieves the SubSport field</summary>
-        /// <returns>Returns nullable SubSport enum representing the SubSport field</returns>
-        public SubSport? GetSubSport()
-        {
-            object obj = GetFieldValue(6, 0, Fit.SubfieldIndexMainField);
-            SubSport? value = obj == null ? (SubSport?)null : (SubSport)obj;
-            return value;
-        }
-
-        /// <summary>
-        /// Set SubSport field</summary>
-        /// <param name="subSport_">Nullable field value to be set</param>
-        public void SetSubSport(SubSport? subSport_)
-        {
-            SetFieldValue(6, 0, subSport_, Fit.SubfieldIndexMainField);
-        }
-        
-        ///<summary>
-        /// Retrieves the TotalElapsedTime field
-        /// Units: s
-        /// Comment: Time (includes pauses)</summary>
-        /// <returns>Returns nullable float representing the TotalElapsedTime field</returns>
-        public float? GetTotalElapsedTime()
-        {
-            Object val = GetFieldValue(7, 0, Fit.SubfieldIndexMainField);
-            if(val == null)
-            {
-                return null;
-            }
-
-            return (Convert.ToSingle(val));
-            
-        }
-
-        /// <summary>
-        /// Set TotalElapsedTime field
-        /// Units: s
-        /// Comment: Time (includes pauses)</summary>
-        /// <param name="totalElapsedTime_">Nullable field value to be set</param>
-        public void SetTotalElapsedTime(float? totalElapsedTime_)
-        {
-            SetFieldValue(7, 0, totalElapsedTime_, Fit.SubfieldIndexMainField);
-        }
-        
-        ///<summary>
-        /// Retrieves the TotalTimerTime field
-        /// Units: s
-        /// Comment: Timer Time (excludes pauses)</summary>
-        /// <returns>Returns nullable float representing the TotalTimerTime field</returns>
-        public float? GetTotalTimerTime()
-        {
-            Object val = GetFieldValue(8, 0, Fit.SubfieldIndexMainField);
-            if(val == null)
-            {
-                return null;
-            }
-
-            return (Convert.ToSingle(val));
-            
-        }
-
-        /// <summary>
-        /// Set TotalTimerTime field
-        /// Units: s
-        /// Comment: Timer Time (excludes pauses)</summary>
-        /// <param name="totalTimerTime_">Nullable field value to be set</param>
-        public void SetTotalTimerTime(float? totalTimerTime_)
-        {
-            SetFieldValue(8, 0, totalTimerTime_, Fit.SubfieldIndexMainField);
-        }
-        
-        ///<summary>
-        /// Retrieves the TotalDistance field
-        /// Units: m</summary>
-        /// <returns>Returns nullable float representing the TotalDistance field</returns>
-        public float? GetTotalDistance()
-        {
-            Object val = GetFieldValue(9, 0, Fit.SubfieldIndexMainField);
-            if(val == null)
-            {
-                return null;
-            }
-
-            return (Convert.ToSingle(val));
-            
-        }
-
-        /// <summary>
-        /// Set TotalDistance field
-        /// Units: m</summary>
-        /// <param name="totalDistance_">Nullable field value to be set</param>
-        public void SetTotalDistance(float? totalDistance_)
-        {
-            SetFieldValue(9, 0, totalDistance_, Fit.SubfieldIndexMainField);
-        }
-        
-        ///<summary>
-        /// Retrieves the TotalCycles field
-        /// Units: cycles</summary>
-        /// <returns>Returns nullable uint representing the TotalCycles field</returns>
-        public uint? GetTotalCycles()
-        {
-            Object val = GetFieldValue(10, 0, Fit.SubfieldIndexMainField);
-            if(val == null)
-            {
-                return null;
-            }
-
-            return (Convert.ToUInt32(val));
-            
-        }
-
-        /// <summary>
-        /// Set TotalCycles field
-        /// Units: cycles</summary>
-        /// <param name="totalCycles_">Nullable field value to be set</param>
-        public void SetTotalCycles(uint? totalCycles_)
-        {
-            SetFieldValue(10, 0, totalCycles_, Fit.SubfieldIndexMainField);
-        }
-        
-
-        /// <summary>
-        /// Retrieves the TotalStrides subfield
-        /// Units: strides</summary>
-        /// <returns>Nullable uint representing the TotalStrides subfield</returns>
-        public uint? GetTotalStrides()
-        {
-            Object val = GetFieldValue(10, 0, TotalCyclesSubfield.TotalStrides);
-            if(val == null)
-            {
-                return null;
-            }
-
-            return (Convert.ToUInt32(val));
-            
-        }
-
-        /// <summary>
-        ///
-        /// Set TotalStrides subfield
-        /// Units: strides</summary>
-        /// <param name="totalStrides">Subfield value to be set</param>
-        public void SetTotalStrides(uint? totalStrides)
-        {
-            SetFieldValue(10, 0, totalStrides, TotalCyclesSubfield.TotalStrides);
-        }
-
-        /// <summary>
-        /// Retrieves the TotalStrokes subfield
-        /// Units: strokes</summary>
-        /// <returns>Nullable uint representing the TotalStrokes subfield</returns>
-        public uint? GetTotalStrokes()
-        {
-            Object val = GetFieldValue(10, 0, TotalCyclesSubfield.TotalStrokes);
-            if(val == null)
-            {
-                return null;
-            }
-
-            return (Convert.ToUInt32(val));
-            
-        }
-
-        /// <summary>
-        ///
-        /// Set TotalStrokes subfield
-        /// Units: strokes</summary>
-        /// <param name="totalStrokes">Subfield value to be set</param>
-        public void SetTotalStrokes(uint? totalStrokes)
-        {
-            SetFieldValue(10, 0, totalStrokes, TotalCyclesSubfield.TotalStrokes);
-        }
-        ///<summary>
-        /// Retrieves the TotalCalories field
-        /// Units: kcal</summary>
-        /// <returns>Returns nullable ushort representing the TotalCalories field</returns>
-        public ushort? GetTotalCalories()
-        {
-            Object val = GetFieldValue(11, 0, Fit.SubfieldIndexMainField);
-            if(val == null)
-            {
-                return null;
-            }
-
-            return (Convert.ToUInt16(val));
-            
-        }
-
-        /// <summary>
-        /// Set TotalCalories field
-        /// Units: kcal</summary>
-        /// <param name="totalCalories_">Nullable field value to be set</param>
-        public void SetTotalCalories(ushort? totalCalories_)
-        {
-            SetFieldValue(11, 0, totalCalories_, Fit.SubfieldIndexMainField);
-        }
-        
-        ///<summary>
-        /// Retrieves the TotalFatCalories field
-        /// Units: kcal</summary>
-        /// <returns>Returns nullable ushort representing the TotalFatCalories field</returns>
-        public ushort? GetTotalFatCalories()
-        {
-            Object val = GetFieldValue(13, 0, Fit.SubfieldIndexMainField);
-            if(val == null)
-            {
-                return null;
-            }
-
-            return (Convert.ToUInt16(val));
-            
-        }
-
-        /// <summary>
-        /// Set TotalFatCalories field
-        /// Units: kcal</summary>
-        /// <param name="totalFatCalories_">Nullable field value to be set</param>
-        public void SetTotalFatCalories(ushort? totalFatCalories_)
-        {
-            SetFieldValue(13, 0, totalFatCalories_, Fit.SubfieldIndexMainField);
-        }
-        
-        ///<summary>
-        /// Retrieves the AvgSpeed field
-        /// Units: m/s
-        /// Comment: total_distance / total_timer_time</summary>
-        /// <returns>Returns nullable float representing the AvgSpeed field</returns>
-        public float? GetAvgSpeed()
-        {
-            Object val = GetFieldValue(14, 0, Fit.SubfieldIndexMainField);
-            if(val == null)
-            {
-                return null;
-            }
-
-            return (Convert.ToSingle(val));
-            
-        }
-
-        /// <summary>
-        /// Set AvgSpeed field
-        /// Units: m/s
-        /// Comment: total_distance / total_timer_time</summary>
-        /// <param name="avgSpeed_">Nullable field value to be set</param>
-        public void SetAvgSpeed(float? avgSpeed_)
-        {
-            SetFieldValue(14, 0, avgSpeed_, Fit.SubfieldIndexMainField);
-        }
-        
-        ///<summary>
-        /// Retrieves the MaxSpeed field
-        /// Units: m/s</summary>
-        /// <returns>Returns nullable float representing the MaxSpeed field</returns>
-        public float? GetMaxSpeed()
-        {
-            Object val = GetFieldValue(15, 0, Fit.SubfieldIndexMainField);
-            if(val == null)
-            {
-                return null;
-            }
-
-            return (Convert.ToSingle(val));
-            
-        }
-
-        /// <summary>
-        /// Set MaxSpeed field
-        /// Units: m/s</summary>
-        /// <param name="maxSpeed_">Nullable field value to be set</param>
-        public void SetMaxSpeed(float? maxSpeed_)
-        {
-            SetFieldValue(15, 0, maxSpeed_, Fit.SubfieldIndexMainField);
-        }
-        
-        ///<summary>
-        /// Retrieves the AvgHeartRate field
-        /// Units: bpm
-        /// Comment: average heart rate (excludes pause time)</summary>
-        /// <returns>Returns nullable byte representing the AvgHeartRate field</returns>
-        public byte? GetAvgHeartRate()
-        {
-            Object val = GetFieldValue(16, 0, Fit.SubfieldIndexMainField);
-            if(val == null)
-            {
-                return null;
-            }
-
-            return (Convert.ToByte(val));
-            
-        }
-
-        /// <summary>
-        /// Set AvgHeartRate field
-        /// Units: bpm
-        /// Comment: average heart rate (excludes pause time)</summary>
-        /// <param name="avgHeartRate_">Nullable field value to be set</param>
-        public void SetAvgHeartRate(byte? avgHeartRate_)
-        {
-            SetFieldValue(16, 0, avgHeartRate_, Fit.SubfieldIndexMainField);
-        }
-        
-        ///<summary>
-        /// Retrieves the MaxHeartRate field
-        /// Units: bpm</summary>
-        /// <returns>Returns nullable byte representing the MaxHeartRate field</returns>
-        public byte? GetMaxHeartRate()
-        {
-            Object val = GetFieldValue(17, 0, Fit.SubfieldIndexMainField);
-            if(val == null)
-            {
-                return null;
-            }
-
-            return (Convert.ToByte(val));
-            
-        }
-
-        /// <summary>
-        /// Set MaxHeartRate field
-        /// Units: bpm</summary>
-        /// <param name="maxHeartRate_">Nullable field value to be set</param>
-        public void SetMaxHeartRate(byte? maxHeartRate_)
-        {
-            SetFieldValue(17, 0, maxHeartRate_, Fit.SubfieldIndexMainField);
-        }
-        
-        ///<summary>
-        /// Retrieves the AvgCadence field
-        /// Units: rpm
-        /// Comment: total_cycles / total_timer_time if non_zero_avg_cadence otherwise total_cycles / total_elapsed_time</summary>
-        /// <returns>Returns nullable byte representing the AvgCadence field</returns>
-        public byte? GetAvgCadence()
-        {
-            Object val = GetFieldValue(18, 0, Fit.SubfieldIndexMainField);
-            if(val == null)
-            {
-                return null;
-            }
-
-            return (Convert.ToByte(val));
-            
-        }
-
-        /// <summary>
-        /// Set AvgCadence field
-        /// Units: rpm
-        /// Comment: total_cycles / total_timer_time if non_zero_avg_cadence otherwise total_cycles / total_elapsed_time</summary>
-        /// <param name="avgCadence_">Nullable field value to be set</param>
-        public void SetAvgCadence(byte? avgCadence_)
-        {
-            SetFieldValue(18, 0, avgCadence_, Fit.SubfieldIndexMainField);
-        }
-        
-
-        /// <summary>
-        /// Retrieves the AvgRunningCadence subfield
-        /// Units: strides/min</summary>
-        /// <returns>Nullable byte representing the AvgRunningCadence subfield</returns>
-        public byte? GetAvgRunningCadence()
-        {
-            Object val = GetFieldValue(18, 0, AvgCadenceSubfield.AvgRunningCadence);
-            if(val == null)
-            {
-                return null;
-            }
-
-            return (Convert.ToByte(val));
-            
-        }
-
-        /// <summary>
-        ///
-        /// Set AvgRunningCadence subfield
-        /// Units: strides/min</summary>
-        /// <param name="avgRunningCadence">Subfield value to be set</param>
-        public void SetAvgRunningCadence(byte? avgRunningCadence)
-        {
-            SetFieldValue(18, 0, avgRunningCadence, AvgCadenceSubfield.AvgRunningCadence);
-        }
-        ///<summary>
-        /// Retrieves the MaxCadence field
-        /// Units: rpm</summary>
-        /// <returns>Returns nullable byte representing the MaxCadence field</returns>
-        public byte? GetMaxCadence()
-        {
-            Object val = GetFieldValue(19, 0, Fit.SubfieldIndexMainField);
-            if(val == null)
-            {
-                return null;
-            }
-
-            return (Convert.ToByte(val));
-            
-        }
-
-        /// <summary>
-        /// Set MaxCadence field
-        /// Units: rpm</summary>
-        /// <param name="maxCadence_">Nullable field value to be set</param>
-        public void SetMaxCadence(byte? maxCadence_)
-        {
-            SetFieldValue(19, 0, maxCadence_, Fit.SubfieldIndexMainField);
-        }
-        
-
-        /// <summary>
-        /// Retrieves the MaxRunningCadence subfield
-        /// Units: strides/min</summary>
-        /// <returns>Nullable byte representing the MaxRunningCadence subfield</returns>
-        public byte? GetMaxRunningCadence()
-        {
-            Object val = GetFieldValue(19, 0, MaxCadenceSubfield.MaxRunningCadence);
-            if(val == null)
-            {
-                return null;
-            }
-
-            return (Convert.ToByte(val));
-            
-        }
-
-        /// <summary>
-        ///
-        /// Set MaxRunningCadence subfield
-        /// Units: strides/min</summary>
-        /// <param name="maxRunningCadence">Subfield value to be set</param>
-        public void SetMaxRunningCadence(byte? maxRunningCadence)
-        {
-            SetFieldValue(19, 0, maxRunningCadence, MaxCadenceSubfield.MaxRunningCadence);
-        }
-        ///<summary>
-        /// Retrieves the AvgPower field
-        /// Units: watts
-        /// Comment: total_power / total_timer_time if non_zero_avg_power otherwise total_power / total_elapsed_time</summary>
-        /// <returns>Returns nullable ushort representing the AvgPower field</returns>
-        public ushort? GetAvgPower()
-        {
-            Object val = GetFieldValue(20, 0, Fit.SubfieldIndexMainField);
-            if(val == null)
-            {
-                return null;
-            }
-
-            return (Convert.ToUInt16(val));
-            
-        }
-
-        /// <summary>
-        /// Set AvgPower field
-        /// Units: watts
-        /// Comment: total_power / total_timer_time if non_zero_avg_power otherwise total_power / total_elapsed_time</summary>
-        /// <param name="avgPower_">Nullable field value to be set</param>
-        public void SetAvgPower(ushort? avgPower_)
-        {
-            SetFieldValue(20, 0, avgPower_, Fit.SubfieldIndexMainField);
-        }
-        
-        ///<summary>
-        /// Retrieves the MaxPower field
-        /// Units: watts</summary>
-        /// <returns>Returns nullable ushort representing the MaxPower field</returns>
-        public ushort? GetMaxPower()
-        {
-            Object val = GetFieldValue(21, 0, Fit.SubfieldIndexMainField);
-            if(val == null)
-            {
-                return null;
-            }
-
-            return (Convert.ToUInt16(val));
-            
-        }
-
-        /// <summary>
-        /// Set MaxPower field
-        /// Units: watts</summary>
-        /// <param name="maxPower_">Nullable field value to be set</param>
-        public void SetMaxPower(ushort? maxPower_)
-        {
-            SetFieldValue(21, 0, maxPower_, Fit.SubfieldIndexMainField);
-        }
-        
-        ///<summary>
-        /// Retrieves the TotalAscent field
-        /// Units: m</summary>
-        /// <returns>Returns nullable ushort representing the TotalAscent field</returns>
-        public ushort? GetTotalAscent()
-        {
-            Object val = GetFieldValue(22, 0, Fit.SubfieldIndexMainField);
-            if(val == null)
-            {
-                return null;
-            }
-
-            return (Convert.ToUInt16(val));
-            
-        }
-
-        /// <summary>
-        /// Set TotalAscent field
-        /// Units: m</summary>
-        /// <param name="totalAscent_">Nullable field value to be set</param>
-        public void SetTotalAscent(ushort? totalAscent_)
-        {
-            SetFieldValue(22, 0, totalAscent_, Fit.SubfieldIndexMainField);
-        }
-        
-        ///<summary>
-        /// Retrieves the TotalDescent field
-        /// Units: m</summary>
-        /// <returns>Returns nullable ushort representing the TotalDescent field</returns>
-        public ushort? GetTotalDescent()
-        {
-            Object val = GetFieldValue(23, 0, Fit.SubfieldIndexMainField);
-            if(val == null)
-            {
-                return null;
-            }
-
-            return (Convert.ToUInt16(val));
-            
-        }
-
-        /// <summary>
-        /// Set TotalDescent field
-        /// Units: m</summary>
-        /// <param name="totalDescent_">Nullable field value to be set</param>
-        public void SetTotalDescent(ushort? totalDescent_)
-        {
-            SetFieldValue(23, 0, totalDescent_, Fit.SubfieldIndexMainField);
-        }
-        
-        ///<summary>
-        /// Retrieves the TotalTrainingEffect field</summary>
-        /// <returns>Returns nullable float representing the TotalTrainingEffect field</returns>
-        public float? GetTotalTrainingEffect()
-        {
-            Object val = GetFieldValue(24, 0, Fit.SubfieldIndexMainField);
-            if(val == null)
-            {
-                return null;
-            }
-
-            return (Convert.ToSingle(val));
-            
-        }
-
-        /// <summary>
-        /// Set TotalTrainingEffect field</summary>
-        /// <param name="totalTrainingEffect_">Nullable field value to be set</param>
-        public void SetTotalTrainingEffect(float? totalTrainingEffect_)
-        {
-            SetFieldValue(24, 0, totalTrainingEffect_, Fit.SubfieldIndexMainField);
-        }
-        
-        ///<summary>
-        /// Retrieves the FirstLapIndex field</summary>
-        /// <returns>Returns nullable ushort representing the FirstLapIndex field</returns>
-        public ushort? GetFirstLapIndex()
-        {
-            Object val = GetFieldValue(25, 0, Fit.SubfieldIndexMainField);
-            if(val == null)
-            {
-                return null;
-            }
-
-            return (Convert.ToUInt16(val));
-            
-        }
-
-        /// <summary>
-        /// Set FirstLapIndex field</summary>
-        /// <param name="firstLapIndex_">Nullable field value to be set</param>
-        public void SetFirstLapIndex(ushort? firstLapIndex_)
-        {
-            SetFieldValue(25, 0, firstLapIndex_, Fit.SubfieldIndexMainField);
-        }
-        
-        ///<summary>
-        /// Retrieves the NumLaps field</summary>
-        /// <returns>Returns nullable ushort representing the NumLaps field</returns>
-        public ushort? GetNumLaps()
-        {
-            Object val = GetFieldValue(26, 0, Fit.SubfieldIndexMainField);
-            if(val == null)
-            {
-                return null;
-            }
-
-            return (Convert.ToUInt16(val));
-            
-        }
-
-        /// <summary>
-        /// Set NumLaps field</summary>
-        /// <param name="numLaps_">Nullable field value to be set</param>
-        public void SetNumLaps(ushort? numLaps_)
-        {
-            SetFieldValue(26, 0, numLaps_, Fit.SubfieldIndexMainField);
-        }
-        
-        ///<summary>
-        /// Retrieves the EventGroup field</summary>
-        /// <returns>Returns nullable byte representing the EventGroup field</returns>
-        public byte? GetEventGroup()
-        {
-            Object val = GetFieldValue(27, 0, Fit.SubfieldIndexMainField);
-            if(val == null)
-            {
-                return null;
-            }
-
-            return (Convert.ToByte(val));
-            
-        }
-
-        /// <summary>
-        /// Set EventGroup field</summary>
-        /// <param name="eventGroup_">Nullable field value to be set</param>
-        public void SetEventGroup(byte? eventGroup_)
-        {
-            SetFieldValue(27, 0, eventGroup_, Fit.SubfieldIndexMainField);
-        }
-        
-        ///<summary>
-        /// Retrieves the Trigger field</summary>
-        /// <returns>Returns nullable SessionTrigger enum representing the Trigger field</returns>
-        public SessionTrigger? GetTrigger()
-        {
-            object obj = GetFieldValue(28, 0, Fit.SubfieldIndexMainField);
-            SessionTrigger? value = obj == null ? (SessionTrigger?)null : (SessionTrigger)obj;
-            return value;
-        }
-
-        /// <summary>
-        /// Set Trigger field</summary>
-        /// <param name="trigger_">Nullable field value to be set</param>
-        public void SetTrigger(SessionTrigger? trigger_)
-        {
-            SetFieldValue(28, 0, trigger_, Fit.SubfieldIndexMainField);
-        }
-        
-        ///<summary>
-        /// Retrieves the NecLat field
-        /// Units: semicircles
-        /// Comment: North east corner latitude</summary>
-        /// <returns>Returns nullable int representing the NecLat field</returns>
-        public int? GetNecLat()
-        {
-            Object val = GetFieldValue(29, 0, Fit.SubfieldIndexMainField);
-            if(val == null)
-            {
-                return null;
-            }
-
-            return (Convert.ToInt32(val));
-            
-        }
-
-        /// <summary>
-        /// Set NecLat field
-        /// Units: semicircles
-        /// Comment: North east corner latitude</summary>
-        /// <param name="necLat_">Nullable field value to be set</param>
-        public void SetNecLat(int? necLat_)
-        {
-            SetFieldValue(29, 0, necLat_, Fit.SubfieldIndexMainField);
-        }
-        
-        ///<summary>
-        /// Retrieves the NecLong field
-        /// Units: semicircles
-        /// Comment: North east corner longitude</summary>
-        /// <returns>Returns nullable int representing the NecLong field</returns>
-        public int? GetNecLong()
-        {
-            Object val = GetFieldValue(30, 0, Fit.SubfieldIndexMainField);
-            if(val == null)
-            {
-                return null;
-            }
-
-            return (Convert.ToInt32(val));
-            
-        }
-
-        /// <summary>
-        /// Set NecLong field
-        /// Units: semicircles
-        /// Comment: North east corner longitude</summary>
-        /// <param name="necLong_">Nullable field value to be set</param>
-        public void SetNecLong(int? necLong_)
-        {
-            SetFieldValue(30, 0, necLong_, Fit.SubfieldIndexMainField);
-        }
-        
-        ///<summary>
-        /// Retrieves the SwcLat field
-        /// Units: semicircles
-        /// Comment: South west corner latitude</summary>
-        /// <returns>Returns nullable int representing the SwcLat field</returns>
-        public int? GetSwcLat()
-        {
-            Object val = GetFieldValue(31, 0, Fit.SubfieldIndexMainField);
-            if(val == null)
-            {
-                return null;
-            }
-
-            return (Convert.ToInt32(val));
-            
-        }
-
-        /// <summary>
-        /// Set SwcLat field
-        /// Units: semicircles
-        /// Comment: South west corner latitude</summary>
-        /// <param name="swcLat_">Nullable field value to be set</param>
-        public void SetSwcLat(int? swcLat_)
-        {
-            SetFieldValue(31, 0, swcLat_, Fit.SubfieldIndexMainField);
-        }
-        
-        ///<summary>
-        /// Retrieves the SwcLong field
-        /// Units: semicircles
-        /// Comment: South west corner longitude</summary>
-        /// <returns>Returns nullable int representing the SwcLong field</returns>
-        public int? GetSwcLong()
-        {
-            Object val = GetFieldValue(32, 0, Fit.SubfieldIndexMainField);
-            if(val == null)
-            {
-                return null;
-            }
-
-            return (Convert.ToInt32(val));
-            
-        }
-
-        /// <summary>
-        /// Set SwcLong field
-        /// Units: semicircles
-        /// Comment: South west corner longitude</summary>
-        /// <param name="swcLong_">Nullable field value to be set</param>
-        public void SetSwcLong(int? swcLong_)
-        {
-            SetFieldValue(32, 0, swcLong_, Fit.SubfieldIndexMainField);
-        }
-        
-        ///<summary>
-        /// Retrieves the NumLengths field
-        /// Units: lengths
-        /// Comment: # of lengths of swim pool</summary>
-        /// <returns>Returns nullable ushort representing the NumLengths field</returns>
-        public ushort? GetNumLengths()
-        {
-            Object val = GetFieldValue(33, 0, Fit.SubfieldIndexMainField);
-            if(val == null)
-            {
-                return null;
-            }
-
-            return (Convert.ToUInt16(val));
-            
-        }
-
-        /// <summary>
-        /// Set NumLengths field
-        /// Units: lengths
-        /// Comment: # of lengths of swim pool</summary>
-        /// <param name="numLengths_">Nullable field value to be set</param>
-        public void SetNumLengths(ushort? numLengths_)
-        {
-            SetFieldValue(33, 0, numLengths_, Fit.SubfieldIndexMainField);
-        }
-        
-        ///<summary>
-        /// Retrieves the NormalizedPower field
-        /// Units: watts</summary>
-        /// <returns>Returns nullable ushort representing the NormalizedPower field</returns>
-        public ushort? GetNormalizedPower()
-        {
-            Object val = GetFieldValue(34, 0, Fit.SubfieldIndexMainField);
-            if(val == null)
-            {
-                return null;
-            }
-
-            return (Convert.ToUInt16(val));
-            
-        }
-
-        /// <summary>
-        /// Set NormalizedPower field
-        /// Units: watts</summary>
-        /// <param name="normalizedPower_">Nullable field value to be set</param>
-        public void SetNormalizedPower(ushort? normalizedPower_)
-        {
-            SetFieldValue(34, 0, normalizedPower_, Fit.SubfieldIndexMainField);
-        }
-        
-        ///<summary>
-        /// Retrieves the TrainingStressScore field
-        /// Units: tss</summary>
-        /// <returns>Returns nullable float representing the TrainingStressScore field</returns>
-        public float? GetTrainingStressScore()
-        {
-            Object val = GetFieldValue(35, 0, Fit.SubfieldIndexMainField);
-            if(val == null)
-            {
-                return null;
-            }
-
-            return (Convert.ToSingle(val));
-            
-        }
-
-        /// <summary>
-        /// Set TrainingStressScore field
-        /// Units: tss</summary>
-        /// <param name="trainingStressScore_">Nullable field value to be set</param>
-        public void SetTrainingStressScore(float? trainingStressScore_)
-        {
-            SetFieldValue(35, 0, trainingStressScore_, Fit.SubfieldIndexMainField);
-        }
-        
-        ///<summary>
-        /// Retrieves the IntensityFactor field
-        /// Units: if</summary>
-        /// <returns>Returns nullable float representing the IntensityFactor field</returns>
-        public float? GetIntensityFactor()
-        {
-            Object val = GetFieldValue(36, 0, Fit.SubfieldIndexMainField);
-            if(val == null)
-            {
-                return null;
-            }
-
-            return (Convert.ToSingle(val));
-            
-        }
-
-        /// <summary>
-        /// Set IntensityFactor field
-        /// Units: if</summary>
-        /// <param name="intensityFactor_">Nullable field value to be set</param>
-        public void SetIntensityFactor(float? intensityFactor_)
-        {
-            SetFieldValue(36, 0, intensityFactor_, Fit.SubfieldIndexMainField);
-        }
-        
-        ///<summary>
-        /// Retrieves the LeftRightBalance field</summary>
-        /// <returns>Returns nullable ushort representing the LeftRightBalance field</returns>
-        public ushort? GetLeftRightBalance()
-        {
-            Object val = GetFieldValue(37, 0, Fit.SubfieldIndexMainField);
-            if(val == null)
-            {
-                return null;
-            }
-
-            return (Convert.ToUInt16(val));
-            
-        }
-
-        /// <summary>
-        /// Set LeftRightBalance field</summary>
-        /// <param name="leftRightBalance_">Nullable field value to be set</param>
-        public void SetLeftRightBalance(ushort? leftRightBalance_)
-        {
-            SetFieldValue(37, 0, leftRightBalance_, Fit.SubfieldIndexMainField);
-        }
-        
-        ///<summary>
-        /// Retrieves the EndPositionLat field
-        /// Units: semicircles</summary>
-        /// <returns>Returns nullable int representing the EndPositionLat field</returns>
-        public int? GetEndPositionLat()
-        {
-            Object val = GetFieldValue(38, 0, Fit.SubfieldIndexMainField);
-            if(val == null)
-            {
-                return null;
-            }
-
-            return (Convert.ToInt32(val));
-            
-        }
-
-        /// <summary>
-        /// Set EndPositionLat field
-        /// Units: semicircles</summary>
-        /// <param name="endPositionLat_">Nullable field value to be set</param>
-        public void SetEndPositionLat(int? endPositionLat_)
-        {
-            SetFieldValue(38, 0, endPositionLat_, Fit.SubfieldIndexMainField);
-        }
-        
-        ///<summary>
-        /// Retrieves the EndPositionLong field
-        /// Units: semicircles</summary>
-        /// <returns>Returns nullable int representing the EndPositionLong field</returns>
-        public int? GetEndPositionLong()
-        {
-            Object val = GetFieldValue(39, 0, Fit.SubfieldIndexMainField);
-            if(val == null)
-            {
-                return null;
-            }
-
-            return (Convert.ToInt32(val));
-            
-        }
-
-        /// <summary>
-        /// Set EndPositionLong field
-        /// Units: semicircles</summary>
-        /// <param name="endPositionLong_">Nullable field value to be set</param>
-        public void SetEndPositionLong(int? endPositionLong_)
-        {
-            SetFieldValue(39, 0, endPositionLong_, Fit.SubfieldIndexMainField);
-        }
-        
-        ///<summary>
-        /// Retrieves the AvgStrokeCount field
-        /// Units: strokes/lap</summary>
-        /// <returns>Returns nullable float representing the AvgStrokeCount field</returns>
-        public float? GetAvgStrokeCount()
-        {
-            Object val = GetFieldValue(41, 0, Fit.SubfieldIndexMainField);
-            if(val == null)
-            {
-                return null;
-            }
-
-            return (Convert.ToSingle(val));
-            
-        }
-
-        /// <summary>
-        /// Set AvgStrokeCount field
-        /// Units: strokes/lap</summary>
-        /// <param name="avgStrokeCount_">Nullable field value to be set</param>
-        public void SetAvgStrokeCount(float? avgStrokeCount_)
-        {
-            SetFieldValue(41, 0, avgStrokeCount_, Fit.SubfieldIndexMainField);
-        }
-        
-        ///<summary>
-        /// Retrieves the AvgStrokeDistance field
-        /// Units: m</summary>
-        /// <returns>Returns nullable float representing the AvgStrokeDistance field</returns>
-        public float? GetAvgStrokeDistance()
-        {
-            Object val = GetFieldValue(42, 0, Fit.SubfieldIndexMainField);
-            if(val == null)
-            {
-                return null;
-            }
-
-            return (Convert.ToSingle(val));
-            
-        }
-
-        /// <summary>
-        /// Set AvgStrokeDistance field
-        /// Units: m</summary>
-        /// <param name="avgStrokeDistance_">Nullable field value to be set</param>
-        public void SetAvgStrokeDistance(float? avgStrokeDistance_)
-        {
-            SetFieldValue(42, 0, avgStrokeDistance_, Fit.SubfieldIndexMainField);
-        }
-        
-        ///<summary>
-        /// Retrieves the SwimStroke field
-        /// Units: swim_stroke</summary>
-        /// <returns>Returns nullable SwimStroke enum representing the SwimStroke field</returns>
-        public SwimStroke? GetSwimStroke()
-        {
-            object obj = GetFieldValue(43, 0, Fit.SubfieldIndexMainField);
-            SwimStroke? value = obj == null ? (SwimStroke?)null : (SwimStroke)obj;
-            return value;
-        }
-
-        /// <summary>
-        /// Set SwimStroke field
-        /// Units: swim_stroke</summary>
-        /// <param name="swimStroke_">Nullable field value to be set</param>
-        public void SetSwimStroke(SwimStroke? swimStroke_)
-        {
-            SetFieldValue(43, 0, swimStroke_, Fit.SubfieldIndexMainField);
-        }
-        
-        ///<summary>
-        /// Retrieves the PoolLength field
-        /// Units: m</summary>
-        /// <returns>Returns nullable float representing the PoolLength field</returns>
-        public float? GetPoolLength()
-        {
-            Object val = GetFieldValue(44, 0, Fit.SubfieldIndexMainField);
-            if(val == null)
-            {
-                return null;
-            }
-
-            return (Convert.ToSingle(val));
-            
-        }
-
-        /// <summary>
-        /// Set PoolLength field
-        /// Units: m</summary>
-        /// <param name="poolLength_">Nullable field value to be set</param>
-        public void SetPoolLength(float? poolLength_)
-        {
-            SetFieldValue(44, 0, poolLength_, Fit.SubfieldIndexMainField);
-        }
-        
-        ///<summary>
-        /// Retrieves the ThresholdPower field
-        /// Units: watts</summary>
-        /// <returns>Returns nullable ushort representing the ThresholdPower field</returns>
-        public ushort? GetThresholdPower()
-        {
-            Object val = GetFieldValue(45, 0, Fit.SubfieldIndexMainField);
-            if(val == null)
-            {
-                return null;
-            }
-
-            return (Convert.ToUInt16(val));
-            
-        }
-
-        /// <summary>
-        /// Set ThresholdPower field
-        /// Units: watts</summary>
-        /// <param name="thresholdPower_">Nullable field value to be set</param>
-        public void SetThresholdPower(ushort? thresholdPower_)
-        {
-            SetFieldValue(45, 0, thresholdPower_, Fit.SubfieldIndexMainField);
-        }
-        
-        ///<summary>
-        /// Retrieves the PoolLengthUnit field</summary>
-        /// <returns>Returns nullable DisplayMeasure enum representing the PoolLengthUnit field</returns>
-        public DisplayMeasure? GetPoolLengthUnit()
-        {
-            object obj = GetFieldValue(46, 0, Fit.SubfieldIndexMainField);
-            DisplayMeasure? value = obj == null ? (DisplayMeasure?)null : (DisplayMeasure)obj;
-            return value;
-        }
-
-        /// <summary>
-        /// Set PoolLengthUnit field</summary>
-        /// <param name="poolLengthUnit_">Nullable field value to be set</param>
-        public void SetPoolLengthUnit(DisplayMeasure? poolLengthUnit_)
-        {
-            SetFieldValue(46, 0, poolLengthUnit_, Fit.SubfieldIndexMainField);
-        }
-        
-        ///<summary>
-        /// Retrieves the NumActiveLengths field
-        /// Units: lengths
-        /// Comment: # of active lengths of swim pool</summary>
-        /// <returns>Returns nullable ushort representing the NumActiveLengths field</returns>
-        public ushort? GetNumActiveLengths()
-        {
-            Object val = GetFieldValue(47, 0, Fit.SubfieldIndexMainField);
-            if(val == null)
-            {
-                return null;
-            }
-
-            return (Convert.ToUInt16(val));
-            
-        }
-
-        /// <summary>
-        /// Set NumActiveLengths field
-        /// Units: lengths
-        /// Comment: # of active lengths of swim pool</summary>
-        /// <param name="numActiveLengths_">Nullable field value to be set</param>
-        public void SetNumActiveLengths(ushort? numActiveLengths_)
-        {
-            SetFieldValue(47, 0, numActiveLengths_, Fit.SubfieldIndexMainField);
-        }
-        
-        ///<summary>
-        /// Retrieves the TotalWork field
-        /// Units: J</summary>
-        /// <returns>Returns nullable uint representing the TotalWork field</returns>
-        public uint? GetTotalWork()
-        {
-            Object val = GetFieldValue(48, 0, Fit.SubfieldIndexMainField);
-            if(val == null)
-            {
-                return null;
-            }
-
-            return (Convert.ToUInt32(val));
-            
-        }
-
-        /// <summary>
-        /// Set TotalWork field
-        /// Units: J</summary>
-        /// <param name="totalWork_">Nullable field value to be set</param>
-        public void SetTotalWork(uint? totalWork_)
-        {
-            SetFieldValue(48, 0, totalWork_, Fit.SubfieldIndexMainField);
-        }
-        
-        ///<summary>
-        /// Retrieves the AvgAltitude field
-        /// Units: m</summary>
-        /// <returns>Returns nullable float representing the AvgAltitude field</returns>
-        public float? GetAvgAltitude()
-        {
-            Object val = GetFieldValue(49, 0, Fit.SubfieldIndexMainField);
-            if(val == null)
-            {
-                return null;
-            }
-
-            return (Convert.ToSingle(val));
-            
-        }
-
-        /// <summary>
-        /// Set AvgAltitude field
-        /// Units: m</summary>
-        /// <param name="avgAltitude_">Nullable field value to be set</param>
-        public void SetAvgAltitude(float? avgAltitude_)
-        {
-            SetFieldValue(49, 0, avgAltitude_, Fit.SubfieldIndexMainField);
-        }
-        
-        ///<summary>
-        /// Retrieves the MaxAltitude field
-        /// Units: m</summary>
-        /// <returns>Returns nullable float representing the MaxAltitude field</returns>
-        public float? GetMaxAltitude()
-        {
-            Object val = GetFieldValue(50, 0, Fit.SubfieldIndexMainField);
-            if(val == null)
-            {
-                return null;
-            }
-
-            return (Convert.ToSingle(val));
-            
-        }
-
-        /// <summary>
-        /// Set MaxAltitude field
-        /// Units: m</summary>
-        /// <param name="maxAltitude_">Nullable field value to be set</param>
-        public void SetMaxAltitude(float? maxAltitude_)
-        {
-            SetFieldValue(50, 0, maxAltitude_, Fit.SubfieldIndexMainField);
-        }
-        
-        ///<summary>
-        /// Retrieves the GpsAccuracy field
-        /// Units: m</summary>
-        /// <returns>Returns nullable byte representing the GpsAccuracy field</returns>
-        public byte? GetGpsAccuracy()
-        {
-            Object val = GetFieldValue(51, 0, Fit.SubfieldIndexMainField);
-            if(val == null)
-            {
-                return null;
-            }
-
-            return (Convert.ToByte(val));
-            
-        }
-
-        /// <summary>
-        /// Set GpsAccuracy field
-        /// Units: m</summary>
-        /// <param name="gpsAccuracy_">Nullable field value to be set</param>
-        public void SetGpsAccuracy(byte? gpsAccuracy_)
-        {
-            SetFieldValue(51, 0, gpsAccuracy_, Fit.SubfieldIndexMainField);
-        }
-        
-        ///<summary>
-        /// Retrieves the AvgGrade field
-        /// Units: %</summary>
-        /// <returns>Returns nullable float representing the AvgGrade field</returns>
-        public float? GetAvgGrade()
-        {
-            Object val = GetFieldValue(52, 0, Fit.SubfieldIndexMainField);
-            if(val == null)
-            {
-                return null;
-            }
-
-            return (Convert.ToSingle(val));
-            
-        }
-
-        /// <summary>
-        /// Set AvgGrade field
-        /// Units: %</summary>
-        /// <param name="avgGrade_">Nullable field value to be set</param>
-        public void SetAvgGrade(float? avgGrade_)
-        {
-            SetFieldValue(52, 0, avgGrade_, Fit.SubfieldIndexMainField);
-        }
-        
-        ///<summary>
-        /// Retrieves the AvgPosGrade field
-        /// Units: %</summary>
-        /// <returns>Returns nullable float representing the AvgPosGrade field</returns>
-        public float? GetAvgPosGrade()
-        {
-            Object val = GetFieldValue(53, 0, Fit.SubfieldIndexMainField);
-            if(val == null)
-            {
-                return null;
-            }
-
-            return (Convert.ToSingle(val));
-            
-        }
-
-        /// <summary>
-        /// Set AvgPosGrade field
-        /// Units: %</summary>
-        /// <param name="avgPosGrade_">Nullable field value to be set</param>
-        public void SetAvgPosGrade(float? avgPosGrade_)
-        {
-            SetFieldValue(53, 0, avgPosGrade_, Fit.SubfieldIndexMainField);
-        }
-        
-        ///<summary>
-        /// Retrieves the AvgNegGrade field
-        /// Units: %</summary>
-        /// <returns>Returns nullable float representing the AvgNegGrade field</returns>
-        public float? GetAvgNegGrade()
-        {
-            Object val = GetFieldValue(54, 0, Fit.SubfieldIndexMainField);
-            if(val == null)
-            {
-                return null;
-            }
-
-            return (Convert.ToSingle(val));
-            
-        }
-
-        /// <summary>
-        /// Set AvgNegGrade field
-        /// Units: %</summary>
-        /// <param name="avgNegGrade_">Nullable field value to be set</param>
-        public void SetAvgNegGrade(float? avgNegGrade_)
-        {
-            SetFieldValue(54, 0, avgNegGrade_, Fit.SubfieldIndexMainField);
-        }
-        
-        ///<summary>
-        /// Retrieves the MaxPosGrade field
-        /// Units: %</summary>
-        /// <returns>Returns nullable float representing the MaxPosGrade field</returns>
-        public float? GetMaxPosGrade()
-        {
-            Object val = GetFieldValue(55, 0, Fit.SubfieldIndexMainField);
-            if(val == null)
-            {
-                return null;
-            }
-
-            return (Convert.ToSingle(val));
-            
-        }
-
-        /// <summary>
-        /// Set MaxPosGrade field
-        /// Units: %</summary>
-        /// <param name="maxPosGrade_">Nullable field value to be set</param>
-        public void SetMaxPosGrade(float? maxPosGrade_)
-        {
-            SetFieldValue(55, 0, maxPosGrade_, Fit.SubfieldIndexMainField);
-        }
-        
-        ///<summary>
-        /// Retrieves the MaxNegGrade field
-        /// Units: %</summary>
-        /// <returns>Returns nullable float representing the MaxNegGrade field</returns>
-        public float? GetMaxNegGrade()
-        {
-            Object val = GetFieldValue(56, 0, Fit.SubfieldIndexMainField);
-            if(val == null)
-            {
-                return null;
-            }
-
-            return (Convert.ToSingle(val));
-            
-        }
-
-        /// <summary>
-        /// Set MaxNegGrade field
-        /// Units: %</summary>
-        /// <param name="maxNegGrade_">Nullable field value to be set</param>
-        public void SetMaxNegGrade(float? maxNegGrade_)
-        {
-            SetFieldValue(56, 0, maxNegGrade_, Fit.SubfieldIndexMainField);
-        }
-        
-        ///<summary>
-        /// Retrieves the AvgTemperature field
-        /// Units: C</summary>
-        /// <returns>Returns nullable sbyte representing the AvgTemperature field</returns>
-        public sbyte? GetAvgTemperature()
-        {
-            Object val = GetFieldValue(57, 0, Fit.SubfieldIndexMainField);
-            if(val == null)
-            {
-                return null;
-            }
-
-            return (Convert.ToSByte(val));
-            
-        }
-
-        /// <summary>
-        /// Set AvgTemperature field
-        /// Units: C</summary>
-        /// <param name="avgTemperature_">Nullable field value to be set</param>
-        public void SetAvgTemperature(sbyte? avgTemperature_)
-        {
-            SetFieldValue(57, 0, avgTemperature_, Fit.SubfieldIndexMainField);
-        }
-        
-        ///<summary>
-        /// Retrieves the MaxTemperature field
-        /// Units: C</summary>
-        /// <returns>Returns nullable sbyte representing the MaxTemperature field</returns>
-        public sbyte? GetMaxTemperature()
-        {
-            Object val = GetFieldValue(58, 0, Fit.SubfieldIndexMainField);
-            if(val == null)
-            {
-                return null;
-            }
-
-            return (Convert.ToSByte(val));
-            
-        }
-
-        /// <summary>
-        /// Set MaxTemperature field
-        /// Units: C</summary>
-        /// <param name="maxTemperature_">Nullable field value to be set</param>
-        public void SetMaxTemperature(sbyte? maxTemperature_)
-        {
-            SetFieldValue(58, 0, maxTemperature_, Fit.SubfieldIndexMainField);
-        }
-        
-        ///<summary>
-        /// Retrieves the TotalMovingTime field
-        /// Units: s</summary>
-        /// <returns>Returns nullable float representing the TotalMovingTime field</returns>
-        public float? GetTotalMovingTime()
-        {
-            Object val = GetFieldValue(59, 0, Fit.SubfieldIndexMainField);
-            if(val == null)
-            {
-                return null;
-            }
-
-            return (Convert.ToSingle(val));
-            
-        }
-
-        /// <summary>
-        /// Set TotalMovingTime field
-        /// Units: s</summary>
-        /// <param name="totalMovingTime_">Nullable field value to be set</param>
-        public void SetTotalMovingTime(float? totalMovingTime_)
-        {
-            SetFieldValue(59, 0, totalMovingTime_, Fit.SubfieldIndexMainField);
-        }
-        
-        ///<summary>
-        /// Retrieves the AvgPosVerticalSpeed field
-        /// Units: m/s</summary>
-        /// <returns>Returns nullable float representing the AvgPosVerticalSpeed field</returns>
-        public float? GetAvgPosVerticalSpeed()
-        {
-            Object val = GetFieldValue(60, 0, Fit.SubfieldIndexMainField);
-            if(val == null)
-            {
-                return null;
-            }
-
-            return (Convert.ToSingle(val));
-            
-        }
-
-        /// <summary>
-        /// Set AvgPosVerticalSpeed field
-        /// Units: m/s</summary>
-        /// <param name="avgPosVerticalSpeed_">Nullable field value to be set</param>
-        public void SetAvgPosVerticalSpeed(float? avgPosVerticalSpeed_)
-        {
-            SetFieldValue(60, 0, avgPosVerticalSpeed_, Fit.SubfieldIndexMainField);
-        }
-        
-        ///<summary>
-        /// Retrieves the AvgNegVerticalSpeed field
-        /// Units: m/s</summary>
-        /// <returns>Returns nullable float representing the AvgNegVerticalSpeed field</returns>
-        public float? GetAvgNegVerticalSpeed()
-        {
-            Object val = GetFieldValue(61, 0, Fit.SubfieldIndexMainField);
-            if(val == null)
-            {
-                return null;
-            }
-
-            return (Convert.ToSingle(val));
-            
-        }
-
-        /// <summary>
-        /// Set AvgNegVerticalSpeed field
-        /// Units: m/s</summary>
-        /// <param name="avgNegVerticalSpeed_">Nullable field value to be set</param>
-        public void SetAvgNegVerticalSpeed(float? avgNegVerticalSpeed_)
-        {
-            SetFieldValue(61, 0, avgNegVerticalSpeed_, Fit.SubfieldIndexMainField);
-        }
-        
-        ///<summary>
-        /// Retrieves the MaxPosVerticalSpeed field
-        /// Units: m/s</summary>
-        /// <returns>Returns nullable float representing the MaxPosVerticalSpeed field</returns>
-        public float? GetMaxPosVerticalSpeed()
-        {
-            Object val = GetFieldValue(62, 0, Fit.SubfieldIndexMainField);
-            if(val == null)
-            {
-                return null;
-            }
-
-            return (Convert.ToSingle(val));
-            
-        }
-
-        /// <summary>
-        /// Set MaxPosVerticalSpeed field
-        /// Units: m/s</summary>
-        /// <param name="maxPosVerticalSpeed_">Nullable field value to be set</param>
-        public void SetMaxPosVerticalSpeed(float? maxPosVerticalSpeed_)
-        {
-            SetFieldValue(62, 0, maxPosVerticalSpeed_, Fit.SubfieldIndexMainField);
-        }
-        
-        ///<summary>
-        /// Retrieves the MaxNegVerticalSpeed field
-        /// Units: m/s</summary>
-        /// <returns>Returns nullable float representing the MaxNegVerticalSpeed field</returns>
-        public float? GetMaxNegVerticalSpeed()
-        {
-            Object val = GetFieldValue(63, 0, Fit.SubfieldIndexMainField);
-            if(val == null)
-            {
-                return null;
-            }
-
-            return (Convert.ToSingle(val));
-            
-        }
-
-        /// <summary>
-        /// Set MaxNegVerticalSpeed field
-        /// Units: m/s</summary>
-        /// <param name="maxNegVerticalSpeed_">Nullable field value to be set</param>
-        public void SetMaxNegVerticalSpeed(float? maxNegVerticalSpeed_)
-        {
-            SetFieldValue(63, 0, maxNegVerticalSpeed_, Fit.SubfieldIndexMainField);
-        }
-        
-        ///<summary>
-        /// Retrieves the MinHeartRate field
-        /// Units: bpm</summary>
-        /// <returns>Returns nullable byte representing the MinHeartRate field</returns>
-        public byte? GetMinHeartRate()
-        {
-            Object val = GetFieldValue(64, 0, Fit.SubfieldIndexMainField);
-            if(val == null)
-            {
-                return null;
-            }
-
-            return (Convert.ToByte(val));
-            
-        }
-
-        /// <summary>
-        /// Set MinHeartRate field
-        /// Units: bpm</summary>
-        /// <param name="minHeartRate_">Nullable field value to be set</param>
-        public void SetMinHeartRate(byte? minHeartRate_)
-        {
-            SetFieldValue(64, 0, minHeartRate_, Fit.SubfieldIndexMainField);
-        }
-        
-        
-        /// <summary>
-        ///
-        /// </summary>
-        /// <returns>returns number of elements in field TimeInHrZone</returns>
-        public int GetNumTimeInHrZone()
-        {
-            return GetNumFieldValues(65, Fit.SubfieldIndexMainField);
-        }
-
-        ///<summary>
-        /// Retrieves the TimeInHrZone field
-        /// Units: s</summary>
-        /// <param name="index">0 based index of TimeInHrZone element to retrieve</param>
-        /// <returns>Returns nullable float representing the TimeInHrZone field</returns>
-        public float? GetTimeInHrZone(int index)
-        {
-            Object val = GetFieldValue(65, index, Fit.SubfieldIndexMainField);
-            if(val == null)
-            {
-                return null;
-            }
-
-            return (Convert.ToSingle(val));
-            
-        }
-
-        /// <summary>
-        /// Set TimeInHrZone field
-        /// Units: s</summary>
-        /// <param name="index">0 based index of time_in_hr_zone</param>
-        /// <param name="timeInHrZone_">Nullable field value to be set</param>
-        public void SetTimeInHrZone(int index, float? timeInHrZone_)
-        {
-            SetFieldValue(65, index, timeInHrZone_, Fit.SubfieldIndexMainField);
-        }
-        
-        
-        /// <summary>
-        ///
-        /// </summary>
-        /// <returns>returns number of elements in field TimeInSpeedZone</returns>
-        public int GetNumTimeInSpeedZone()
-        {
-            return GetNumFieldValues(66, Fit.SubfieldIndexMainField);
-        }
-
-        ///<summary>
-        /// Retrieves the TimeInSpeedZone field
-        /// Units: s</summary>
-        /// <param name="index">0 based index of TimeInSpeedZone element to retrieve</param>
-        /// <returns>Returns nullable float representing the TimeInSpeedZone field</returns>
-        public float? GetTimeInSpeedZone(int index)
-        {
-            Object val = GetFieldValue(66, index, Fit.SubfieldIndexMainField);
-            if(val == null)
-            {
-                return null;
-            }
-
-            return (Convert.ToSingle(val));
-            
-        }
-
-        /// <summary>
-        /// Set TimeInSpeedZone field
-        /// Units: s</summary>
-        /// <param name="index">0 based index of time_in_speed_zone</param>
-        /// <param name="timeInSpeedZone_">Nullable field value to be set</param>
-        public void SetTimeInSpeedZone(int index, float? timeInSpeedZone_)
-        {
-            SetFieldValue(66, index, timeInSpeedZone_, Fit.SubfieldIndexMainField);
-        }
-        
-        
-        /// <summary>
-        ///
-        /// </summary>
-        /// <returns>returns number of elements in field TimeInCadenceZone</returns>
-        public int GetNumTimeInCadenceZone()
-        {
-            return GetNumFieldValues(67, Fit.SubfieldIndexMainField);
-        }
-
-        ///<summary>
-        /// Retrieves the TimeInCadenceZone field
-        /// Units: s</summary>
-        /// <param name="index">0 based index of TimeInCadenceZone element to retrieve</param>
-        /// <returns>Returns nullable float representing the TimeInCadenceZone field</returns>
-        public float? GetTimeInCadenceZone(int index)
-        {
-            Object val = GetFieldValue(67, index, Fit.SubfieldIndexMainField);
-            if(val == null)
-            {
-                return null;
-            }
-
-            return (Convert.ToSingle(val));
-            
-        }
-
-        /// <summary>
-        /// Set TimeInCadenceZone field
-        /// Units: s</summary>
-        /// <param name="index">0 based index of time_in_cadence_zone</param>
-        /// <param name="timeInCadenceZone_">Nullable field value to be set</param>
-        public void SetTimeInCadenceZone(int index, float? timeInCadenceZone_)
-        {
-            SetFieldValue(67, index, timeInCadenceZone_, Fit.SubfieldIndexMainField);
-        }
-        
-        
-        /// <summary>
-        ///
-        /// </summary>
-        /// <returns>returns number of elements in field TimeInPowerZone</returns>
-        public int GetNumTimeInPowerZone()
-        {
-            return GetNumFieldValues(68, Fit.SubfieldIndexMainField);
-        }
-
-        ///<summary>
-        /// Retrieves the TimeInPowerZone field
-        /// Units: s</summary>
-        /// <param name="index">0 based index of TimeInPowerZone element to retrieve</param>
-        /// <returns>Returns nullable float representing the TimeInPowerZone field</returns>
-        public float? GetTimeInPowerZone(int index)
-        {
-            Object val = GetFieldValue(68, index, Fit.SubfieldIndexMainField);
-            if(val == null)
-            {
-                return null;
-            }
-
-            return (Convert.ToSingle(val));
-            
-        }
-
-        /// <summary>
-        /// Set TimeInPowerZone field
-        /// Units: s</summary>
-        /// <param name="index">0 based index of time_in_power_zone</param>
-        /// <param name="timeInPowerZone_">Nullable field value to be set</param>
-        public void SetTimeInPowerZone(int index, float? timeInPowerZone_)
-        {
-            SetFieldValue(68, index, timeInPowerZone_, Fit.SubfieldIndexMainField);
-        }
-        
-        ///<summary>
-        /// Retrieves the AvgLapTime field
-        /// Units: s</summary>
-        /// <returns>Returns nullable float representing the AvgLapTime field</returns>
-        public float? GetAvgLapTime()
-        {
-            Object val = GetFieldValue(69, 0, Fit.SubfieldIndexMainField);
-            if(val == null)
-            {
-                return null;
-            }
-
-            return (Convert.ToSingle(val));
-            
-        }
-
-        /// <summary>
-        /// Set AvgLapTime field
-        /// Units: s</summary>
-        /// <param name="avgLapTime_">Nullable field value to be set</param>
-        public void SetAvgLapTime(float? avgLapTime_)
-        {
-            SetFieldValue(69, 0, avgLapTime_, Fit.SubfieldIndexMainField);
-        }
-        
-        ///<summary>
-        /// Retrieves the BestLapIndex field</summary>
-        /// <returns>Returns nullable ushort representing the BestLapIndex field</returns>
-        public ushort? GetBestLapIndex()
-        {
-            Object val = GetFieldValue(70, 0, Fit.SubfieldIndexMainField);
-            if(val == null)
-            {
-                return null;
-            }
-
-            return (Convert.ToUInt16(val));
-            
-        }
-
-        /// <summary>
-        /// Set BestLapIndex field</summary>
-        /// <param name="bestLapIndex_">Nullable field value to be set</param>
-        public void SetBestLapIndex(ushort? bestLapIndex_)
-        {
-            SetFieldValue(70, 0, bestLapIndex_, Fit.SubfieldIndexMainField);
-        }
-        
-        ///<summary>
-        /// Retrieves the MinAltitude field
-        /// Units: m</summary>
-        /// <returns>Returns nullable float representing the MinAltitude field</returns>
-        public float? GetMinAltitude()
-        {
-            Object val = GetFieldValue(71, 0, Fit.SubfieldIndexMainField);
-            if(val == null)
-            {
-                return null;
-            }
-
-            return (Convert.ToSingle(val));
-            
-        }
-
-        /// <summary>
-        /// Set MinAltitude field
-        /// Units: m</summary>
-        /// <param name="minAltitude_">Nullable field value to be set</param>
-        public void SetMinAltitude(float? minAltitude_)
-        {
-            SetFieldValue(71, 0, minAltitude_, Fit.SubfieldIndexMainField);
-        }
-        
-        ///<summary>
-        /// Retrieves the PlayerScore field</summary>
-        /// <returns>Returns nullable ushort representing the PlayerScore field</returns>
-        public ushort? GetPlayerScore()
-        {
-            Object val = GetFieldValue(82, 0, Fit.SubfieldIndexMainField);
-            if(val == null)
-            {
-                return null;
-            }
-
-            return (Convert.ToUInt16(val));
-            
-        }
-
-        /// <summary>
-        /// Set PlayerScore field</summary>
-        /// <param name="playerScore_">Nullable field value to be set</param>
-        public void SetPlayerScore(ushort? playerScore_)
-        {
-            SetFieldValue(82, 0, playerScore_, Fit.SubfieldIndexMainField);
-        }
-        
-        ///<summary>
-        /// Retrieves the OpponentScore field</summary>
-        /// <returns>Returns nullable ushort representing the OpponentScore field</returns>
-        public ushort? GetOpponentScore()
-        {
-            Object val = GetFieldValue(83, 0, Fit.SubfieldIndexMainField);
-            if(val == null)
-            {
-                return null;
-            }
-
-            return (Convert.ToUInt16(val));
-            
-        }
-
-        /// <summary>
-        /// Set OpponentScore field</summary>
-        /// <param name="opponentScore_">Nullable field value to be set</param>
-        public void SetOpponentScore(ushort? opponentScore_)
-        {
-            SetFieldValue(83, 0, opponentScore_, Fit.SubfieldIndexMainField);
-        }
-        
-        ///<summary>
-        /// Retrieves the OpponentName field</summary>
-        /// <returns>Returns byte[] representing the OpponentName field</returns>
-        public byte[] GetOpponentName()
-        {
-            byte[] data = (byte[])GetFieldValue(84, 0, Fit.SubfieldIndexMainField);
-            return data.Take(data.Length - 1).ToArray();
-        }
-
-        ///<summary>
-        /// Retrieves the OpponentName field</summary>
-        /// <returns>Returns String representing the OpponentName field</returns>
-        public String GetOpponentNameAsString()
-        {
-            byte[] data = (byte[])GetFieldValue(84, 0, Fit.SubfieldIndexMainField);
-            return data != null ? Encoding.UTF8.GetString(data, 0, data.Length - 1) : null;
-        }
-
-        ///<summary>
-        /// Set OpponentName field</summary>
-        /// <param name="opponentName_"> field value to be set</param>
-        public void SetOpponentName(String opponentName_)
-        {
-            byte[] data = Encoding.UTF8.GetBytes(opponentName_);
-            byte[] zdata = new byte[data.Length + 1];
-            data.CopyTo(zdata, 0);
-            SetFieldValue(84, 0, zdata, Fit.SubfieldIndexMainField);
-        }
-
-        
-        /// <summary>
-        /// Set OpponentName field</summary>
-        /// <param name="opponentName_">field value to be set</param>
-        public void SetOpponentName(byte[] opponentName_)
-        {
-            SetFieldValue(84, 0, opponentName_, Fit.SubfieldIndexMainField);
-        }
-        
-        
-        /// <summary>
-        ///
-        /// </summary>
-        /// <returns>returns number of elements in field StrokeCount</returns>
-        public int GetNumStrokeCount()
-        {
-            return GetNumFieldValues(85, Fit.SubfieldIndexMainField);
-        }
-
-        ///<summary>
-        /// Retrieves the StrokeCount field
-        /// Units: counts
-        /// Comment: stroke_type enum used as the index</summary>
-        /// <param name="index">0 based index of StrokeCount element to retrieve</param>
-        /// <returns>Returns nullable ushort representing the StrokeCount field</returns>
-        public ushort? GetStrokeCount(int index)
-        {
-            Object val = GetFieldValue(85, index, Fit.SubfieldIndexMainField);
-            if(val == null)
-            {
-                return null;
-            }
-
-            return (Convert.ToUInt16(val));
-            
-        }
-
-        /// <summary>
-        /// Set StrokeCount field
-        /// Units: counts
-        /// Comment: stroke_type enum used as the index</summary>
-        /// <param name="index">0 based index of stroke_count</param>
-        /// <param name="strokeCount_">Nullable field value to be set</param>
-        public void SetStrokeCount(int index, ushort? strokeCount_)
-        {
-            SetFieldValue(85, index, strokeCount_, Fit.SubfieldIndexMainField);
-        }
-        
-        
-        /// <summary>
-        ///
-        /// </summary>
-        /// <returns>returns number of elements in field ZoneCount</returns>
-        public int GetNumZoneCount()
-        {
-            return GetNumFieldValues(86, Fit.SubfieldIndexMainField);
-        }
-
-        ///<summary>
-        /// Retrieves the ZoneCount field
-        /// Units: counts
-        /// Comment: zone number used as the index</summary>
-        /// <param name="index">0 based index of ZoneCount element to retrieve</param>
-        /// <returns>Returns nullable ushort representing the ZoneCount field</returns>
-        public ushort? GetZoneCount(int index)
-        {
-            Object val = GetFieldValue(86, index, Fit.SubfieldIndexMainField);
-            if(val == null)
-            {
-                return null;
-            }
-
-            return (Convert.ToUInt16(val));
-            
-        }
-
-        /// <summary>
-        /// Set ZoneCount field
-        /// Units: counts
-        /// Comment: zone number used as the index</summary>
-        /// <param name="index">0 based index of zone_count</param>
-        /// <param name="zoneCount_">Nullable field value to be set</param>
-        public void SetZoneCount(int index, ushort? zoneCount_)
-        {
-            SetFieldValue(86, index, zoneCount_, Fit.SubfieldIndexMainField);
-        }
-        
-        ///<summary>
-        /// Retrieves the MaxBallSpeed field
-        /// Units: m/s</summary>
-        /// <returns>Returns nullable float representing the MaxBallSpeed field</returns>
-        public float? GetMaxBallSpeed()
-        {
-            Object val = GetFieldValue(87, 0, Fit.SubfieldIndexMainField);
-            if(val == null)
-            {
-                return null;
-            }
-
-            return (Convert.ToSingle(val));
-            
-        }
-
-        /// <summary>
-        /// Set MaxBallSpeed field
-        /// Units: m/s</summary>
-        /// <param name="maxBallSpeed_">Nullable field value to be set</param>
-        public void SetMaxBallSpeed(float? maxBallSpeed_)
-        {
-            SetFieldValue(87, 0, maxBallSpeed_, Fit.SubfieldIndexMainField);
-        }
-        
-        ///<summary>
-        /// Retrieves the AvgBallSpeed field
-        /// Units: m/s</summary>
-        /// <returns>Returns nullable float representing the AvgBallSpeed field</returns>
-        public float? GetAvgBallSpeed()
-        {
-            Object val = GetFieldValue(88, 0, Fit.SubfieldIndexMainField);
-            if(val == null)
-            {
-                return null;
-            }
-
-            return (Convert.ToSingle(val));
-            
-        }
-
-        /// <summary>
-        /// Set AvgBallSpeed field
-        /// Units: m/s</summary>
-        /// <param name="avgBallSpeed_">Nullable field value to be set</param>
-        public void SetAvgBallSpeed(float? avgBallSpeed_)
-        {
-            SetFieldValue(88, 0, avgBallSpeed_, Fit.SubfieldIndexMainField);
-        }
-        
-        ///<summary>
-        /// Retrieves the AvgVerticalOscillation field
-        /// Units: mm</summary>
-        /// <returns>Returns nullable float representing the AvgVerticalOscillation field</returns>
-        public float? GetAvgVerticalOscillation()
-        {
-            Object val = GetFieldValue(89, 0, Fit.SubfieldIndexMainField);
-            if(val == null)
-            {
-                return null;
-            }
-
-            return (Convert.ToSingle(val));
-            
-        }
-
-        /// <summary>
-        /// Set AvgVerticalOscillation field
-        /// Units: mm</summary>
-        /// <param name="avgVerticalOscillation_">Nullable field value to be set</param>
-        public void SetAvgVerticalOscillation(float? avgVerticalOscillation_)
-        {
-            SetFieldValue(89, 0, avgVerticalOscillation_, Fit.SubfieldIndexMainField);
-        }
-        
-        ///<summary>
-        /// Retrieves the AvgStanceTimePercent field
-        /// Units: percent</summary>
-        /// <returns>Returns nullable float representing the AvgStanceTimePercent field</returns>
-        public float? GetAvgStanceTimePercent()
-        {
-            Object val = GetFieldValue(90, 0, Fit.SubfieldIndexMainField);
-            if(val == null)
-            {
-                return null;
-            }
-
-            return (Convert.ToSingle(val));
-            
-        }
-
-        /// <summary>
-        /// Set AvgStanceTimePercent field
-        /// Units: percent</summary>
-        /// <param name="avgStanceTimePercent_">Nullable field value to be set</param>
-        public void SetAvgStanceTimePercent(float? avgStanceTimePercent_)
-        {
-            SetFieldValue(90, 0, avgStanceTimePercent_, Fit.SubfieldIndexMainField);
-        }
-        
-        ///<summary>
-        /// Retrieves the AvgStanceTime field
-        /// Units: ms</summary>
-        /// <returns>Returns nullable float representing the AvgStanceTime field</returns>
-        public float? GetAvgStanceTime()
-        {
-            Object val = GetFieldValue(91, 0, Fit.SubfieldIndexMainField);
-            if(val == null)
-            {
-                return null;
-            }
-
-            return (Convert.ToSingle(val));
-            
-        }
-
-        /// <summary>
-        /// Set AvgStanceTime field
-        /// Units: ms</summary>
-        /// <param name="avgStanceTime_">Nullable field value to be set</param>
-        public void SetAvgStanceTime(float? avgStanceTime_)
-        {
-            SetFieldValue(91, 0, avgStanceTime_, Fit.SubfieldIndexMainField);
-        }
-        
-        ///<summary>
-        /// Retrieves the AvgFractionalCadence field
-        /// Units: rpm
-        /// Comment: fractional part of the avg_cadence</summary>
-        /// <returns>Returns nullable float representing the AvgFractionalCadence field</returns>
-        public float? GetAvgFractionalCadence()
-        {
-            Object val = GetFieldValue(92, 0, Fit.SubfieldIndexMainField);
-            if(val == null)
-            {
-                return null;
-            }
-
-            return (Convert.ToSingle(val));
-            
-        }
-
-        /// <summary>
-        /// Set AvgFractionalCadence field
-        /// Units: rpm
-        /// Comment: fractional part of the avg_cadence</summary>
-        /// <param name="avgFractionalCadence_">Nullable field value to be set</param>
-        public void SetAvgFractionalCadence(float? avgFractionalCadence_)
-        {
-            SetFieldValue(92, 0, avgFractionalCadence_, Fit.SubfieldIndexMainField);
-        }
-        
-        ///<summary>
-        /// Retrieves the MaxFractionalCadence field
-        /// Units: rpm
-        /// Comment: fractional part of the max_cadence</summary>
-        /// <returns>Returns nullable float representing the MaxFractionalCadence field</returns>
-        public float? GetMaxFractionalCadence()
-        {
-            Object val = GetFieldValue(93, 0, Fit.SubfieldIndexMainField);
-            if(val == null)
-            {
-                return null;
-            }
-
-            return (Convert.ToSingle(val));
-            
-        }
-
-        /// <summary>
-        /// Set MaxFractionalCadence field
-        /// Units: rpm
-        /// Comment: fractional part of the max_cadence</summary>
-        /// <param name="maxFractionalCadence_">Nullable field value to be set</param>
-        public void SetMaxFractionalCadence(float? maxFractionalCadence_)
-        {
-            SetFieldValue(93, 0, maxFractionalCadence_, Fit.SubfieldIndexMainField);
-        }
-        
-        ///<summary>
-        /// Retrieves the TotalFractionalCycles field
-        /// Units: cycles
-        /// Comment: fractional part of the total_cycles</summary>
-        /// <returns>Returns nullable float representing the TotalFractionalCycles field</returns>
-        public float? GetTotalFractionalCycles()
-        {
-            Object val = GetFieldValue(94, 0, Fit.SubfieldIndexMainField);
-            if(val == null)
-            {
-                return null;
-            }
-
-            return (Convert.ToSingle(val));
-            
-        }
-
-        /// <summary>
-        /// Set TotalFractionalCycles field
-        /// Units: cycles
-        /// Comment: fractional part of the total_cycles</summary>
-        /// <param name="totalFractionalCycles_">Nullable field value to be set</param>
-        public void SetTotalFractionalCycles(float? totalFractionalCycles_)
-        {
-            SetFieldValue(94, 0, totalFractionalCycles_, Fit.SubfieldIndexMainField);
-        }
-        
-        
-        /// <summary>
-        ///
-        /// </summary>
-        /// <returns>returns number of elements in field AvgTotalHemoglobinConc</returns>
-        public int GetNumAvgTotalHemoglobinConc()
-        {
-            return GetNumFieldValues(95, Fit.SubfieldIndexMainField);
-        }
-
-        ///<summary>
-        /// Retrieves the AvgTotalHemoglobinConc field
-        /// Units: g/dL
-        /// Comment: Avg saturated and unsaturated hemoglobin</summary>
-        /// <param name="index">0 based index of AvgTotalHemoglobinConc element to retrieve</param>
-        /// <returns>Returns nullable float representing the AvgTotalHemoglobinConc field</returns>
-        public float? GetAvgTotalHemoglobinConc(int index)
-        {
-            Object val = GetFieldValue(95, index, Fit.SubfieldIndexMainField);
-            if(val == null)
-            {
-                return null;
-            }
-
-            return (Convert.ToSingle(val));
-            
-        }
-
-        /// <summary>
-        /// Set AvgTotalHemoglobinConc field
-        /// Units: g/dL
-        /// Comment: Avg saturated and unsaturated hemoglobin</summary>
-        /// <param name="index">0 based index of avg_total_hemoglobin_conc</param>
-        /// <param name="avgTotalHemoglobinConc_">Nullable field value to be set</param>
-        public void SetAvgTotalHemoglobinConc(int index, float? avgTotalHemoglobinConc_)
-        {
-            SetFieldValue(95, index, avgTotalHemoglobinConc_, Fit.SubfieldIndexMainField);
-        }
-        
-        
-        /// <summary>
-        ///
-        /// </summary>
-        /// <returns>returns number of elements in field MinTotalHemoglobinConc</returns>
-        public int GetNumMinTotalHemoglobinConc()
-        {
-            return GetNumFieldValues(96, Fit.SubfieldIndexMainField);
-        }
-
-        ///<summary>
-        /// Retrieves the MinTotalHemoglobinConc field
-        /// Units: g/dL
-        /// Comment: Min saturated and unsaturated hemoglobin</summary>
-        /// <param name="index">0 based index of MinTotalHemoglobinConc element to retrieve</param>
-        /// <returns>Returns nullable float representing the MinTotalHemoglobinConc field</returns>
-        public float? GetMinTotalHemoglobinConc(int index)
-        {
-            Object val = GetFieldValue(96, index, Fit.SubfieldIndexMainField);
-            if(val == null)
-            {
-                return null;
-            }
-
-            return (Convert.ToSingle(val));
-            
-        }
-
-        /// <summary>
-        /// Set MinTotalHemoglobinConc field
-        /// Units: g/dL
-        /// Comment: Min saturated and unsaturated hemoglobin</summary>
-        /// <param name="index">0 based index of min_total_hemoglobin_conc</param>
-        /// <param name="minTotalHemoglobinConc_">Nullable field value to be set</param>
-        public void SetMinTotalHemoglobinConc(int index, float? minTotalHemoglobinConc_)
-        {
-            SetFieldValue(96, index, minTotalHemoglobinConc_, Fit.SubfieldIndexMainField);
-        }
-        
-        
-        /// <summary>
-        ///
-        /// </summary>
-        /// <returns>returns number of elements in field MaxTotalHemoglobinConc</returns>
-        public int GetNumMaxTotalHemoglobinConc()
-        {
-            return GetNumFieldValues(97, Fit.SubfieldIndexMainField);
-        }
-
-        ///<summary>
-        /// Retrieves the MaxTotalHemoglobinConc field
-        /// Units: g/dL
-        /// Comment: Max saturated and unsaturated hemoglobin</summary>
-        /// <param name="index">0 based index of MaxTotalHemoglobinConc element to retrieve</param>
-        /// <returns>Returns nullable float representing the MaxTotalHemoglobinConc field</returns>
-        public float? GetMaxTotalHemoglobinConc(int index)
-        {
-            Object val = GetFieldValue(97, index, Fit.SubfieldIndexMainField);
-            if(val == null)
-            {
-                return null;
-            }
-
-            return (Convert.ToSingle(val));
-            
-        }
-
-        /// <summary>
-        /// Set MaxTotalHemoglobinConc field
-        /// Units: g/dL
-        /// Comment: Max saturated and unsaturated hemoglobin</summary>
-        /// <param name="index">0 based index of max_total_hemoglobin_conc</param>
-        /// <param name="maxTotalHemoglobinConc_">Nullable field value to be set</param>
-        public void SetMaxTotalHemoglobinConc(int index, float? maxTotalHemoglobinConc_)
-        {
-            SetFieldValue(97, index, maxTotalHemoglobinConc_, Fit.SubfieldIndexMainField);
-        }
-        
-        
-        /// <summary>
-        ///
-        /// </summary>
-        /// <returns>returns number of elements in field AvgSaturatedHemoglobinPercent</returns>
-        public int GetNumAvgSaturatedHemoglobinPercent()
-        {
-            return GetNumFieldValues(98, Fit.SubfieldIndexMainField);
-        }
-
-        ///<summary>
-        /// Retrieves the AvgSaturatedHemoglobinPercent field
-        /// Units: %
-        /// Comment: Avg percentage of hemoglobin saturated with oxygen</summary>
-        /// <param name="index">0 based index of AvgSaturatedHemoglobinPercent element to retrieve</param>
-        /// <returns>Returns nullable float representing the AvgSaturatedHemoglobinPercent field</returns>
-        public float? GetAvgSaturatedHemoglobinPercent(int index)
-        {
-            Object val = GetFieldValue(98, index, Fit.SubfieldIndexMainField);
-            if(val == null)
-            {
-                return null;
-            }
-
-            return (Convert.ToSingle(val));
-            
-        }
-
-        /// <summary>
-        /// Set AvgSaturatedHemoglobinPercent field
-        /// Units: %
-        /// Comment: Avg percentage of hemoglobin saturated with oxygen</summary>
-        /// <param name="index">0 based index of avg_saturated_hemoglobin_percent</param>
-        /// <param name="avgSaturatedHemoglobinPercent_">Nullable field value to be set</param>
-        public void SetAvgSaturatedHemoglobinPercent(int index, float? avgSaturatedHemoglobinPercent_)
-        {
-            SetFieldValue(98, index, avgSaturatedHemoglobinPercent_, Fit.SubfieldIndexMainField);
-        }
-        
-        
-        /// <summary>
-        ///
-        /// </summary>
-        /// <returns>returns number of elements in field MinSaturatedHemoglobinPercent</returns>
-        public int GetNumMinSaturatedHemoglobinPercent()
-        {
-            return GetNumFieldValues(99, Fit.SubfieldIndexMainField);
-        }
-
-        ///<summary>
-        /// Retrieves the MinSaturatedHemoglobinPercent field
-        /// Units: %
-        /// Comment: Min percentage of hemoglobin saturated with oxygen</summary>
-        /// <param name="index">0 based index of MinSaturatedHemoglobinPercent element to retrieve</param>
-        /// <returns>Returns nullable float representing the MinSaturatedHemoglobinPercent field</returns>
-        public float? GetMinSaturatedHemoglobinPercent(int index)
-        {
-            Object val = GetFieldValue(99, index, Fit.SubfieldIndexMainField);
-            if(val == null)
-            {
-                return null;
-            }
-
-            return (Convert.ToSingle(val));
-            
-        }
-
-        /// <summary>
-        /// Set MinSaturatedHemoglobinPercent field
-        /// Units: %
-        /// Comment: Min percentage of hemoglobin saturated with oxygen</summary>
-        /// <param name="index">0 based index of min_saturated_hemoglobin_percent</param>
-        /// <param name="minSaturatedHemoglobinPercent_">Nullable field value to be set</param>
-        public void SetMinSaturatedHemoglobinPercent(int index, float? minSaturatedHemoglobinPercent_)
-        {
-            SetFieldValue(99, index, minSaturatedHemoglobinPercent_, Fit.SubfieldIndexMainField);
-        }
-        
-        
-        /// <summary>
-        ///
-        /// </summary>
-        /// <returns>returns number of elements in field MaxSaturatedHemoglobinPercent</returns>
-        public int GetNumMaxSaturatedHemoglobinPercent()
-        {
-            return GetNumFieldValues(100, Fit.SubfieldIndexMainField);
-        }
-
-        ///<summary>
-        /// Retrieves the MaxSaturatedHemoglobinPercent field
-        /// Units: %
-        /// Comment: Max percentage of hemoglobin saturated with oxygen</summary>
-        /// <param name="index">0 based index of MaxSaturatedHemoglobinPercent element to retrieve</param>
-        /// <returns>Returns nullable float representing the MaxSaturatedHemoglobinPercent field</returns>
-        public float? GetMaxSaturatedHemoglobinPercent(int index)
-        {
-            Object val = GetFieldValue(100, index, Fit.SubfieldIndexMainField);
-            if(val == null)
-            {
-                return null;
-            }
-
-            return (Convert.ToSingle(val));
-            
-        }
-
-        /// <summary>
-        /// Set MaxSaturatedHemoglobinPercent field
-        /// Units: %
-        /// Comment: Max percentage of hemoglobin saturated with oxygen</summary>
-        /// <param name="index">0 based index of max_saturated_hemoglobin_percent</param>
-        /// <param name="maxSaturatedHemoglobinPercent_">Nullable field value to be set</param>
-        public void SetMaxSaturatedHemoglobinPercent(int index, float? maxSaturatedHemoglobinPercent_)
-        {
-            SetFieldValue(100, index, maxSaturatedHemoglobinPercent_, Fit.SubfieldIndexMainField);
-        }
-        
-        ///<summary>
-        /// Retrieves the AvgLeftTorqueEffectiveness field
-        /// Units: percent</summary>
-        /// <returns>Returns nullable float representing the AvgLeftTorqueEffectiveness field</returns>
-        public float? GetAvgLeftTorqueEffectiveness()
-        {
-            Object val = GetFieldValue(101, 0, Fit.SubfieldIndexMainField);
-            if(val == null)
-            {
-                return null;
-            }
-
-            return (Convert.ToSingle(val));
-            
-        }
-
-        /// <summary>
-        /// Set AvgLeftTorqueEffectiveness field
-        /// Units: percent</summary>
-        /// <param name="avgLeftTorqueEffectiveness_">Nullable field value to be set</param>
-        public void SetAvgLeftTorqueEffectiveness(float? avgLeftTorqueEffectiveness_)
-        {
-            SetFieldValue(101, 0, avgLeftTorqueEffectiveness_, Fit.SubfieldIndexMainField);
-        }
-        
-        ///<summary>
-        /// Retrieves the AvgRightTorqueEffectiveness field
-        /// Units: percent</summary>
-        /// <returns>Returns nullable float representing the AvgRightTorqueEffectiveness field</returns>
-        public float? GetAvgRightTorqueEffectiveness()
-        {
-            Object val = GetFieldValue(102, 0, Fit.SubfieldIndexMainField);
-            if(val == null)
-            {
-                return null;
-            }
-
-            return (Convert.ToSingle(val));
-            
-        }
-
-        /// <summary>
-        /// Set AvgRightTorqueEffectiveness field
-        /// Units: percent</summary>
-        /// <param name="avgRightTorqueEffectiveness_">Nullable field value to be set</param>
-        public void SetAvgRightTorqueEffectiveness(float? avgRightTorqueEffectiveness_)
-        {
-            SetFieldValue(102, 0, avgRightTorqueEffectiveness_, Fit.SubfieldIndexMainField);
-        }
-        
-        ///<summary>
-        /// Retrieves the AvgLeftPedalSmoothness field
-        /// Units: percent</summary>
-        /// <returns>Returns nullable float representing the AvgLeftPedalSmoothness field</returns>
-        public float? GetAvgLeftPedalSmoothness()
-        {
-            Object val = GetFieldValue(103, 0, Fit.SubfieldIndexMainField);
-            if(val == null)
-            {
-                return null;
-            }
-
-            return (Convert.ToSingle(val));
-            
-        }
-
-        /// <summary>
-        /// Set AvgLeftPedalSmoothness field
-        /// Units: percent</summary>
-        /// <param name="avgLeftPedalSmoothness_">Nullable field value to be set</param>
-        public void SetAvgLeftPedalSmoothness(float? avgLeftPedalSmoothness_)
-        {
-            SetFieldValue(103, 0, avgLeftPedalSmoothness_, Fit.SubfieldIndexMainField);
-        }
-        
-        ///<summary>
-        /// Retrieves the AvgRightPedalSmoothness field
-        /// Units: percent</summary>
-        /// <returns>Returns nullable float representing the AvgRightPedalSmoothness field</returns>
-        public float? GetAvgRightPedalSmoothness()
-        {
-            Object val = GetFieldValue(104, 0, Fit.SubfieldIndexMainField);
-            if(val == null)
-            {
-                return null;
-            }
-
-            return (Convert.ToSingle(val));
-            
-        }
-
-        /// <summary>
-        /// Set AvgRightPedalSmoothness field
-        /// Units: percent</summary>
-        /// <param name="avgRightPedalSmoothness_">Nullable field value to be set</param>
-        public void SetAvgRightPedalSmoothness(float? avgRightPedalSmoothness_)
-        {
-            SetFieldValue(104, 0, avgRightPedalSmoothness_, Fit.SubfieldIndexMainField);
-        }
-        
-        ///<summary>
-        /// Retrieves the AvgCombinedPedalSmoothness field
-        /// Units: percent</summary>
-        /// <returns>Returns nullable float representing the AvgCombinedPedalSmoothness field</returns>
-        public float? GetAvgCombinedPedalSmoothness()
-        {
-            Object val = GetFieldValue(105, 0, Fit.SubfieldIndexMainField);
-            if(val == null)
-            {
-                return null;
-            }
-
-            return (Convert.ToSingle(val));
-            
-        }
-
-        /// <summary>
-        /// Set AvgCombinedPedalSmoothness field
-        /// Units: percent</summary>
-        /// <param name="avgCombinedPedalSmoothness_">Nullable field value to be set</param>
-        public void SetAvgCombinedPedalSmoothness(float? avgCombinedPedalSmoothness_)
-        {
-            SetFieldValue(105, 0, avgCombinedPedalSmoothness_, Fit.SubfieldIndexMainField);
-        }
-        
-        ///<summary>
-        /// Retrieves the SportProfileName field
-        /// Comment: Sport name from associated sport mesg</summary>
-        /// <returns>Returns byte[] representing the SportProfileName field</returns>
-        public byte[] GetSportProfileName()
-        {
-            byte[] data = (byte[])GetFieldValue(110, 0, Fit.SubfieldIndexMainField);
-            return data.Take(data.Length - 1).ToArray();
-        }
-
-        ///<summary>
-        /// Retrieves the SportProfileName field
-        /// Comment: Sport name from associated sport mesg</summary>
-        /// <returns>Returns String representing the SportProfileName field</returns>
-        public String GetSportProfileNameAsString()
-        {
-            byte[] data = (byte[])GetFieldValue(110, 0, Fit.SubfieldIndexMainField);
-            return data != null ? Encoding.UTF8.GetString(data, 0, data.Length - 1) : null;
-        }
-
-        ///<summary>
-        /// Set SportProfileName field
-        /// Comment: Sport name from associated sport mesg</summary>
-        /// <param name="sportProfileName_"> field value to be set</param>
-        public void SetSportProfileName(String sportProfileName_)
-        {
-            byte[] data = Encoding.UTF8.GetBytes(sportProfileName_);
-            byte[] zdata = new byte[data.Length + 1];
-            data.CopyTo(zdata, 0);
-            SetFieldValue(110, 0, zdata, Fit.SubfieldIndexMainField);
-        }
-
-        
-        /// <summary>
-        /// Set SportProfileName field
-        /// Comment: Sport name from associated sport mesg</summary>
-        /// <param name="sportProfileName_">field value to be set</param>
-        public void SetSportProfileName(byte[] sportProfileName_)
-        {
-            SetFieldValue(110, 0, sportProfileName_, Fit.SubfieldIndexMainField);
-        }
-        
-        ///<summary>
-        /// Retrieves the SportIndex field</summary>
-        /// <returns>Returns nullable byte representing the SportIndex field</returns>
-        public byte? GetSportIndex()
-        {
-            Object val = GetFieldValue(111, 0, Fit.SubfieldIndexMainField);
-            if(val == null)
-            {
-                return null;
-            }
-
-            return (Convert.ToByte(val));
-            
-        }
-
-        /// <summary>
-        /// Set SportIndex field</summary>
-        /// <param name="sportIndex_">Nullable field value to be set</param>
-        public void SetSportIndex(byte? sportIndex_)
-        {
-            SetFieldValue(111, 0, sportIndex_, Fit.SubfieldIndexMainField);
-        }
-        
-        ///<summary>
-        /// Retrieves the TimeStanding field
-        /// Units: s
-        /// Comment: Total time spend in the standing position</summary>
-        /// <returns>Returns nullable float representing the TimeStanding field</returns>
-        public float? GetTimeStanding()
-        {
-            Object val = GetFieldValue(112, 0, Fit.SubfieldIndexMainField);
-            if(val == null)
-            {
-                return null;
-            }
-
-            return (Convert.ToSingle(val));
-            
-        }
-
-        /// <summary>
-        /// Set TimeStanding field
-        /// Units: s
-        /// Comment: Total time spend in the standing position</summary>
-        /// <param name="timeStanding_">Nullable field value to be set</param>
-        public void SetTimeStanding(float? timeStanding_)
-        {
-            SetFieldValue(112, 0, timeStanding_, Fit.SubfieldIndexMainField);
-        }
-        
-        ///<summary>
-        /// Retrieves the StandCount field
-        /// Comment: Number of transitions to the standing state</summary>
-        /// <returns>Returns nullable ushort representing the StandCount field</returns>
-        public ushort? GetStandCount()
-        {
-            Object val = GetFieldValue(113, 0, Fit.SubfieldIndexMainField);
-            if(val == null)
-            {
-                return null;
-            }
-
-            return (Convert.ToUInt16(val));
-            
-        }
-
-        /// <summary>
-        /// Set StandCount field
-        /// Comment: Number of transitions to the standing state</summary>
-        /// <param name="standCount_">Nullable field value to be set</param>
-        public void SetStandCount(ushort? standCount_)
-        {
-            SetFieldValue(113, 0, standCount_, Fit.SubfieldIndexMainField);
-        }
-        
-        ///<summary>
-        /// Retrieves the AvgLeftPco field
-        /// Units: mm
-        /// Comment: Average platform center offset Left</summary>
-        /// <returns>Returns nullable sbyte representing the AvgLeftPco field</returns>
-        public sbyte? GetAvgLeftPco()
-        {
-            Object val = GetFieldValue(114, 0, Fit.SubfieldIndexMainField);
-            if(val == null)
-            {
-                return null;
-            }
-
-            return (Convert.ToSByte(val));
-            
-        }
-
-        /// <summary>
-        /// Set AvgLeftPco field
-        /// Units: mm
-        /// Comment: Average platform center offset Left</summary>
-        /// <param name="avgLeftPco_">Nullable field value to be set</param>
-        public void SetAvgLeftPco(sbyte? avgLeftPco_)
-        {
-            SetFieldValue(114, 0, avgLeftPco_, Fit.SubfieldIndexMainField);
-        }
-        
-        ///<summary>
-        /// Retrieves the AvgRightPco field
-        /// Units: mm
-        /// Comment: Average platform center offset Right</summary>
-        /// <returns>Returns nullable sbyte representing the AvgRightPco field</returns>
-        public sbyte? GetAvgRightPco()
-        {
-            Object val = GetFieldValue(115, 0, Fit.SubfieldIndexMainField);
-            if(val == null)
-            {
-                return null;
-            }
-
-            return (Convert.ToSByte(val));
-            
-        }
-
-        /// <summary>
-        /// Set AvgRightPco field
-        /// Units: mm
-        /// Comment: Average platform center offset Right</summary>
-        /// <param name="avgRightPco_">Nullable field value to be set</param>
-        public void SetAvgRightPco(sbyte? avgRightPco_)
-        {
-            SetFieldValue(115, 0, avgRightPco_, Fit.SubfieldIndexMainField);
-        }
-        
-        
-        /// <summary>
-        ///
-        /// </summary>
-        /// <returns>returns number of elements in field AvgLeftPowerPhase</returns>
-        public int GetNumAvgLeftPowerPhase()
-        {
-            return GetNumFieldValues(116, Fit.SubfieldIndexMainField);
-        }
-
-        ///<summary>
-        /// Retrieves the AvgLeftPowerPhase field
-        /// Units: degrees
-        /// Comment: Average left power phase angles. Indexes defined by power_phase_type.</summary>
-        /// <param name="index">0 based index of AvgLeftPowerPhase element to retrieve</param>
-        /// <returns>Returns nullable float representing the AvgLeftPowerPhase field</returns>
-        public float? GetAvgLeftPowerPhase(int index)
-        {
-            Object val = GetFieldValue(116, index, Fit.SubfieldIndexMainField);
-            if(val == null)
-            {
-                return null;
-            }
-
-            return (Convert.ToSingle(val));
-            
-        }
-
-        /// <summary>
-        /// Set AvgLeftPowerPhase field
-        /// Units: degrees
-        /// Comment: Average left power phase angles. Indexes defined by power_phase_type.</summary>
-        /// <param name="index">0 based index of avg_left_power_phase</param>
-        /// <param name="avgLeftPowerPhase_">Nullable field value to be set</param>
-        public void SetAvgLeftPowerPhase(int index, float? avgLeftPowerPhase_)
-        {
-            SetFieldValue(116, index, avgLeftPowerPhase_, Fit.SubfieldIndexMainField);
-        }
-        
-        
-        /// <summary>
-        ///
-        /// </summary>
-        /// <returns>returns number of elements in field AvgLeftPowerPhasePeak</returns>
-        public int GetNumAvgLeftPowerPhasePeak()
-        {
-            return GetNumFieldValues(117, Fit.SubfieldIndexMainField);
-        }
-
-        ///<summary>
-        /// Retrieves the AvgLeftPowerPhasePeak field
-        /// Units: degrees
-        /// Comment: Average left power phase peak angles. Data value indexes defined by power_phase_type.</summary>
-        /// <param name="index">0 based index of AvgLeftPowerPhasePeak element to retrieve</param>
-        /// <returns>Returns nullable float representing the AvgLeftPowerPhasePeak field</returns>
-        public float? GetAvgLeftPowerPhasePeak(int index)
-        {
-            Object val = GetFieldValue(117, index, Fit.SubfieldIndexMainField);
-            if(val == null)
-            {
-                return null;
-            }
-
-            return (Convert.ToSingle(val));
-            
-        }
-
-        /// <summary>
-        /// Set AvgLeftPowerPhasePeak field
-        /// Units: degrees
-        /// Comment: Average left power phase peak angles. Data value indexes defined by power_phase_type.</summary>
-        /// <param name="index">0 based index of avg_left_power_phase_peak</param>
-        /// <param name="avgLeftPowerPhasePeak_">Nullable field value to be set</param>
-        public void SetAvgLeftPowerPhasePeak(int index, float? avgLeftPowerPhasePeak_)
-        {
-            SetFieldValue(117, index, avgLeftPowerPhasePeak_, Fit.SubfieldIndexMainField);
-        }
-        
-        
-        /// <summary>
-        ///
-        /// </summary>
-        /// <returns>returns number of elements in field AvgRightPowerPhase</returns>
-        public int GetNumAvgRightPowerPhase()
-        {
-            return GetNumFieldValues(118, Fit.SubfieldIndexMainField);
-        }
-
-        ///<summary>
-        /// Retrieves the AvgRightPowerPhase field
-        /// Units: degrees
-        /// Comment: Average right power phase angles. Data value indexes defined by power_phase_type.</summary>
-        /// <param name="index">0 based index of AvgRightPowerPhase element to retrieve</param>
-        /// <returns>Returns nullable float representing the AvgRightPowerPhase field</returns>
-        public float? GetAvgRightPowerPhase(int index)
-        {
-            Object val = GetFieldValue(118, index, Fit.SubfieldIndexMainField);
-            if(val == null)
-            {
-                return null;
-            }
-
-            return (Convert.ToSingle(val));
-            
-        }
-
-        /// <summary>
-        /// Set AvgRightPowerPhase field
-        /// Units: degrees
-        /// Comment: Average right power phase angles. Data value indexes defined by power_phase_type.</summary>
-        /// <param name="index">0 based index of avg_right_power_phase</param>
-        /// <param name="avgRightPowerPhase_">Nullable field value to be set</param>
-        public void SetAvgRightPowerPhase(int index, float? avgRightPowerPhase_)
-        {
-            SetFieldValue(118, index, avgRightPowerPhase_, Fit.SubfieldIndexMainField);
-        }
-        
-        
-        /// <summary>
-        ///
-        /// </summary>
-        /// <returns>returns number of elements in field AvgRightPowerPhasePeak</returns>
-        public int GetNumAvgRightPowerPhasePeak()
-        {
-            return GetNumFieldValues(119, Fit.SubfieldIndexMainField);
-        }
-
-        ///<summary>
-        /// Retrieves the AvgRightPowerPhasePeak field
-        /// Units: degrees
-        /// Comment: Average right power phase peak angles data value indexes defined by power_phase_type.</summary>
-        /// <param name="index">0 based index of AvgRightPowerPhasePeak element to retrieve</param>
-        /// <returns>Returns nullable float representing the AvgRightPowerPhasePeak field</returns>
-        public float? GetAvgRightPowerPhasePeak(int index)
-        {
-            Object val = GetFieldValue(119, index, Fit.SubfieldIndexMainField);
-            if(val == null)
-            {
-                return null;
-            }
-
-            return (Convert.ToSingle(val));
-            
-        }
-
-        /// <summary>
-        /// Set AvgRightPowerPhasePeak field
-        /// Units: degrees
-        /// Comment: Average right power phase peak angles data value indexes defined by power_phase_type.</summary>
-        /// <param name="index">0 based index of avg_right_power_phase_peak</param>
-        /// <param name="avgRightPowerPhasePeak_">Nullable field value to be set</param>
-        public void SetAvgRightPowerPhasePeak(int index, float? avgRightPowerPhasePeak_)
-        {
-            SetFieldValue(119, index, avgRightPowerPhasePeak_, Fit.SubfieldIndexMainField);
-        }
-        
-        
-        /// <summary>
-        ///
-        /// </summary>
-        /// <returns>returns number of elements in field AvgPowerPosition</returns>
-        public int GetNumAvgPowerPosition()
-        {
-            return GetNumFieldValues(120, Fit.SubfieldIndexMainField);
-        }
-
-        ///<summary>
-        /// Retrieves the AvgPowerPosition field
-        /// Units: watts
-        /// Comment: Average power by position. Data value indexes defined by rider_position_type.</summary>
-        /// <param name="index">0 based index of AvgPowerPosition element to retrieve</param>
-        /// <returns>Returns nullable ushort representing the AvgPowerPosition field</returns>
-        public ushort? GetAvgPowerPosition(int index)
-        {
-            Object val = GetFieldValue(120, index, Fit.SubfieldIndexMainField);
-            if(val == null)
-            {
-                return null;
-            }
-
-            return (Convert.ToUInt16(val));
-            
-        }
-
-        /// <summary>
-        /// Set AvgPowerPosition field
-        /// Units: watts
-        /// Comment: Average power by position. Data value indexes defined by rider_position_type.</summary>
-        /// <param name="index">0 based index of avg_power_position</param>
-        /// <param name="avgPowerPosition_">Nullable field value to be set</param>
-        public void SetAvgPowerPosition(int index, ushort? avgPowerPosition_)
-        {
-            SetFieldValue(120, index, avgPowerPosition_, Fit.SubfieldIndexMainField);
-        }
-        
-        
-        /// <summary>
-        ///
-        /// </summary>
-        /// <returns>returns number of elements in field MaxPowerPosition</returns>
-        public int GetNumMaxPowerPosition()
-        {
-            return GetNumFieldValues(121, Fit.SubfieldIndexMainField);
-        }
-
-        ///<summary>
-        /// Retrieves the MaxPowerPosition field
-        /// Units: watts
-        /// Comment: Maximum power by position. Data value indexes defined by rider_position_type.</summary>
-        /// <param name="index">0 based index of MaxPowerPosition element to retrieve</param>
-        /// <returns>Returns nullable ushort representing the MaxPowerPosition field</returns>
-        public ushort? GetMaxPowerPosition(int index)
-        {
-            Object val = GetFieldValue(121, index, Fit.SubfieldIndexMainField);
-            if(val == null)
-            {
-                return null;
-            }
-
-            return (Convert.ToUInt16(val));
-            
-        }
-
-        /// <summary>
-        /// Set MaxPowerPosition field
-        /// Units: watts
-        /// Comment: Maximum power by position. Data value indexes defined by rider_position_type.</summary>
-        /// <param name="index">0 based index of max_power_position</param>
-        /// <param name="maxPowerPosition_">Nullable field value to be set</param>
-        public void SetMaxPowerPosition(int index, ushort? maxPowerPosition_)
-        {
-            SetFieldValue(121, index, maxPowerPosition_, Fit.SubfieldIndexMainField);
-        }
-        
-        
-        /// <summary>
-        ///
-        /// </summary>
-        /// <returns>returns number of elements in field AvgCadencePosition</returns>
-        public int GetNumAvgCadencePosition()
-        {
-            return GetNumFieldValues(122, Fit.SubfieldIndexMainField);
-        }
-
-        ///<summary>
-        /// Retrieves the AvgCadencePosition field
-        /// Units: rpm
-        /// Comment: Average cadence by position. Data value indexes defined by rider_position_type.</summary>
-        /// <param name="index">0 based index of AvgCadencePosition element to retrieve</param>
-        /// <returns>Returns nullable byte representing the AvgCadencePosition field</returns>
-        public byte? GetAvgCadencePosition(int index)
-        {
-            Object val = GetFieldValue(122, index, Fit.SubfieldIndexMainField);
-            if(val == null)
-            {
-                return null;
-            }
-
-            return (Convert.ToByte(val));
-            
-        }
-
-        /// <summary>
-        /// Set AvgCadencePosition field
-        /// Units: rpm
-        /// Comment: Average cadence by position. Data value indexes defined by rider_position_type.</summary>
-        /// <param name="index">0 based index of avg_cadence_position</param>
-        /// <param name="avgCadencePosition_">Nullable field value to be set</param>
-        public void SetAvgCadencePosition(int index, byte? avgCadencePosition_)
-        {
-            SetFieldValue(122, index, avgCadencePosition_, Fit.SubfieldIndexMainField);
-        }
-        
-        
-        /// <summary>
-        ///
-        /// </summary>
-        /// <returns>returns number of elements in field MaxCadencePosition</returns>
-        public int GetNumMaxCadencePosition()
-        {
-            return GetNumFieldValues(123, Fit.SubfieldIndexMainField);
-        }
-
-        ///<summary>
-        /// Retrieves the MaxCadencePosition field
-        /// Units: rpm
-        /// Comment: Maximum cadence by position. Data value indexes defined by rider_position_type.</summary>
-        /// <param name="index">0 based index of MaxCadencePosition element to retrieve</param>
-        /// <returns>Returns nullable byte representing the MaxCadencePosition field</returns>
-        public byte? GetMaxCadencePosition(int index)
-        {
-            Object val = GetFieldValue(123, index, Fit.SubfieldIndexMainField);
-            if(val == null)
-            {
-                return null;
-            }
-
-            return (Convert.ToByte(val));
-            
-        }
-
-        /// <summary>
-        /// Set MaxCadencePosition field
-        /// Units: rpm
-        /// Comment: Maximum cadence by position. Data value indexes defined by rider_position_type.</summary>
-        /// <param name="index">0 based index of max_cadence_position</param>
-        /// <param name="maxCadencePosition_">Nullable field value to be set</param>
-        public void SetMaxCadencePosition(int index, byte? maxCadencePosition_)
-        {
-            SetFieldValue(123, index, maxCadencePosition_, Fit.SubfieldIndexMainField);
-        }
-        
-        ///<summary>
-        /// Retrieves the EnhancedAvgSpeed field
-        /// Units: m/s
-        /// Comment: total_distance / total_timer_time</summary>
-        /// <returns>Returns nullable float representing the EnhancedAvgSpeed field</returns>
-        public float? GetEnhancedAvgSpeed()
-        {
-            Object val = GetFieldValue(124, 0, Fit.SubfieldIndexMainField);
-            if(val == null)
-            {
-                return null;
-            }
-
-            return (Convert.ToSingle(val));
-            
-        }
-
-        /// <summary>
-        /// Set EnhancedAvgSpeed field
-        /// Units: m/s
-        /// Comment: total_distance / total_timer_time</summary>
-        /// <param name="enhancedAvgSpeed_">Nullable field value to be set</param>
-        public void SetEnhancedAvgSpeed(float? enhancedAvgSpeed_)
-        {
-            SetFieldValue(124, 0, enhancedAvgSpeed_, Fit.SubfieldIndexMainField);
-        }
-        
-        ///<summary>
-        /// Retrieves the EnhancedMaxSpeed field
-        /// Units: m/s</summary>
-        /// <returns>Returns nullable float representing the EnhancedMaxSpeed field</returns>
-        public float? GetEnhancedMaxSpeed()
-        {
-            Object val = GetFieldValue(125, 0, Fit.SubfieldIndexMainField);
-            if(val == null)
-            {
-                return null;
-            }
-
-            return (Convert.ToSingle(val));
-            
-        }
-
-        /// <summary>
-        /// Set EnhancedMaxSpeed field
-        /// Units: m/s</summary>
-        /// <param name="enhancedMaxSpeed_">Nullable field value to be set</param>
-        public void SetEnhancedMaxSpeed(float? enhancedMaxSpeed_)
-        {
-            SetFieldValue(125, 0, enhancedMaxSpeed_, Fit.SubfieldIndexMainField);
-        }
-        
-        ///<summary>
-        /// Retrieves the EnhancedAvgAltitude field
-        /// Units: m</summary>
-        /// <returns>Returns nullable float representing the EnhancedAvgAltitude field</returns>
-        public float? GetEnhancedAvgAltitude()
-        {
-            Object val = GetFieldValue(126, 0, Fit.SubfieldIndexMainField);
-            if(val == null)
-            {
-                return null;
-            }
-
-            return (Convert.ToSingle(val));
-            
-        }
-
-        /// <summary>
-        /// Set EnhancedAvgAltitude field
-        /// Units: m</summary>
-        /// <param name="enhancedAvgAltitude_">Nullable field value to be set</param>
-        public void SetEnhancedAvgAltitude(float? enhancedAvgAltitude_)
-        {
-            SetFieldValue(126, 0, enhancedAvgAltitude_, Fit.SubfieldIndexMainField);
-        }
-        
-        ///<summary>
-        /// Retrieves the EnhancedMinAltitude field
-        /// Units: m</summary>
-        /// <returns>Returns nullable float representing the EnhancedMinAltitude field</returns>
-        public float? GetEnhancedMinAltitude()
-        {
-            Object val = GetFieldValue(127, 0, Fit.SubfieldIndexMainField);
-            if(val == null)
-            {
-                return null;
-            }
-
-            return (Convert.ToSingle(val));
-            
-        }
-
-        /// <summary>
-        /// Set EnhancedMinAltitude field
-        /// Units: m</summary>
-        /// <param name="enhancedMinAltitude_">Nullable field value to be set</param>
-        public void SetEnhancedMinAltitude(float? enhancedMinAltitude_)
-        {
-            SetFieldValue(127, 0, enhancedMinAltitude_, Fit.SubfieldIndexMainField);
-        }
-        
-        ///<summary>
-        /// Retrieves the EnhancedMaxAltitude field
-        /// Units: m</summary>
-        /// <returns>Returns nullable float representing the EnhancedMaxAltitude field</returns>
-        public float? GetEnhancedMaxAltitude()
-        {
-            Object val = GetFieldValue(128, 0, Fit.SubfieldIndexMainField);
-            if(val == null)
-            {
-                return null;
-            }
-
-            return (Convert.ToSingle(val));
-            
-        }
-
-        /// <summary>
-        /// Set EnhancedMaxAltitude field
-        /// Units: m</summary>
-        /// <param name="enhancedMaxAltitude_">Nullable field value to be set</param>
-        public void SetEnhancedMaxAltitude(float? enhancedMaxAltitude_)
-        {
-            SetFieldValue(128, 0, enhancedMaxAltitude_, Fit.SubfieldIndexMainField);
-        }
-        
-        ///<summary>
-        /// Retrieves the AvgLevMotorPower field
-        /// Units: watts
-        /// Comment: lev average motor power during session</summary>
-        /// <returns>Returns nullable ushort representing the AvgLevMotorPower field</returns>
-        public ushort? GetAvgLevMotorPower()
-        {
-            Object val = GetFieldValue(129, 0, Fit.SubfieldIndexMainField);
-            if(val == null)
-            {
-                return null;
-            }
-
-            return (Convert.ToUInt16(val));
-            
-        }
-
-        /// <summary>
-        /// Set AvgLevMotorPower field
-        /// Units: watts
-        /// Comment: lev average motor power during session</summary>
-        /// <param name="avgLevMotorPower_">Nullable field value to be set</param>
-        public void SetAvgLevMotorPower(ushort? avgLevMotorPower_)
-        {
-            SetFieldValue(129, 0, avgLevMotorPower_, Fit.SubfieldIndexMainField);
-        }
-        
-        ///<summary>
-        /// Retrieves the MaxLevMotorPower field
-        /// Units: watts
-        /// Comment: lev maximum motor power during session</summary>
-        /// <returns>Returns nullable ushort representing the MaxLevMotorPower field</returns>
-        public ushort? GetMaxLevMotorPower()
-        {
-            Object val = GetFieldValue(130, 0, Fit.SubfieldIndexMainField);
-            if(val == null)
-            {
-                return null;
-            }
-
-            return (Convert.ToUInt16(val));
-            
-        }
-
-        /// <summary>
-        /// Set MaxLevMotorPower field
-        /// Units: watts
-        /// Comment: lev maximum motor power during session</summary>
-        /// <param name="maxLevMotorPower_">Nullable field value to be set</param>
-        public void SetMaxLevMotorPower(ushort? maxLevMotorPower_)
-        {
-            SetFieldValue(130, 0, maxLevMotorPower_, Fit.SubfieldIndexMainField);
-        }
-        
-        ///<summary>
-        /// Retrieves the LevBatteryConsumption field
-        /// Units: percent
-        /// Comment: lev battery consumption during session</summary>
-        /// <returns>Returns nullable float representing the LevBatteryConsumption field</returns>
-        public float? GetLevBatteryConsumption()
-        {
-            Object val = GetFieldValue(131, 0, Fit.SubfieldIndexMainField);
-            if(val == null)
-            {
-                return null;
-            }
-
-            return (Convert.ToSingle(val));
-            
-        }
-
-        /// <summary>
-        /// Set LevBatteryConsumption field
-        /// Units: percent
-        /// Comment: lev battery consumption during session</summary>
-        /// <param name="levBatteryConsumption_">Nullable field value to be set</param>
-        public void SetLevBatteryConsumption(float? levBatteryConsumption_)
-        {
-            SetFieldValue(131, 0, levBatteryConsumption_, Fit.SubfieldIndexMainField);
-        }
-        
-        ///<summary>
-        /// Retrieves the AvgVerticalRatio field
-        /// Units: percent</summary>
-        /// <returns>Returns nullable float representing the AvgVerticalRatio field</returns>
-        public float? GetAvgVerticalRatio()
-        {
-            Object val = GetFieldValue(132, 0, Fit.SubfieldIndexMainField);
-            if(val == null)
-            {
-                return null;
-            }
-
-            return (Convert.ToSingle(val));
-            
-        }
-
-        /// <summary>
-        /// Set AvgVerticalRatio field
-        /// Units: percent</summary>
-        /// <param name="avgVerticalRatio_">Nullable field value to be set</param>
-        public void SetAvgVerticalRatio(float? avgVerticalRatio_)
-        {
-            SetFieldValue(132, 0, avgVerticalRatio_, Fit.SubfieldIndexMainField);
-        }
-        
-        ///<summary>
-        /// Retrieves the AvgStanceTimeBalance field
-        /// Units: percent</summary>
-        /// <returns>Returns nullable float representing the AvgStanceTimeBalance field</returns>
-        public float? GetAvgStanceTimeBalance()
-        {
-            Object val = GetFieldValue(133, 0, Fit.SubfieldIndexMainField);
-            if(val == null)
-            {
-                return null;
-            }
-
-            return (Convert.ToSingle(val));
-            
-        }
-
-        /// <summary>
-        /// Set AvgStanceTimeBalance field
-        /// Units: percent</summary>
-        /// <param name="avgStanceTimeBalance_">Nullable field value to be set</param>
-        public void SetAvgStanceTimeBalance(float? avgStanceTimeBalance_)
-        {
-            SetFieldValue(133, 0, avgStanceTimeBalance_, Fit.SubfieldIndexMainField);
-        }
-        
-        ///<summary>
-        /// Retrieves the AvgStepLength field
-        /// Units: mm</summary>
-        /// <returns>Returns nullable float representing the AvgStepLength field</returns>
-        public float? GetAvgStepLength()
-        {
-            Object val = GetFieldValue(134, 0, Fit.SubfieldIndexMainField);
-            if(val == null)
-            {
-                return null;
-            }
-
-            return (Convert.ToSingle(val));
-            
-        }
-
-        /// <summary>
-        /// Set AvgStepLength field
-        /// Units: mm</summary>
-        /// <param name="avgStepLength_">Nullable field value to be set</param>
-        public void SetAvgStepLength(float? avgStepLength_)
-        {
-            SetFieldValue(134, 0, avgStepLength_, Fit.SubfieldIndexMainField);
-        }
-        
-        ///<summary>
-        /// Retrieves the TotalAnaerobicTrainingEffect field</summary>
-        /// <returns>Returns nullable float representing the TotalAnaerobicTrainingEffect field</returns>
-        public float? GetTotalAnaerobicTrainingEffect()
-        {
-            Object val = GetFieldValue(137, 0, Fit.SubfieldIndexMainField);
-            if(val == null)
-            {
-                return null;
-            }
-
-            return (Convert.ToSingle(val));
-            
-        }
-
-        /// <summary>
-        /// Set TotalAnaerobicTrainingEffect field</summary>
-        /// <param name="totalAnaerobicTrainingEffect_">Nullable field value to be set</param>
-        public void SetTotalAnaerobicTrainingEffect(float? totalAnaerobicTrainingEffect_)
-        {
-            SetFieldValue(137, 0, totalAnaerobicTrainingEffect_, Fit.SubfieldIndexMainField);
-        }
-        
-        ///<summary>
-        /// Retrieves the AvgVam field
-        /// Units: m/s</summary>
-        /// <returns>Returns nullable float representing the AvgVam field</returns>
-        public float? GetAvgVam()
-        {
-            Object val = GetFieldValue(139, 0, Fit.SubfieldIndexMainField);
-            if(val == null)
-            {
-                return null;
-            }
-
-            return (Convert.ToSingle(val));
-            
-        }
-
-        /// <summary>
-        /// Set AvgVam field
-        /// Units: m/s</summary>
-        /// <param name="avgVam_">Nullable field value to be set</param>
-        public void SetAvgVam(float? avgVam_)
-        {
-            SetFieldValue(139, 0, avgVam_, Fit.SubfieldIndexMainField);
-        }
-        
-        ///<summary>
-        /// Retrieves the AvgDepth field
-        /// Units: m
-        /// Comment: 0 if above water</summary>
-        /// <returns>Returns nullable float representing the AvgDepth field</returns>
-        public float? GetAvgDepth()
-        {
-            Object val = GetFieldValue(140, 0, Fit.SubfieldIndexMainField);
-            if(val == null)
-            {
-                return null;
-            }
-
-            return (Convert.ToSingle(val));
-            
-        }
-
-        /// <summary>
-        /// Set AvgDepth field
-        /// Units: m
-        /// Comment: 0 if above water</summary>
-        /// <param name="avgDepth_">Nullable field value to be set</param>
-        public void SetAvgDepth(float? avgDepth_)
-        {
-            SetFieldValue(140, 0, avgDepth_, Fit.SubfieldIndexMainField);
-        }
-        
-        ///<summary>
-        /// Retrieves the MaxDepth field
-        /// Units: m
-        /// Comment: 0 if above water</summary>
-        /// <returns>Returns nullable float representing the MaxDepth field</returns>
-        public float? GetMaxDepth()
-        {
-            Object val = GetFieldValue(141, 0, Fit.SubfieldIndexMainField);
-            if(val == null)
-            {
-                return null;
-            }
-
-            return (Convert.ToSingle(val));
-            
-        }
-
-        /// <summary>
-        /// Set MaxDepth field
-        /// Units: m
-        /// Comment: 0 if above water</summary>
-        /// <param name="maxDepth_">Nullable field value to be set</param>
-        public void SetMaxDepth(float? maxDepth_)
-        {
-            SetFieldValue(141, 0, maxDepth_, Fit.SubfieldIndexMainField);
-        }
-        
-        ///<summary>
-        /// Retrieves the SurfaceInterval field
-        /// Units: s
-        /// Comment: Time since end of last dive</summary>
-        /// <returns>Returns nullable uint representing the SurfaceInterval field</returns>
-        public uint? GetSurfaceInterval()
-        {
-            Object val = GetFieldValue(142, 0, Fit.SubfieldIndexMainField);
-            if(val == null)
-            {
-                return null;
-            }
-
-            return (Convert.ToUInt32(val));
-            
-        }
-
-        /// <summary>
-        /// Set SurfaceInterval field
-        /// Units: s
-        /// Comment: Time since end of last dive</summary>
-        /// <param name="surfaceInterval_">Nullable field value to be set</param>
-        public void SetSurfaceInterval(uint? surfaceInterval_)
-        {
-            SetFieldValue(142, 0, surfaceInterval_, Fit.SubfieldIndexMainField);
-        }
-        
-        ///<summary>
-        /// Retrieves the StartCns field
-        /// Units: percent</summary>
-        /// <returns>Returns nullable byte representing the StartCns field</returns>
-        public byte? GetStartCns()
-        {
-            Object val = GetFieldValue(143, 0, Fit.SubfieldIndexMainField);
-            if(val == null)
-            {
-                return null;
-            }
-
-            return (Convert.ToByte(val));
-            
-        }
-
-        /// <summary>
-        /// Set StartCns field
-        /// Units: percent</summary>
-        /// <param name="startCns_">Nullable field value to be set</param>
-        public void SetStartCns(byte? startCns_)
-        {
-            SetFieldValue(143, 0, startCns_, Fit.SubfieldIndexMainField);
-        }
-        
-        ///<summary>
-        /// Retrieves the EndCns field
-        /// Units: percent</summary>
-        /// <returns>Returns nullable byte representing the EndCns field</returns>
-        public byte? GetEndCns()
-        {
-            Object val = GetFieldValue(144, 0, Fit.SubfieldIndexMainField);
-            if(val == null)
-            {
-                return null;
-            }
-
-            return (Convert.ToByte(val));
-            
-        }
-
-        /// <summary>
-        /// Set EndCns field
-        /// Units: percent</summary>
-        /// <param name="endCns_">Nullable field value to be set</param>
-        public void SetEndCns(byte? endCns_)
-        {
-            SetFieldValue(144, 0, endCns_, Fit.SubfieldIndexMainField);
-        }
-        
-        ///<summary>
-        /// Retrieves the StartN2 field
-        /// Units: percent</summary>
-        /// <returns>Returns nullable ushort representing the StartN2 field</returns>
-        public ushort? GetStartN2()
-        {
-            Object val = GetFieldValue(145, 0, Fit.SubfieldIndexMainField);
-            if(val == null)
-            {
-                return null;
-            }
-
-            return (Convert.ToUInt16(val));
-            
-        }
-
-        /// <summary>
-        /// Set StartN2 field
-        /// Units: percent</summary>
-        /// <param name="startN2_">Nullable field value to be set</param>
-        public void SetStartN2(ushort? startN2_)
-        {
-            SetFieldValue(145, 0, startN2_, Fit.SubfieldIndexMainField);
-        }
-        
-        ///<summary>
-        /// Retrieves the EndN2 field
-        /// Units: percent</summary>
-        /// <returns>Returns nullable ushort representing the EndN2 field</returns>
-        public ushort? GetEndN2()
-        {
-            Object val = GetFieldValue(146, 0, Fit.SubfieldIndexMainField);
-            if(val == null)
-            {
-                return null;
-            }
-
-            return (Convert.ToUInt16(val));
-            
-        }
-
-        /// <summary>
-        /// Set EndN2 field
-        /// Units: percent</summary>
-        /// <param name="endN2_">Nullable field value to be set</param>
-        public void SetEndN2(ushort? endN2_)
-        {
-            SetFieldValue(146, 0, endN2_, Fit.SubfieldIndexMainField);
-        }
-        
-        ///<summary>
-        /// Retrieves the AvgRespirationRate field</summary>
-        /// <returns>Returns nullable byte representing the AvgRespirationRate field</returns>
-        public byte? GetAvgRespirationRate()
-        {
-            Object val = GetFieldValue(147, 0, Fit.SubfieldIndexMainField);
-            if(val == null)
-            {
-                return null;
-            }
-
-            return (Convert.ToByte(val));
-            
-        }
-
-        /// <summary>
-        /// Set AvgRespirationRate field</summary>
-        /// <param name="avgRespirationRate_">Nullable field value to be set</param>
-        public void SetAvgRespirationRate(byte? avgRespirationRate_)
-        {
-            SetFieldValue(147, 0, avgRespirationRate_, Fit.SubfieldIndexMainField);
-        }
-        
-        ///<summary>
-        /// Retrieves the MaxRespirationRate field</summary>
-        /// <returns>Returns nullable byte representing the MaxRespirationRate field</returns>
-        public byte? GetMaxRespirationRate()
-        {
-            Object val = GetFieldValue(148, 0, Fit.SubfieldIndexMainField);
-            if(val == null)
-            {
-                return null;
-            }
-
-            return (Convert.ToByte(val));
-            
-        }
-
-        /// <summary>
-        /// Set MaxRespirationRate field</summary>
-        /// <param name="maxRespirationRate_">Nullable field value to be set</param>
-        public void SetMaxRespirationRate(byte? maxRespirationRate_)
-        {
-            SetFieldValue(148, 0, maxRespirationRate_, Fit.SubfieldIndexMainField);
-        }
-        
-        ///<summary>
-        /// Retrieves the MinRespirationRate field</summary>
-        /// <returns>Returns nullable byte representing the MinRespirationRate field</returns>
-        public byte? GetMinRespirationRate()
-        {
-            Object val = GetFieldValue(149, 0, Fit.SubfieldIndexMainField);
-            if(val == null)
-            {
-                return null;
-            }
-
-            return (Convert.ToByte(val));
-            
-        }
-
-        /// <summary>
-        /// Set MinRespirationRate field</summary>
-        /// <param name="minRespirationRate_">Nullable field value to be set</param>
-        public void SetMinRespirationRate(byte? minRespirationRate_)
-        {
-            SetFieldValue(149, 0, minRespirationRate_, Fit.SubfieldIndexMainField);
-        }
-        
-        ///<summary>
-        /// Retrieves the MinTemperature field
-        /// Units: C</summary>
-        /// <returns>Returns nullable sbyte representing the MinTemperature field</returns>
-        public sbyte? GetMinTemperature()
-        {
-            Object val = GetFieldValue(150, 0, Fit.SubfieldIndexMainField);
-            if(val == null)
-            {
-                return null;
-            }
-
-            return (Convert.ToSByte(val));
-            
-        }
-
-        /// <summary>
-        /// Set MinTemperature field
-        /// Units: C</summary>
-        /// <param name="minTemperature_">Nullable field value to be set</param>
-        public void SetMinTemperature(sbyte? minTemperature_)
-        {
-            SetFieldValue(150, 0, minTemperature_, Fit.SubfieldIndexMainField);
-        }
-        
-        ///<summary>
-        /// Retrieves the O2Toxicity field
-        /// Units: OTUs</summary>
-        /// <returns>Returns nullable ushort representing the O2Toxicity field</returns>
-        public ushort? GetO2Toxicity()
-        {
-            Object val = GetFieldValue(155, 0, Fit.SubfieldIndexMainField);
-            if(val == null)
-            {
-                return null;
-            }
-
-            return (Convert.ToUInt16(val));
-            
-        }
-
-        /// <summary>
-        /// Set O2Toxicity field
-        /// Units: OTUs</summary>
-        /// <param name="o2Toxicity_">Nullable field value to be set</param>
-        public void SetO2Toxicity(ushort? o2Toxicity_)
-        {
-            SetFieldValue(155, 0, o2Toxicity_, Fit.SubfieldIndexMainField);
-        }
-        
-        ///<summary>
-        /// Retrieves the DiveNumber field</summary>
-        /// <returns>Returns nullable uint representing the DiveNumber field</returns>
-        public uint? GetDiveNumber()
-        {
-            Object val = GetFieldValue(156, 0, Fit.SubfieldIndexMainField);
-            if(val == null)
-            {
-                return null;
-            }
-
-            return (Convert.ToUInt32(val));
-            
-        }
-
-        /// <summary>
-        /// Set DiveNumber field</summary>
-        /// <param name="diveNumber_">Nullable field value to be set</param>
-        public void SetDiveNumber(uint? diveNumber_)
-        {
-            SetFieldValue(156, 0, diveNumber_, Fit.SubfieldIndexMainField);
-        }
-        
-        ///<summary>
-        /// Retrieves the TrainingLoadPeak field</summary>
-        /// <returns>Returns nullable float representing the TrainingLoadPeak field</returns>
-        public float? GetTrainingLoadPeak()
-        {
-            Object val = GetFieldValue(168, 0, Fit.SubfieldIndexMainField);
-            if(val == null)
-            {
-                return null;
-            }
-
-            return (Convert.ToSingle(val));
-            
-        }
-
-        /// <summary>
-        /// Set TrainingLoadPeak field</summary>
-        /// <param name="trainingLoadPeak_">Nullable field value to be set</param>
-        public void SetTrainingLoadPeak(float? trainingLoadPeak_)
-        {
-            SetFieldValue(168, 0, trainingLoadPeak_, Fit.SubfieldIndexMainField);
-        }
-        
-        ///<summary>
-        /// Retrieves the EnhancedAvgRespirationRate field
-        /// Units: Breaths/min</summary>
-        /// <returns>Returns nullable float representing the EnhancedAvgRespirationRate field</returns>
-        public float? GetEnhancedAvgRespirationRate()
-        {
-            Object val = GetFieldValue(169, 0, Fit.SubfieldIndexMainField);
-            if(val == null)
-            {
-                return null;
-            }
-
-            return (Convert.ToSingle(val));
-            
-        }
-
-        /// <summary>
-        /// Set EnhancedAvgRespirationRate field
-        /// Units: Breaths/min</summary>
-        /// <param name="enhancedAvgRespirationRate_">Nullable field value to be set</param>
-        public void SetEnhancedAvgRespirationRate(float? enhancedAvgRespirationRate_)
-        {
-            SetFieldValue(169, 0, enhancedAvgRespirationRate_, Fit.SubfieldIndexMainField);
-        }
-        
-        ///<summary>
-        /// Retrieves the EnhancedMaxRespirationRate field
-        /// Units: Breaths/min</summary>
-        /// <returns>Returns nullable float representing the EnhancedMaxRespirationRate field</returns>
-        public float? GetEnhancedMaxRespirationRate()
-        {
-            Object val = GetFieldValue(170, 0, Fit.SubfieldIndexMainField);
-            if(val == null)
-            {
-                return null;
-            }
-
-            return (Convert.ToSingle(val));
-            
-        }
-
-        /// <summary>
-        /// Set EnhancedMaxRespirationRate field
-        /// Units: Breaths/min</summary>
-        /// <param name="enhancedMaxRespirationRate_">Nullable field value to be set</param>
-        public void SetEnhancedMaxRespirationRate(float? enhancedMaxRespirationRate_)
-        {
-            SetFieldValue(170, 0, enhancedMaxRespirationRate_, Fit.SubfieldIndexMainField);
-        }
-        
-        ///<summary>
-        /// Retrieves the EnhancedMinRespirationRate field</summary>
-        /// <returns>Returns nullable float representing the EnhancedMinRespirationRate field</returns>
-        public float? GetEnhancedMinRespirationRate()
-        {
-            Object val = GetFieldValue(180, 0, Fit.SubfieldIndexMainField);
-            if(val == null)
-            {
-                return null;
-            }
-
-            return (Convert.ToSingle(val));
-            
-        }
-
-        /// <summary>
-        /// Set EnhancedMinRespirationRate field</summary>
-        /// <param name="enhancedMinRespirationRate_">Nullable field value to be set</param>
-        public void SetEnhancedMinRespirationRate(float? enhancedMinRespirationRate_)
-        {
-            SetFieldValue(180, 0, enhancedMinRespirationRate_, Fit.SubfieldIndexMainField);
-        }
-        
-        ///<summary>
-        /// Retrieves the TotalGrit field
-        /// Units: kGrit
-        /// Comment: The grit score estimates how challenging a route could be for a cyclist in terms of time spent going over sharp turns or large grade slopes.</summary>
-        /// <returns>Returns nullable float representing the TotalGrit field</returns>
-        public float? GetTotalGrit()
-        {
-            Object val = GetFieldValue(181, 0, Fit.SubfieldIndexMainField);
-            if(val == null)
-            {
-                return null;
-            }
-
-            return (Convert.ToSingle(val));
-            
-        }
-
-        /// <summary>
-        /// Set TotalGrit field
-        /// Units: kGrit
-        /// Comment: The grit score estimates how challenging a route could be for a cyclist in terms of time spent going over sharp turns or large grade slopes.</summary>
-        /// <param name="totalGrit_">Nullable field value to be set</param>
-        public void SetTotalGrit(float? totalGrit_)
-        {
-            SetFieldValue(181, 0, totalGrit_, Fit.SubfieldIndexMainField);
-        }
-        
-        ///<summary>
-        /// Retrieves the TotalFlow field
-        /// Units: Flow
-        /// Comment: The flow score estimates how long distance wise a cyclist deaccelerates over intervals where deacceleration is unnecessary such as smooth turns or small grade angle intervals.</summary>
-        /// <returns>Returns nullable float representing the TotalFlow field</returns>
-        public float? GetTotalFlow()
-        {
-            Object val = GetFieldValue(182, 0, Fit.SubfieldIndexMainField);
-            if(val == null)
-            {
-                return null;
-            }
-
-            return (Convert.ToSingle(val));
-            
-        }
-
-        /// <summary>
-        /// Set TotalFlow field
-        /// Units: Flow
-        /// Comment: The flow score estimates how long distance wise a cyclist deaccelerates over intervals where deacceleration is unnecessary such as smooth turns or small grade angle intervals.</summary>
-        /// <param name="totalFlow_">Nullable field value to be set</param>
-        public void SetTotalFlow(float? totalFlow_)
-        {
-            SetFieldValue(182, 0, totalFlow_, Fit.SubfieldIndexMainField);
-        }
-        
-        ///<summary>
-        /// Retrieves the JumpCount field</summary>
-        /// <returns>Returns nullable ushort representing the JumpCount field</returns>
-        public ushort? GetJumpCount()
-        {
-            Object val = GetFieldValue(183, 0, Fit.SubfieldIndexMainField);
-            if(val == null)
-            {
-                return null;
-            }
-
-            return (Convert.ToUInt16(val));
-            
-        }
-
-        /// <summary>
-        /// Set JumpCount field</summary>
-        /// <param name="jumpCount_">Nullable field value to be set</param>
-        public void SetJumpCount(ushort? jumpCount_)
-        {
-            SetFieldValue(183, 0, jumpCount_, Fit.SubfieldIndexMainField);
-        }
-        
-        ///<summary>
-        /// Retrieves the AvgGrit field
-        /// Units: kGrit
-        /// Comment: The grit score estimates how challenging a route could be for a cyclist in terms of time spent going over sharp turns or large grade slopes.</summary>
-        /// <returns>Returns nullable float representing the AvgGrit field</returns>
-        public float? GetAvgGrit()
-        {
-            Object val = GetFieldValue(186, 0, Fit.SubfieldIndexMainField);
-            if(val == null)
-            {
-                return null;
-            }
-
-            return (Convert.ToSingle(val));
-            
-        }
-
-        /// <summary>
-        /// Set AvgGrit field
-        /// Units: kGrit
-        /// Comment: The grit score estimates how challenging a route could be for a cyclist in terms of time spent going over sharp turns or large grade slopes.</summary>
-        /// <param name="avgGrit_">Nullable field value to be set</param>
-        public void SetAvgGrit(float? avgGrit_)
-        {
-            SetFieldValue(186, 0, avgGrit_, Fit.SubfieldIndexMainField);
-        }
-        
-        ///<summary>
-        /// Retrieves the AvgFlow field
-        /// Units: Flow
-        /// Comment: The flow score estimates how long distance wise a cyclist deaccelerates over intervals where deacceleration is unnecessary such as smooth turns or small grade angle intervals.</summary>
-        /// <returns>Returns nullable float representing the AvgFlow field</returns>
-        public float? GetAvgFlow()
-        {
-            Object val = GetFieldValue(187, 0, Fit.SubfieldIndexMainField);
-            if(val == null)
-            {
-                return null;
-            }
-
-            return (Convert.ToSingle(val));
-            
-        }
-
-        /// <summary>
-        /// Set AvgFlow field
-        /// Units: Flow
-        /// Comment: The flow score estimates how long distance wise a cyclist deaccelerates over intervals where deacceleration is unnecessary such as smooth turns or small grade angle intervals.</summary>
-        /// <param name="avgFlow_">Nullable field value to be set</param>
-        public void SetAvgFlow(float? avgFlow_)
-        {
-            SetFieldValue(187, 0, avgFlow_, Fit.SubfieldIndexMainField);
-        }
-        
-        ///<summary>
-        /// Retrieves the WorkoutFeel field
-        /// Comment: A 0-100 scale representing how a user felt while performing a workout. Low values are considered feeling bad, while high values are good.</summary>
-        /// <returns>Returns nullable byte representing the WorkoutFeel field</returns>
-        public byte? GetWorkoutFeel()
-        {
-            Object val = GetFieldValue(192, 0, Fit.SubfieldIndexMainField);
-            if(val == null)
-            {
-                return null;
-            }
-
-            return (Convert.ToByte(val));
-            
-        }
-
-        /// <summary>
-        /// Set WorkoutFeel field
-        /// Comment: A 0-100 scale representing how a user felt while performing a workout. Low values are considered feeling bad, while high values are good.</summary>
-        /// <param name="workoutFeel_">Nullable field value to be set</param>
-        public void SetWorkoutFeel(byte? workoutFeel_)
-        {
-            SetFieldValue(192, 0, workoutFeel_, Fit.SubfieldIndexMainField);
-        }
-        
-        ///<summary>
-        /// Retrieves the WorkoutRpe field
-        /// Comment: Common Borg CR10 / 0-10 RPE scale, multiplied 10x.. Aggregate score for all workouts in a single session.</summary>
-        /// <returns>Returns nullable byte representing the WorkoutRpe field</returns>
-        public byte? GetWorkoutRpe()
-        {
-            Object val = GetFieldValue(193, 0, Fit.SubfieldIndexMainField);
-            if(val == null)
-            {
-                return null;
-            }
-
-            return (Convert.ToByte(val));
-            
-        }
-
-        /// <summary>
-        /// Set WorkoutRpe field
-        /// Comment: Common Borg CR10 / 0-10 RPE scale, multiplied 10x.. Aggregate score for all workouts in a single session.</summary>
-        /// <param name="workoutRpe_">Nullable field value to be set</param>
-        public void SetWorkoutRpe(byte? workoutRpe_)
-        {
-            SetFieldValue(193, 0, workoutRpe_, Fit.SubfieldIndexMainField);
-        }
-        
-        ///<summary>
-        /// Retrieves the AvgSpo2 field
-        /// Units: percent
-        /// Comment: Average SPO2 for the monitoring session</summary>
-        /// <returns>Returns nullable byte representing the AvgSpo2 field</returns>
-        public byte? GetAvgSpo2()
-        {
-            Object val = GetFieldValue(194, 0, Fit.SubfieldIndexMainField);
-            if(val == null)
-            {
-                return null;
-            }
-
-            return (Convert.ToByte(val));
-            
-        }
-
-        /// <summary>
-        /// Set AvgSpo2 field
-        /// Units: percent
-        /// Comment: Average SPO2 for the monitoring session</summary>
-        /// <param name="avgSpo2_">Nullable field value to be set</param>
-        public void SetAvgSpo2(byte? avgSpo2_)
-        {
-            SetFieldValue(194, 0, avgSpo2_, Fit.SubfieldIndexMainField);
-        }
-        
-        ///<summary>
-        /// Retrieves the AvgStress field
-        /// Units: percent
-        /// Comment: Average stress for the monitoring session</summary>
-        /// <returns>Returns nullable byte representing the AvgStress field</returns>
-        public byte? GetAvgStress()
-        {
-            Object val = GetFieldValue(195, 0, Fit.SubfieldIndexMainField);
-            if(val == null)
-            {
-                return null;
-            }
-
-            return (Convert.ToByte(val));
-            
-        }
-
-        /// <summary>
-        /// Set AvgStress field
-        /// Units: percent
-        /// Comment: Average stress for the monitoring session</summary>
-        /// <param name="avgStress_">Nullable field value to be set</param>
-        public void SetAvgStress(byte? avgStress_)
-        {
-            SetFieldValue(195, 0, avgStress_, Fit.SubfieldIndexMainField);
-        }
-        
-        ///<summary>
-        /// Retrieves the SdrrHrv field
-        /// Units: mS
-        /// Comment: Standard deviation of R-R interval (SDRR) - Heart rate variability measure most useful for wellness users.</summary>
-        /// <returns>Returns nullable byte representing the SdrrHrv field</returns>
-        public byte? GetSdrrHrv()
-        {
-            Object val = GetFieldValue(197, 0, Fit.SubfieldIndexMainField);
-            if(val == null)
-            {
-                return null;
-            }
-
-            return (Convert.ToByte(val));
-            
-        }
-
-        /// <summary>
-        /// Set SdrrHrv field
-        /// Units: mS
-        /// Comment: Standard deviation of R-R interval (SDRR) - Heart rate variability measure most useful for wellness users.</summary>
-        /// <param name="sdrrHrv_">Nullable field value to be set</param>
-        public void SetSdrrHrv(byte? sdrrHrv_)
-        {
-            SetFieldValue(197, 0, sdrrHrv_, Fit.SubfieldIndexMainField);
-        }
-        
-        ///<summary>
-        /// Retrieves the RmssdHrv field
-        /// Units: mS
-        /// Comment: Root mean square successive difference (RMSSD) - Heart rate variability measure most useful for athletes</summary>
-        /// <returns>Returns nullable byte representing the RmssdHrv field</returns>
-        public byte? GetRmssdHrv()
-        {
-            Object val = GetFieldValue(198, 0, Fit.SubfieldIndexMainField);
-            if(val == null)
-            {
-                return null;
-            }
-
-            return (Convert.ToByte(val));
-            
-        }
-
-        /// <summary>
-        /// Set RmssdHrv field
-        /// Units: mS
-        /// Comment: Root mean square successive difference (RMSSD) - Heart rate variability measure most useful for athletes</summary>
-        /// <param name="rmssdHrv_">Nullable field value to be set</param>
-        public void SetRmssdHrv(byte? rmssdHrv_)
-        {
-            SetFieldValue(198, 0, rmssdHrv_, Fit.SubfieldIndexMainField);
-        }
-        
-        ///<summary>
-        /// Retrieves the TotalFractionalAscent field
-        /// Units: m
-        /// Comment: fractional part of total_ascent</summary>
-        /// <returns>Returns nullable float representing the TotalFractionalAscent field</returns>
-        public float? GetTotalFractionalAscent()
-        {
-            Object val = GetFieldValue(199, 0, Fit.SubfieldIndexMainField);
-            if(val == null)
-            {
-                return null;
-            }
-
-            return (Convert.ToSingle(val));
-            
-        }
-
-        /// <summary>
-        /// Set TotalFractionalAscent field
-        /// Units: m
-        /// Comment: fractional part of total_ascent</summary>
-        /// <param name="totalFractionalAscent_">Nullable field value to be set</param>
-        public void SetTotalFractionalAscent(float? totalFractionalAscent_)
-        {
-            SetFieldValue(199, 0, totalFractionalAscent_, Fit.SubfieldIndexMainField);
-        }
-        
-        ///<summary>
-        /// Retrieves the TotalFractionalDescent field
-        /// Units: m
-        /// Comment: fractional part of total_descent</summary>
-        /// <returns>Returns nullable float representing the TotalFractionalDescent field</returns>
-        public float? GetTotalFractionalDescent()
-        {
-            Object val = GetFieldValue(200, 0, Fit.SubfieldIndexMainField);
-            if(val == null)
-            {
-                return null;
-            }
-
-            return (Convert.ToSingle(val));
-            
-        }
-
-        /// <summary>
-        /// Set TotalFractionalDescent field
-        /// Units: m
-        /// Comment: fractional part of total_descent</summary>
-        /// <param name="totalFractionalDescent_">Nullable field value to be set</param>
-        public void SetTotalFractionalDescent(float? totalFractionalDescent_)
-        {
-            SetFieldValue(200, 0, totalFractionalDescent_, Fit.SubfieldIndexMainField);
-        }
-        
-        ///<summary>
-        /// Retrieves the AvgCoreTemperature field
-        /// Units: C</summary>
-        /// <returns>Returns nullable float representing the AvgCoreTemperature field</returns>
-        public float? GetAvgCoreTemperature()
-        {
-            Object val = GetFieldValue(208, 0, Fit.SubfieldIndexMainField);
-            if(val == null)
-            {
-                return null;
-            }
-
-            return (Convert.ToSingle(val));
-            
-        }
-
-        /// <summary>
-        /// Set AvgCoreTemperature field
-        /// Units: C</summary>
-        /// <param name="avgCoreTemperature_">Nullable field value to be set</param>
-        public void SetAvgCoreTemperature(float? avgCoreTemperature_)
-        {
-            SetFieldValue(208, 0, avgCoreTemperature_, Fit.SubfieldIndexMainField);
-        }
-        
-        ///<summary>
-        /// Retrieves the MinCoreTemperature field
-        /// Units: C</summary>
-        /// <returns>Returns nullable float representing the MinCoreTemperature field</returns>
-        public float? GetMinCoreTemperature()
-        {
-            Object val = GetFieldValue(209, 0, Fit.SubfieldIndexMainField);
-            if(val == null)
-            {
-                return null;
-            }
-
-            return (Convert.ToSingle(val));
-            
-        }
-
-        /// <summary>
-        /// Set MinCoreTemperature field
-        /// Units: C</summary>
-        /// <param name="minCoreTemperature_">Nullable field value to be set</param>
-        public void SetMinCoreTemperature(float? minCoreTemperature_)
-        {
-            SetFieldValue(209, 0, minCoreTemperature_, Fit.SubfieldIndexMainField);
-        }
-        
-        ///<summary>
-        /// Retrieves the MaxCoreTemperature field
-        /// Units: C</summary>
-        /// <returns>Returns nullable float representing the MaxCoreTemperature field</returns>
-        public float? GetMaxCoreTemperature()
-        {
-            Object val = GetFieldValue(210, 0, Fit.SubfieldIndexMainField);
-            if(val == null)
-            {
-                return null;
-            }
-
-            return (Convert.ToSingle(val));
-            
-        }
-
-        /// <summary>
-        /// Set MaxCoreTemperature field
-        /// Units: C</summary>
-        /// <param name="maxCoreTemperature_">Nullable field value to be set</param>
-        public void SetMaxCoreTemperature(float? maxCoreTemperature_)
-        {
-            SetFieldValue(210, 0, maxCoreTemperature_, Fit.SubfieldIndexMainField);
-        }
-        
-        #endregion // Methods
-    } // Class
+	/// <summary>
+	/// Implements the Session profile message.
+	/// </summary>
+	public class SessionMesg : Mesg
+	{
+		#region Fields
+		static class TotalCyclesSubfield
+		{
+			public static ushort TotalStrides = 0;
+			public static ushort TotalStrokes = 1;
+			public static ushort Subfields = 2;
+			public static ushort Active = Fit.SubfieldIndexActiveSubfield;
+			public static ushort MainField = Fit.SubfieldIndexMainField;
+		}
+		static class AvgCadenceSubfield
+		{
+			public static ushort AvgRunningCadence = 0;
+			public static ushort Subfields = 1;
+			public static ushort Active = Fit.SubfieldIndexActiveSubfield;
+			public static ushort MainField = Fit.SubfieldIndexMainField;
+		}
+		static class MaxCadenceSubfield
+		{
+			public static ushort MaxRunningCadence = 0;
+			public static ushort Subfields = 1;
+			public static ushort Active = Fit.SubfieldIndexActiveSubfield;
+			public static ushort MainField = Fit.SubfieldIndexMainField;
+		}
+		#endregion
+
+		/// <summary>
+		/// Field Numbers for <see cref="SessionMesg"/>
+		/// </summary>
+		public sealed class FieldDefNum
+		{
+			public const byte MessageIndex = 254;
+			public const byte Timestamp = 253;
+			public const byte Event = 0;
+			public const byte EventType = 1;
+			public const byte StartTime = 2;
+			public const byte StartPositionLat = 3;
+			public const byte StartPositionLong = 4;
+			public const byte Sport = 5;
+			public const byte SubSport = 6;
+			public const byte TotalElapsedTime = 7;
+			public const byte TotalTimerTime = 8;
+			public const byte TotalDistance = 9;
+			public const byte TotalCycles = 10;
+			public const byte TotalCalories = 11;
+			public const byte TotalFatCalories = 13;
+			public const byte AvgSpeed = 14;
+			public const byte MaxSpeed = 15;
+			public const byte AvgHeartRate = 16;
+			public const byte MaxHeartRate = 17;
+			public const byte AvgCadence = 18;
+			public const byte MaxCadence = 19;
+			public const byte AvgPower = 20;
+			public const byte MaxPower = 21;
+			public const byte TotalAscent = 22;
+			public const byte TotalDescent = 23;
+			public const byte TotalTrainingEffect = 24;
+			public const byte FirstLapIndex = 25;
+			public const byte NumLaps = 26;
+			public const byte EventGroup = 27;
+			public const byte Trigger = 28;
+			public const byte NecLat = 29;
+			public const byte NecLong = 30;
+			public const byte SwcLat = 31;
+			public const byte SwcLong = 32;
+			public const byte NumLengths = 33;
+			public const byte NormalizedPower = 34;
+			public const byte TrainingStressScore = 35;
+			public const byte IntensityFactor = 36;
+			public const byte LeftRightBalance = 37;
+			public const byte EndPositionLat = 38;
+			public const byte EndPositionLong = 39;
+			public const byte AvgStrokeCount = 41;
+			public const byte AvgStrokeDistance = 42;
+			public const byte SwimStroke = 43;
+			public const byte PoolLength = 44;
+			public const byte ThresholdPower = 45;
+			public const byte PoolLengthUnit = 46;
+			public const byte NumActiveLengths = 47;
+			public const byte TotalWork = 48;
+			public const byte AvgAltitude = 49;
+			public const byte MaxAltitude = 50;
+			public const byte GpsAccuracy = 51;
+			public const byte AvgGrade = 52;
+			public const byte AvgPosGrade = 53;
+			public const byte AvgNegGrade = 54;
+			public const byte MaxPosGrade = 55;
+			public const byte MaxNegGrade = 56;
+			public const byte AvgTemperature = 57;
+			public const byte MaxTemperature = 58;
+			public const byte TotalMovingTime = 59;
+			public const byte AvgPosVerticalSpeed = 60;
+			public const byte AvgNegVerticalSpeed = 61;
+			public const byte MaxPosVerticalSpeed = 62;
+			public const byte MaxNegVerticalSpeed = 63;
+			public const byte MinHeartRate = 64;
+			public const byte TimeInHrZone = 65;
+			public const byte TimeInSpeedZone = 66;
+			public const byte TimeInCadenceZone = 67;
+			public const byte TimeInPowerZone = 68;
+			public const byte AvgLapTime = 69;
+			public const byte BestLapIndex = 70;
+			public const byte MinAltitude = 71;
+			public const byte PlayerScore = 82;
+			public const byte OpponentScore = 83;
+			public const byte OpponentName = 84;
+			public const byte StrokeCount = 85;
+			public const byte ZoneCount = 86;
+			public const byte MaxBallSpeed = 87;
+			public const byte AvgBallSpeed = 88;
+			public const byte AvgVerticalOscillation = 89;
+			public const byte AvgStanceTimePercent = 90;
+			public const byte AvgStanceTime = 91;
+			public const byte AvgFractionalCadence = 92;
+			public const byte MaxFractionalCadence = 93;
+			public const byte TotalFractionalCycles = 94;
+			public const byte AvgTotalHemoglobinConc = 95;
+			public const byte MinTotalHemoglobinConc = 96;
+			public const byte MaxTotalHemoglobinConc = 97;
+			public const byte AvgSaturatedHemoglobinPercent = 98;
+			public const byte MinSaturatedHemoglobinPercent = 99;
+			public const byte MaxSaturatedHemoglobinPercent = 100;
+			public const byte AvgLeftTorqueEffectiveness = 101;
+			public const byte AvgRightTorqueEffectiveness = 102;
+			public const byte AvgLeftPedalSmoothness = 103;
+			public const byte AvgRightPedalSmoothness = 104;
+			public const byte AvgCombinedPedalSmoothness = 105;
+			public const byte SportProfileName = 110;
+			public const byte SportIndex = 111;
+			public const byte TimeStanding = 112;
+			public const byte StandCount = 113;
+			public const byte AvgLeftPco = 114;
+			public const byte AvgRightPco = 115;
+			public const byte AvgLeftPowerPhase = 116;
+			public const byte AvgLeftPowerPhasePeak = 117;
+			public const byte AvgRightPowerPhase = 118;
+			public const byte AvgRightPowerPhasePeak = 119;
+			public const byte AvgPowerPosition = 120;
+			public const byte MaxPowerPosition = 121;
+			public const byte AvgCadencePosition = 122;
+			public const byte MaxCadencePosition = 123;
+			public const byte EnhancedAvgSpeed = 124;
+			public const byte EnhancedMaxSpeed = 125;
+			public const byte EnhancedAvgAltitude = 126;
+			public const byte EnhancedMinAltitude = 127;
+			public const byte EnhancedMaxAltitude = 128;
+			public const byte AvgLevMotorPower = 129;
+			public const byte MaxLevMotorPower = 130;
+			public const byte LevBatteryConsumption = 131;
+			public const byte AvgVerticalRatio = 132;
+			public const byte AvgStanceTimeBalance = 133;
+			public const byte AvgStepLength = 134;
+			public const byte TotalAnaerobicTrainingEffect = 137;
+			public const byte AvgVam = 139;
+			public const byte AvgDepth = 140;
+			public const byte MaxDepth = 141;
+			public const byte SurfaceInterval = 142;
+			public const byte StartCns = 143;
+			public const byte EndCns = 144;
+			public const byte StartN2 = 145;
+			public const byte EndN2 = 146;
+			public const byte AvgRespirationRate = 147;
+			public const byte MaxRespirationRate = 148;
+			public const byte MinRespirationRate = 149;
+			public const byte MinTemperature = 150;
+			public const byte O2Toxicity = 155;
+			public const byte DiveNumber = 156;
+			public const byte TrainingLoadPeak = 168;
+			public const byte EnhancedAvgRespirationRate = 169;
+			public const byte EnhancedMaxRespirationRate = 170;
+			public const byte EnhancedMinRespirationRate = 180;
+			public const byte TotalGrit = 181;
+			public const byte TotalFlow = 182;
+			public const byte JumpCount = 183;
+			public const byte AvgGrit = 186;
+			public const byte AvgFlow = 187;
+			public const byte WorkoutFeel = 192;
+			public const byte WorkoutRpe = 193;
+			public const byte AvgSpo2 = 194;
+			public const byte AvgStress = 195;
+			public const byte SdrrHrv = 197;
+			public const byte RmssdHrv = 198;
+			public const byte TotalFractionalAscent = 199;
+			public const byte TotalFractionalDescent = 200;
+			public const byte AvgCoreTemperature = 208;
+			public const byte MinCoreTemperature = 209;
+			public const byte MaxCoreTemperature = 210;
+			public const byte Invalid = Fit.FieldNumInvalid;
+		}
+
+		#region Constructors
+		public SessionMesg() : base(Profile.GetMesg(MesgNum.Session))
+		{
+		}
+
+		public SessionMesg(Mesg mesg) : base(mesg)
+		{
+		}
+		#endregion // Constructors
+
+		#region Methods
+		///<summary>
+		/// Retrieves the MessageIndex field
+		/// Comment: Selected bit is set for the current session.</summary>
+		/// <returns>Returns nullable ushort representing the MessageIndex field</returns>
+		public ushort? MessageIndex
+		{
+			get
+			{
+				Object val = GetFieldValue(254, 0, Fit.SubfieldIndexMainField);
+				if (val == null)
+				{
+					return null;
+				}
+
+				return (Convert.ToUInt16(val));
+
+			}
+			set
+			{
+				SetFieldValue(254, 0, value, Fit.SubfieldIndexMainField);
+			}
+		}
+
+		///<summary>
+		/// Retrieves the Timestamp field
+		/// Units: s
+		/// Comment: Sesson end time.</summary>
+		/// <returns>Returns DateTime representing the Timestamp field</returns>
+		public DateTime Timestamp
+		{
+			get
+			{
+				Object val = GetFieldValue(253, 0, Fit.SubfieldIndexMainField);
+				if (val == null)
+				{
+					return null;
+				}
+
+				return TimestampToDateTime(Convert.ToUInt32(val));
+
+			}
+			set
+			{
+				SetFieldValue(253, 0, value.GetTimeStamp(), Fit.SubfieldIndexMainField);
+			}
+		}
+
+		///<summary>
+		/// Retrieves the Event field
+		/// Comment: session</summary>
+		/// <returns>Returns nullable Event enum representing the Event field</returns>
+		public Event? Event
+		{
+			get
+			{
+				object obj = GetFieldValue(0, 0, Fit.SubfieldIndexMainField);
+				Event? value = obj == null ? (Event?)null : (Event)obj;
+				return value;
+			}
+			set
+			{
+				SetFieldValue(0, 0, value, Fit.SubfieldIndexMainField);
+			}
+		}
+
+		///<summary>
+		/// Retrieves the EventType field
+		/// Comment: stop</summary>
+		/// <returns>Returns nullable EventType enum representing the EventType field</returns>
+		public EventType? EventType
+		{
+			get
+			{
+				object obj = GetFieldValue(1, 0, Fit.SubfieldIndexMainField);
+				EventType? value = obj == null ? (EventType?)null : (EventType)obj;
+				return value;
+			}
+			set
+			{
+				SetFieldValue(1, 0, value, Fit.SubfieldIndexMainField);
+			}
+		}
+
+		///<summary>
+		/// Retrieves the StartTime field</summary>
+		/// <returns>Returns DateTime representing the StartTime field</returns>
+		public DateTime StartTime
+		{
+			get
+			{
+				Object val = GetFieldValue(2, 0, Fit.SubfieldIndexMainField);
+				if (val == null)
+				{
+					return null;
+				}
+
+				return TimestampToDateTime(Convert.ToUInt32(val));
+
+			}
+			set
+			{
+				SetFieldValue(2, 0, value.GetTimeStamp(), Fit.SubfieldIndexMainField);
+			}
+		}
+
+		///<summary>
+		/// Retrieves the StartPositionLat field
+		/// Units: semicircles</summary>
+		/// <returns>Returns nullable int representing the StartPositionLat field</returns>
+		public int? StartPositionLat
+		{
+			get
+			{
+				Object val = GetFieldValue(3, 0, Fit.SubfieldIndexMainField);
+				if (val == null)
+				{
+					return null;
+				}
+
+				return (Convert.ToInt32(val));
+
+			}
+			set
+			{
+				SetFieldValue(3, 0, value, Fit.SubfieldIndexMainField);
+			}
+		}
+
+		///<summary>
+		/// Retrieves the StartPositionLong field
+		/// Units: semicircles</summary>
+		/// <returns>Returns nullable int representing the StartPositionLong field</returns>
+		public int? StartPositionLong
+		{
+			get
+			{
+				Object val = GetFieldValue(4, 0, Fit.SubfieldIndexMainField);
+				if (val == null)
+				{
+					return null;
+				}
+
+				return (Convert.ToInt32(val));
+
+			}
+			set
+			{
+				SetFieldValue(4, 0, value, Fit.SubfieldIndexMainField);
+			}
+		}
+
+		///<summary>
+		/// Retrieves the Sport field</summary>
+		/// <returns>Returns nullable Sport enum representing the Sport field</returns>
+		public Sport? Sport
+		{
+			get
+			{
+				object obj = GetFieldValue(5, 0, Fit.SubfieldIndexMainField);
+				Sport? value = obj == null ? (Sport?)null : (Sport)obj;
+				return value;
+			}
+			set
+			{
+				SetFieldValue(5, 0, value, Fit.SubfieldIndexMainField);
+			}
+		}
+
+		///<summary>
+		/// Retrieves the SubSport field</summary>
+		/// <returns>Returns nullable SubSport enum representing the SubSport field</returns>
+		public SubSport? SubSport
+		{
+			get
+			{
+				object obj = GetFieldValue(6, 0, Fit.SubfieldIndexMainField);
+				SubSport? value = obj == null ? (SubSport?)null : (SubSport)obj;
+				return value;
+			}
+			set
+			{
+				SetFieldValue(6, 0, value, Fit.SubfieldIndexMainField);
+			}
+		}
+
+		///<summary>
+		/// Retrieves the TotalElapsedTime field
+		/// Units: s
+		/// Comment: Time (includes pauses)</summary>
+		/// <returns>Returns nullable float representing the TotalElapsedTime field</returns>
+		public float? TotalElapsedTime
+		{
+			get
+			{
+				Object val = GetFieldValue(7, 0, Fit.SubfieldIndexMainField);
+				if (val == null)
+				{
+					return null;
+				}
+
+				return (Convert.ToSingle(val));
+
+			}
+			set
+			{
+				SetFieldValue(7, 0, value, Fit.SubfieldIndexMainField);
+			}
+		}
+
+		///<summary>
+		/// Retrieves the TotalTimerTime field
+		/// Units: s
+		/// Comment: Timer Time (excludes pauses)</summary>
+		/// <returns>Returns nullable float representing the TotalTimerTime field</returns>
+		public float? TotalTimerTime
+		{
+			get
+			{
+				Object val = GetFieldValue(8, 0, Fit.SubfieldIndexMainField);
+				if (val == null)
+				{
+					return null;
+				}
+
+				return (Convert.ToSingle(val));
+
+			}
+			set
+			{
+				SetFieldValue(8, 0, value, Fit.SubfieldIndexMainField);
+			}
+		}
+
+		///<summary>
+		/// Retrieves the TotalDistance field
+		/// Units: m</summary>
+		/// <returns>Returns nullable float representing the TotalDistance field</returns>
+		public float? TotalDistance
+		{
+			get
+			{
+				Object val = GetFieldValue(9, 0, Fit.SubfieldIndexMainField);
+				if (val == null)
+				{
+					return null;
+				}
+
+				return (Convert.ToSingle(val));
+
+			}
+			set
+			{
+				SetFieldValue(9, 0, value, Fit.SubfieldIndexMainField);
+			}
+		}
+
+		///<summary>
+		/// Retrieves the TotalCycles field
+		/// Units: cycles</summary>
+		/// <returns>Returns nullable uint representing the TotalCycles field</returns>
+		public uint? TotalCycles
+		{
+			get
+			{
+				Object val = GetFieldValue(10, 0, Fit.SubfieldIndexMainField);
+				if (val == null)
+				{
+					return null;
+				}
+
+				return (Convert.ToUInt32(val));
+
+			}
+			set
+			{
+				SetFieldValue(10, 0, value, Fit.SubfieldIndexMainField);
+			}
+		}
+
+
+		/// <summary>
+		/// Retrieves the TotalStrides subfield
+		/// Units: strides</summary>
+		/// <returns>Nullable uint representing the TotalStrides subfield</returns>
+		public uint? TotalStrides
+		{
+			get
+			{
+				Object val = GetFieldValue(10, 0, TotalCyclesSubfield.TotalStrides);
+				if (val == null)
+				{
+					return null;
+				}
+
+				return (Convert.ToUInt32(val));
+
+			}
+			set
+			{
+				SetFieldValue(10, 0, value, TotalCyclesSubfield.TotalStrides);
+			}
+		}
+
+		/// <summary>
+		/// Retrieves the TotalStrokes subfield
+		/// Units: strokes</summary>
+		/// <returns>Nullable uint representing the TotalStrokes subfield</returns>
+		public uint? TotalStrokes
+		{
+			get
+			{
+				Object val = GetFieldValue(10, 0, TotalCyclesSubfield.TotalStrokes);
+				if (val == null)
+				{
+					return null;
+				}
+
+				return (Convert.ToUInt32(val));
+
+			}
+			set
+			{
+				SetFieldValue(10, 0, value, TotalCyclesSubfield.TotalStrokes);
+			}
+		}
+		///<summary>
+		/// Retrieves the TotalCalories field
+		/// Units: kcal</summary>
+		/// <returns>Returns nullable ushort representing the TotalCalories field</returns>
+		public ushort? TotalCalories
+		{
+			get
+			{
+				Object val = GetFieldValue(11, 0, Fit.SubfieldIndexMainField);
+				if (val == null)
+				{
+					return null;
+				}
+
+				return (Convert.ToUInt16(val));
+
+			}
+			set
+			{
+				SetFieldValue(11, 0, value, Fit.SubfieldIndexMainField);
+			}
+		}
+
+		///<summary>
+		/// Retrieves the TotalFatCalories field
+		/// Units: kcal</summary>
+		/// <returns>Returns nullable ushort representing the TotalFatCalories field</returns>
+		public ushort? TotalFatCalories
+		{
+			get
+			{
+				Object val = GetFieldValue(13, 0, Fit.SubfieldIndexMainField);
+				if (val == null)
+				{
+					return null;
+				}
+
+				return (Convert.ToUInt16(val));
+
+			}
+			set
+			{
+				SetFieldValue(13, 0, value, Fit.SubfieldIndexMainField);
+			}
+		}
+
+		///<summary>
+		/// Retrieves the AvgSpeed field
+		/// Units: m/s
+		/// Comment: total_distance / total_timer_time</summary>
+		/// <returns>Returns nullable float representing the AvgSpeed field</returns>
+		public float? AvgSpeed
+		{
+			get
+			{
+				Object val = GetFieldValue(14, 0, Fit.SubfieldIndexMainField);
+				if (val == null)
+				{
+					return null;
+				}
+
+				return (Convert.ToSingle(val));
+
+			}
+			set
+			{
+				SetFieldValue(14, 0, value, Fit.SubfieldIndexMainField);
+			}
+		}
+
+		///<summary>
+		/// Retrieves the MaxSpeed field
+		/// Units: m/s</summary>
+		/// <returns>Returns nullable float representing the MaxSpeed field</returns>
+		public float? MaxSpeed
+		{
+			get
+			{
+				Object val = GetFieldValue(15, 0, Fit.SubfieldIndexMainField);
+				if (val == null)
+				{
+					return null;
+				}
+
+				return (Convert.ToSingle(val));
+
+			}
+			set
+			{
+				SetFieldValue(15, 0, value, Fit.SubfieldIndexMainField);
+			}
+		}
+
+		///<summary>
+		/// Retrieves the AvgHeartRate field
+		/// Units: bpm
+		/// Comment: average heart rate (excludes pause time)</summary>
+		/// <returns>Returns nullable byte representing the AvgHeartRate field</returns>
+		public byte? AvgHeartRate
+		{
+			get
+			{
+				Object val = GetFieldValue(16, 0, Fit.SubfieldIndexMainField);
+				if (val == null)
+				{
+					return null;
+				}
+
+				return (Convert.ToByte(val));
+
+			}
+			set
+			{
+				SetFieldValue(16, 0, value, Fit.SubfieldIndexMainField);
+			}
+		}
+
+		///<summary>
+		/// Retrieves the MaxHeartRate field
+		/// Units: bpm</summary>
+		/// <returns>Returns nullable byte representing the MaxHeartRate field</returns>
+		public byte? MaxHeartRate
+		{
+			get
+			{
+				Object val = GetFieldValue(17, 0, Fit.SubfieldIndexMainField);
+				if (val == null)
+				{
+					return null;
+				}
+
+				return (Convert.ToByte(val));
+
+			}
+			set
+			{
+				SetFieldValue(17, 0, value, Fit.SubfieldIndexMainField);
+			}
+		}
+
+		///<summary>
+		/// Retrieves the AvgCadence field
+		/// Units: rpm
+		/// Comment: total_cycles / total_timer_time if non_zero_avg_cadence otherwise total_cycles / total_elapsed_time</summary>
+		/// <returns>Returns nullable byte representing the AvgCadence field</returns>
+		public byte? AvgCadence
+		{
+			get
+			{
+				Object val = GetFieldValue(18, 0, Fit.SubfieldIndexMainField);
+				if (val == null)
+				{
+					return null;
+				}
+
+				return (Convert.ToByte(val));
+
+			}
+			set
+			{
+				SetFieldValue(18, 0, value, Fit.SubfieldIndexMainField);
+			}
+		}
+
+
+		/// <summary>
+		/// Retrieves the AvgRunningCadence subfield
+		/// Units: strides/min</summary>
+		/// <returns>Nullable byte representing the AvgRunningCadence subfield</returns>
+		public byte? AvgRunningCadence
+		{
+			get
+			{
+				Object val = GetFieldValue(18, 0, AvgCadenceSubfield.AvgRunningCadence);
+				if (val == null)
+				{
+					return null;
+				}
+
+				return (Convert.ToByte(val));
+
+			}
+			set
+			{
+				SetFieldValue(18, 0, value, AvgCadenceSubfield.AvgRunningCadence);
+			}
+		}
+		///<summary>
+		/// Retrieves the MaxCadence field
+		/// Units: rpm</summary>
+		/// <returns>Returns nullable byte representing the MaxCadence field</returns>
+		public byte? MaxCadence
+		{
+			get
+			{
+				Object val = GetFieldValue(19, 0, Fit.SubfieldIndexMainField);
+				if (val == null)
+				{
+					return null;
+				}
+
+				return (Convert.ToByte(val));
+
+			}
+			set
+			{
+				SetFieldValue(19, 0, value, Fit.SubfieldIndexMainField);
+			}
+		}
+
+
+		/// <summary>
+		/// Retrieves the MaxRunningCadence subfield
+		/// Units: strides/min</summary>
+		/// <returns>Nullable byte representing the MaxRunningCadence subfield</returns>
+		public byte? MaxRunningCadence
+		{
+			get
+			{
+				Object val = GetFieldValue(19, 0, MaxCadenceSubfield.MaxRunningCadence);
+				if (val == null)
+				{
+					return null;
+				}
+
+				return (Convert.ToByte(val));
+
+			}
+			set
+			{
+				SetFieldValue(19, 0, value, MaxCadenceSubfield.MaxRunningCadence);
+			}
+		}
+		///<summary>
+		/// Retrieves the AvgPower field
+		/// Units: watts
+		/// Comment: total_power / total_timer_time if non_zero_avg_power otherwise total_power / total_elapsed_time</summary>
+		/// <returns>Returns nullable ushort representing the AvgPower field</returns>
+		public ushort? AvgPower
+		{
+			get
+			{
+				Object val = GetFieldValue(20, 0, Fit.SubfieldIndexMainField);
+				if (val == null)
+				{
+					return null;
+				}
+
+				return (Convert.ToUInt16(val));
+
+			}
+			set
+			{
+				SetFieldValue(20, 0, value, Fit.SubfieldIndexMainField);
+			}
+		}
+
+		///<summary>
+		/// Retrieves the MaxPower field
+		/// Units: watts</summary>
+		/// <returns>Returns nullable ushort representing the MaxPower field</returns>
+		public ushort? MaxPower
+		{
+			get
+			{
+				Object val = GetFieldValue(21, 0, Fit.SubfieldIndexMainField);
+				if (val == null)
+				{
+					return null;
+				}
+
+				return (Convert.ToUInt16(val));
+
+			}
+			set
+			{
+				SetFieldValue(21, 0, value, Fit.SubfieldIndexMainField);
+			}
+		}
+
+		///<summary>
+		/// Retrieves the TotalAscent field
+		/// Units: m</summary>
+		/// <returns>Returns nullable ushort representing the TotalAscent field</returns>
+		public ushort? TotalAscent
+		{
+			get
+			{
+				Object val = GetFieldValue(22, 0, Fit.SubfieldIndexMainField);
+				if (val == null)
+				{
+					return null;
+				}
+
+				return (Convert.ToUInt16(val));
+
+			}
+			set
+			{
+				SetFieldValue(22, 0, value, Fit.SubfieldIndexMainField);
+			}
+		}
+
+		///<summary>
+		/// Retrieves the TotalDescent field
+		/// Units: m</summary>
+		/// <returns>Returns nullable ushort representing the TotalDescent field</returns>
+		public ushort? TotalDescent
+		{
+			get
+			{
+				Object val = GetFieldValue(23, 0, Fit.SubfieldIndexMainField);
+				if (val == null)
+				{
+					return null;
+				}
+
+				return (Convert.ToUInt16(val));
+
+			}
+			set
+			{
+				SetFieldValue(23, 0, value, Fit.SubfieldIndexMainField);
+			}
+		}
+
+		///<summary>
+		/// Retrieves the TotalTrainingEffect field</summary>
+		/// <returns>Returns nullable float representing the TotalTrainingEffect field</returns>
+		public float? TotalTrainingEffect
+		{
+			get
+			{
+				Object val = GetFieldValue(24, 0, Fit.SubfieldIndexMainField);
+				if (val == null)
+				{
+					return null;
+				}
+
+				return (Convert.ToSingle(val));
+
+			}
+			set
+			{
+				SetFieldValue(24, 0, value, Fit.SubfieldIndexMainField);
+			}
+		}
+
+		///<summary>
+		/// Retrieves the FirstLapIndex field</summary>
+		/// <returns>Returns nullable ushort representing the FirstLapIndex field</returns>
+		public ushort? FirstLapIndex
+		{
+			get
+			{
+				Object val = GetFieldValue(25, 0, Fit.SubfieldIndexMainField);
+				if (val == null)
+				{
+					return null;
+				}
+
+				return (Convert.ToUInt16(val));
+
+			}
+			set
+			{
+				SetFieldValue(25, 0, value, Fit.SubfieldIndexMainField);
+			}
+		}
+
+		///<summary>
+		/// Retrieves the NumLaps field</summary>
+		/// <returns>Returns nullable ushort representing the NumLaps field</returns>
+		public ushort? NumLaps
+		{
+			get
+			{
+				Object val = GetFieldValue(26, 0, Fit.SubfieldIndexMainField);
+				if (val == null)
+				{
+					return null;
+				}
+
+				return (Convert.ToUInt16(val));
+
+			}
+			set
+			{
+				SetFieldValue(26, 0, value, Fit.SubfieldIndexMainField);
+			}
+		}
+
+		///<summary>
+		/// Retrieves the EventGroup field</summary>
+		/// <returns>Returns nullable byte representing the EventGroup field</returns>
+		public byte? EventGroup
+		{
+			get
+			{
+				Object val = GetFieldValue(27, 0, Fit.SubfieldIndexMainField);
+				if (val == null)
+				{
+					return null;
+				}
+
+				return (Convert.ToByte(val));
+
+			}
+			set
+			{
+				SetFieldValue(27, 0, value, Fit.SubfieldIndexMainField);
+			}
+		}
+
+		///<summary>
+		/// Retrieves the Trigger field</summary>
+		/// <returns>Returns nullable SessionTrigger enum representing the Trigger field</returns>
+		public SessionTrigger? Trigger
+		{
+			get
+			{
+				object obj = GetFieldValue(28, 0, Fit.SubfieldIndexMainField);
+				SessionTrigger? value = obj == null ? (SessionTrigger?)null : (SessionTrigger)obj;
+				return value;
+			}
+			set
+			{
+				SetFieldValue(28, 0, value, Fit.SubfieldIndexMainField);
+			}
+		}
+
+		///<summary>
+		/// Retrieves the NecLat field
+		/// Units: semicircles
+		/// Comment: North east corner latitude</summary>
+		/// <returns>Returns nullable int representing the NecLat field</returns>
+		public int? NecLat
+		{
+			get
+			{
+				Object val = GetFieldValue(29, 0, Fit.SubfieldIndexMainField);
+				if (val == null)
+				{
+					return null;
+				}
+
+				return (Convert.ToInt32(val));
+
+			}
+			set
+			{
+				SetFieldValue(29, 0, value, Fit.SubfieldIndexMainField);
+			}
+		}
+
+		///<summary>
+		/// Retrieves the NecLong field
+		/// Units: semicircles
+		/// Comment: North east corner longitude</summary>
+		/// <returns>Returns nullable int representing the NecLong field</returns>
+		public int? NecLong
+		{
+			get
+			{
+				Object val = GetFieldValue(30, 0, Fit.SubfieldIndexMainField);
+				if (val == null)
+				{
+					return null;
+				}
+
+				return (Convert.ToInt32(val));
+
+			}
+			set
+			{
+				SetFieldValue(30, 0, value, Fit.SubfieldIndexMainField);
+			}
+		}
+
+		///<summary>
+		/// Retrieves the SwcLat field
+		/// Units: semicircles
+		/// Comment: South west corner latitude</summary>
+		/// <returns>Returns nullable int representing the SwcLat field</returns>
+		public int? SwcLat
+		{
+			get
+			{
+				Object val = GetFieldValue(31, 0, Fit.SubfieldIndexMainField);
+				if (val == null)
+				{
+					return null;
+				}
+
+				return (Convert.ToInt32(val));
+
+			}
+			set
+			{
+				SetFieldValue(31, 0, value, Fit.SubfieldIndexMainField);
+			}
+		}
+
+		///<summary>
+		/// Retrieves the SwcLong field
+		/// Units: semicircles
+		/// Comment: South west corner longitude</summary>
+		/// <returns>Returns nullable int representing the SwcLong field</returns>
+		public int? SwcLong
+		{
+			get
+			{
+				Object val = GetFieldValue(32, 0, Fit.SubfieldIndexMainField);
+				if (val == null)
+				{
+					return null;
+				}
+
+				return (Convert.ToInt32(val));
+
+			}
+			set
+			{
+				SetFieldValue(32, 0, value, Fit.SubfieldIndexMainField);
+			}
+		}
+
+		///<summary>
+		/// Retrieves the NumLengths field
+		/// Units: lengths
+		/// Comment: # of lengths of swim pool</summary>
+		/// <returns>Returns nullable ushort representing the NumLengths field</returns>
+		public ushort? NumLengths
+		{
+			get
+			{
+				Object val = GetFieldValue(33, 0, Fit.SubfieldIndexMainField);
+				if (val == null)
+				{
+					return null;
+				}
+
+				return (Convert.ToUInt16(val));
+
+			}
+			set
+			{
+				SetFieldValue(33, 0, value, Fit.SubfieldIndexMainField);
+			}
+		}
+
+		///<summary>
+		/// Retrieves the NormalizedPower field
+		/// Units: watts</summary>
+		/// <returns>Returns nullable ushort representing the NormalizedPower field</returns>
+		public ushort? NormalizedPower
+		{
+			get
+			{
+				Object val = GetFieldValue(34, 0, Fit.SubfieldIndexMainField);
+				if (val == null)
+				{
+					return null;
+				}
+
+				return (Convert.ToUInt16(val));
+
+			}
+			set
+			{
+				SetFieldValue(34, 0, value, Fit.SubfieldIndexMainField);
+			}
+		}
+
+		///<summary>
+		/// Retrieves the TrainingStressScore field
+		/// Units: tss</summary>
+		/// <returns>Returns nullable float representing the TrainingStressScore field</returns>
+		public float? TrainingStressScore
+		{
+			get
+			{
+				Object val = GetFieldValue(35, 0, Fit.SubfieldIndexMainField);
+				if (val == null)
+				{
+					return null;
+				}
+
+				return (Convert.ToSingle(val));
+
+			}
+			set
+			{
+				SetFieldValue(35, 0, value, Fit.SubfieldIndexMainField);
+			}
+		}
+
+		///<summary>
+		/// Retrieves the IntensityFactor field
+		/// Units: if</summary>
+		/// <returns>Returns nullable float representing the IntensityFactor field</returns>
+		public float? IntensityFactor
+		{
+			get
+			{
+				Object val = GetFieldValue(36, 0, Fit.SubfieldIndexMainField);
+				if (val == null)
+				{
+					return null;
+				}
+
+				return (Convert.ToSingle(val));
+
+			}
+			set
+			{
+				SetFieldValue(36, 0, value, Fit.SubfieldIndexMainField);
+			}
+		}
+
+		///<summary>
+		/// Retrieves the LeftRightBalance field</summary>
+		/// <returns>Returns nullable ushort representing the LeftRightBalance field</returns>
+		public ushort? LeftRightBalance
+		{
+			get
+			{
+				Object val = GetFieldValue(37, 0, Fit.SubfieldIndexMainField);
+				if (val == null)
+				{
+					return null;
+				}
+
+				return (Convert.ToUInt16(val));
+
+			}
+			set
+			{
+				SetFieldValue(37, 0, value, Fit.SubfieldIndexMainField);
+			}
+		}
+
+		///<summary>
+		/// Retrieves the EndPositionLat field
+		/// Units: semicircles</summary>
+		/// <returns>Returns nullable int representing the EndPositionLat field</returns>
+		public int? EndPositionLat
+		{
+			get
+			{
+				Object val = GetFieldValue(38, 0, Fit.SubfieldIndexMainField);
+				if (val == null)
+				{
+					return null;
+				}
+
+				return (Convert.ToInt32(val));
+
+			}
+			set
+			{
+				SetFieldValue(38, 0, value, Fit.SubfieldIndexMainField);
+			}
+		}
+
+		///<summary>
+		/// Retrieves the EndPositionLong field
+		/// Units: semicircles</summary>
+		/// <returns>Returns nullable int representing the EndPositionLong field</returns>
+		public int? EndPositionLong
+		{
+			get
+			{
+				Object val = GetFieldValue(39, 0, Fit.SubfieldIndexMainField);
+				if (val == null)
+				{
+					return null;
+				}
+
+				return (Convert.ToInt32(val));
+
+			}
+			set
+			{
+				SetFieldValue(39, 0, value, Fit.SubfieldIndexMainField);
+			}
+		}
+
+		///<summary>
+		/// Retrieves the AvgStrokeCount field
+		/// Units: strokes/lap</summary>
+		/// <returns>Returns nullable float representing the AvgStrokeCount field</returns>
+		public float? AvgStrokeCount
+		{
+			get
+			{
+				Object val = GetFieldValue(41, 0, Fit.SubfieldIndexMainField);
+				if (val == null)
+				{
+					return null;
+				}
+
+				return (Convert.ToSingle(val));
+
+			}
+			set
+			{
+				SetFieldValue(41, 0, value, Fit.SubfieldIndexMainField);
+			}
+		}
+
+		///<summary>
+		/// Retrieves the AvgStrokeDistance field
+		/// Units: m</summary>
+		/// <returns>Returns nullable float representing the AvgStrokeDistance field</returns>
+		public float? AvgStrokeDistance
+		{
+			get
+			{
+				Object val = GetFieldValue(42, 0, Fit.SubfieldIndexMainField);
+				if (val == null)
+				{
+					return null;
+				}
+
+				return (Convert.ToSingle(val));
+
+			}
+			set
+			{
+				SetFieldValue(42, 0, value, Fit.SubfieldIndexMainField);
+			}
+		}
+
+		///<summary>
+		/// Retrieves the SwimStroke field
+		/// Units: swim_stroke</summary>
+		/// <returns>Returns nullable SwimStroke enum representing the SwimStroke field</returns>
+		public SwimStroke? SwimStroke
+		{
+			get
+			{
+				object obj = GetFieldValue(43, 0, Fit.SubfieldIndexMainField);
+				SwimStroke? value = obj == null ? (SwimStroke?)null : (SwimStroke)obj;
+				return value;
+			}
+			set
+			{
+				SetFieldValue(43, 0, value, Fit.SubfieldIndexMainField);
+			}
+		}
+
+		///<summary>
+		/// Retrieves the PoolLength field
+		/// Units: m</summary>
+		/// <returns>Returns nullable float representing the PoolLength field</returns>
+		public float? PoolLength
+		{
+			get
+			{
+				Object val = GetFieldValue(44, 0, Fit.SubfieldIndexMainField);
+				if (val == null)
+				{
+					return null;
+				}
+
+				return (Convert.ToSingle(val));
+
+			}
+			set
+			{
+				SetFieldValue(44, 0, value, Fit.SubfieldIndexMainField);
+			}
+		}
+
+		///<summary>
+		/// Retrieves the ThresholdPower field
+		/// Units: watts</summary>
+		/// <returns>Returns nullable ushort representing the ThresholdPower field</returns>
+		public ushort? ThresholdPower
+		{
+			get
+			{
+				Object val = GetFieldValue(45, 0, Fit.SubfieldIndexMainField);
+				if (val == null)
+				{
+					return null;
+				}
+
+				return (Convert.ToUInt16(val));
+
+			}
+			set
+			{
+				SetFieldValue(45, 0, value, Fit.SubfieldIndexMainField);
+			}
+		}
+
+		///<summary>
+		/// Retrieves the PoolLengthUnit field</summary>
+		/// <returns>Returns nullable DisplayMeasure enum representing the PoolLengthUnit field</returns>
+		public DisplayMeasure? PoolLengthUnit
+		{
+			get
+			{
+				object obj = GetFieldValue(46, 0, Fit.SubfieldIndexMainField);
+				DisplayMeasure? value = obj == null ? (DisplayMeasure?)null : (DisplayMeasure)obj;
+				return value;
+			}
+			set
+			{
+				SetFieldValue(46, 0, value, Fit.SubfieldIndexMainField);
+			}
+		}
+
+		///<summary>
+		/// Retrieves the NumActiveLengths field
+		/// Units: lengths
+		/// Comment: # of active lengths of swim pool</summary>
+		/// <returns>Returns nullable ushort representing the NumActiveLengths field</returns>
+		public ushort? NumActiveLengths
+		{
+			get
+			{
+				Object val = GetFieldValue(47, 0, Fit.SubfieldIndexMainField);
+				if (val == null)
+				{
+					return null;
+				}
+
+				return (Convert.ToUInt16(val));
+
+			}
+			set
+			{
+				SetFieldValue(47, 0, value, Fit.SubfieldIndexMainField);
+			}
+		}
+
+		///<summary>
+		/// Retrieves the TotalWork field
+		/// Units: J</summary>
+		/// <returns>Returns nullable uint representing the TotalWork field</returns>
+		public uint? TotalWork
+		{
+			get
+			{
+				Object val = GetFieldValue(48, 0, Fit.SubfieldIndexMainField);
+				if (val == null)
+				{
+					return null;
+				}
+
+				return (Convert.ToUInt32(val));
+
+			}
+			set
+			{
+				SetFieldValue(48, 0, value, Fit.SubfieldIndexMainField);
+			}
+		}
+
+		///<summary>
+		/// Retrieves the AvgAltitude field
+		/// Units: m</summary>
+		/// <returns>Returns nullable float representing the AvgAltitude field</returns>
+		public float? AvgAltitude
+		{
+			get
+			{
+				Object val = GetFieldValue(49, 0, Fit.SubfieldIndexMainField);
+				if (val == null)
+				{
+					return null;
+				}
+
+				return (Convert.ToSingle(val));
+
+			}
+			set
+			{
+				SetFieldValue(49, 0, value, Fit.SubfieldIndexMainField);
+			}
+		}
+
+		///<summary>
+		/// Retrieves the MaxAltitude field
+		/// Units: m</summary>
+		/// <returns>Returns nullable float representing the MaxAltitude field</returns>
+		public float? MaxAltitude
+		{
+			get
+			{
+				Object val = GetFieldValue(50, 0, Fit.SubfieldIndexMainField);
+				if (val == null)
+				{
+					return null;
+				}
+
+				return (Convert.ToSingle(val));
+
+			}
+			set
+			{
+				SetFieldValue(50, 0, value, Fit.SubfieldIndexMainField);
+			}
+		}
+
+		///<summary>
+		/// Retrieves the GpsAccuracy field
+		/// Units: m</summary>
+		/// <returns>Returns nullable byte representing the GpsAccuracy field</returns>
+		public byte? GpsAccuracy
+		{
+			get
+			{
+				Object val = GetFieldValue(51, 0, Fit.SubfieldIndexMainField);
+				if (val == null)
+				{
+					return null;
+				}
+
+				return (Convert.ToByte(val));
+
+			}
+			set
+			{
+				SetFieldValue(51, 0, value, Fit.SubfieldIndexMainField);
+			}
+		}
+
+		///<summary>
+		/// Retrieves the AvgGrade field
+		/// Units: %</summary>
+		/// <returns>Returns nullable float representing the AvgGrade field</returns>
+		public float? AvgGrade
+		{
+			get
+			{
+				Object val = GetFieldValue(52, 0, Fit.SubfieldIndexMainField);
+				if (val == null)
+				{
+					return null;
+				}
+
+				return (Convert.ToSingle(val));
+
+			}
+			set
+			{
+				SetFieldValue(52, 0, value, Fit.SubfieldIndexMainField);
+			}
+		}
+
+		///<summary>
+		/// Retrieves the AvgPosGrade field
+		/// Units: %</summary>
+		/// <returns>Returns nullable float representing the AvgPosGrade field</returns>
+		public float? AvgPosGrade
+		{
+			get
+			{
+				Object val = GetFieldValue(53, 0, Fit.SubfieldIndexMainField);
+				if (val == null)
+				{
+					return null;
+				}
+
+				return (Convert.ToSingle(val));
+
+			}
+			set
+			{
+				SetFieldValue(53, 0, value, Fit.SubfieldIndexMainField);
+			}
+		}
+
+		///<summary>
+		/// Retrieves the AvgNegGrade field
+		/// Units: %</summary>
+		/// <returns>Returns nullable float representing the AvgNegGrade field</returns>
+		public float? AvgNegGrade
+		{
+			get
+			{
+				Object val = GetFieldValue(54, 0, Fit.SubfieldIndexMainField);
+				if (val == null)
+				{
+					return null;
+				}
+
+				return (Convert.ToSingle(val));
+
+			}
+			set
+			{
+				SetFieldValue(54, 0, value, Fit.SubfieldIndexMainField);
+			}
+		}
+
+		///<summary>
+		/// Retrieves the MaxPosGrade field
+		/// Units: %</summary>
+		/// <returns>Returns nullable float representing the MaxPosGrade field</returns>
+		public float? MaxPosGrade
+		{
+			get
+			{
+				Object val = GetFieldValue(55, 0, Fit.SubfieldIndexMainField);
+				if (val == null)
+				{
+					return null;
+				}
+
+				return (Convert.ToSingle(val));
+
+			}
+			set
+			{
+				SetFieldValue(55, 0, value, Fit.SubfieldIndexMainField);
+			}
+		}
+
+		///<summary>
+		/// Retrieves the MaxNegGrade field
+		/// Units: %</summary>
+		/// <returns>Returns nullable float representing the MaxNegGrade field</returns>
+		public float? MaxNegGrade
+		{
+			get
+			{
+				Object val = GetFieldValue(56, 0, Fit.SubfieldIndexMainField);
+				if (val == null)
+				{
+					return null;
+				}
+
+				return (Convert.ToSingle(val));
+
+			}
+			set
+			{
+				SetFieldValue(56, 0, value, Fit.SubfieldIndexMainField);
+			}
+		}
+
+		///<summary>
+		/// Retrieves the AvgTemperature field
+		/// Units: C</summary>
+		/// <returns>Returns nullable sbyte representing the AvgTemperature field</returns>
+		public sbyte? AvgTemperature
+		{
+			get
+			{
+				Object val = GetFieldValue(57, 0, Fit.SubfieldIndexMainField);
+				if (val == null)
+				{
+					return null;
+				}
+
+				return (Convert.ToSByte(val));
+
+			}
+			set
+			{
+				SetFieldValue(57, 0, value, Fit.SubfieldIndexMainField);
+			}
+		}
+
+		///<summary>
+		/// Retrieves the MaxTemperature field
+		/// Units: C</summary>
+		/// <returns>Returns nullable sbyte representing the MaxTemperature field</returns>
+		public sbyte? MaxTemperature
+		{
+			get
+			{
+				Object val = GetFieldValue(58, 0, Fit.SubfieldIndexMainField);
+				if (val == null)
+				{
+					return null;
+				}
+
+				return (Convert.ToSByte(val));
+
+			}
+			set
+			{
+				SetFieldValue(58, 0, value, Fit.SubfieldIndexMainField);
+			}
+		}
+
+		///<summary>
+		/// Retrieves the TotalMovingTime field
+		/// Units: s</summary>
+		/// <returns>Returns nullable float representing the TotalMovingTime field</returns>
+		public float? TotalMovingTime
+		{
+			get
+			{
+				Object val = GetFieldValue(59, 0, Fit.SubfieldIndexMainField);
+				if (val == null)
+				{
+					return null;
+				}
+
+				return (Convert.ToSingle(val));
+
+			}
+			set
+			{
+				SetFieldValue(59, 0, value, Fit.SubfieldIndexMainField);
+			}
+		}
+
+		///<summary>
+		/// Retrieves the AvgPosVerticalSpeed field
+		/// Units: m/s</summary>
+		/// <returns>Returns nullable float representing the AvgPosVerticalSpeed field</returns>
+		public float? AvgPosVerticalSpeed
+		{
+			get
+			{
+				Object val = GetFieldValue(60, 0, Fit.SubfieldIndexMainField);
+				if (val == null)
+				{
+					return null;
+				}
+
+				return (Convert.ToSingle(val));
+
+			}
+			set
+			{
+				SetFieldValue(60, 0, value, Fit.SubfieldIndexMainField);
+			}
+		}
+
+		///<summary>
+		/// Retrieves the AvgNegVerticalSpeed field
+		/// Units: m/s</summary>
+		/// <returns>Returns nullable float representing the AvgNegVerticalSpeed field</returns>
+		public float? AvgNegVerticalSpeed
+		{
+			get
+			{
+				Object val = GetFieldValue(61, 0, Fit.SubfieldIndexMainField);
+				if (val == null)
+				{
+					return null;
+				}
+
+				return (Convert.ToSingle(val));
+
+			}
+			set
+			{
+				SetFieldValue(61, 0, value, Fit.SubfieldIndexMainField);
+			}
+		}
+
+		///<summary>
+		/// Retrieves the MaxPosVerticalSpeed field
+		/// Units: m/s</summary>
+		/// <returns>Returns nullable float representing the MaxPosVerticalSpeed field</returns>
+		public float? MaxPosVerticalSpeed
+		{
+			get
+			{
+				Object val = GetFieldValue(62, 0, Fit.SubfieldIndexMainField);
+				if (val == null)
+				{
+					return null;
+				}
+
+				return (Convert.ToSingle(val));
+
+			}
+			set
+			{
+				SetFieldValue(62, 0, value, Fit.SubfieldIndexMainField);
+			}
+		}
+
+		///<summary>
+		/// Retrieves the MaxNegVerticalSpeed field
+		/// Units: m/s</summary>
+		/// <returns>Returns nullable float representing the MaxNegVerticalSpeed field</returns>
+		public float? MaxNegVerticalSpeed
+		{
+			get
+			{
+				Object val = GetFieldValue(63, 0, Fit.SubfieldIndexMainField);
+				if (val == null)
+				{
+					return null;
+				}
+
+				return (Convert.ToSingle(val));
+
+			}
+			set
+			{
+				SetFieldValue(63, 0, value, Fit.SubfieldIndexMainField);
+			}
+		}
+
+		///<summary>
+		/// Retrieves the MinHeartRate field
+		/// Units: bpm</summary>
+		/// <returns>Returns nullable byte representing the MinHeartRate field</returns>
+		public byte? MinHeartRate
+		{
+			get
+			{
+				Object val = GetFieldValue(64, 0, Fit.SubfieldIndexMainField);
+				if (val == null)
+				{
+					return null;
+				}
+
+				return (Convert.ToByte(val));
+
+			}
+			set
+			{
+				SetFieldValue(64, 0, value, Fit.SubfieldIndexMainField);
+			}
+		}
+
+
+		/// <summary>
+		///
+		/// </summary>
+		/// <returns>returns number of elements in field TimeInHrZone</returns>
+		public int GetNumTimeInHrZone()
+		{
+			return GetNumFieldValues(65, Fit.SubfieldIndexMainField);
+		}
+
+		///<summary>
+		/// Retrieves the TimeInHrZone field
+		/// Units: s</summary>
+		/// <param name="index">0 based index of TimeInHrZone element to retrieve</param>
+		/// <returns>Returns nullable float representing the TimeInHrZone field</returns>
+		public float? GetTimeInHrZone(int index)
+		{
+			Object val = GetFieldValue(65, index, Fit.SubfieldIndexMainField);
+			if (val == null)
+			{
+				return null;
+			}
+
+			return (Convert.ToSingle(val));
+
+		}
+
+		/// <summary>
+		/// Set TimeInHrZone field
+		/// Units: s</summary>
+		/// <param name="index">0 based index of time_in_hr_zone</param>
+		/// <param name="timeInHrZone_">Nullable field value to be set</param>
+		public void SetTimeInHrZone(int index, float? timeInHrZone_)
+		{
+			SetFieldValue(65, index, timeInHrZone_, Fit.SubfieldIndexMainField);
+		}
+
+
+		/// <summary>
+		///
+		/// </summary>
+		/// <returns>returns number of elements in field TimeInSpeedZone</returns>
+		public int GetNumTimeInSpeedZone()
+		{
+			return GetNumFieldValues(66, Fit.SubfieldIndexMainField);
+		}
+
+		///<summary>
+		/// Retrieves the TimeInSpeedZone field
+		/// Units: s</summary>
+		/// <param name="index">0 based index of TimeInSpeedZone element to retrieve</param>
+		/// <returns>Returns nullable float representing the TimeInSpeedZone field</returns>
+		public float? GetTimeInSpeedZone(int index)
+		{
+			Object val = GetFieldValue(66, index, Fit.SubfieldIndexMainField);
+			if (val == null)
+			{
+				return null;
+			}
+
+			return (Convert.ToSingle(val));
+
+		}
+
+		/// <summary>
+		/// Set TimeInSpeedZone field
+		/// Units: s</summary>
+		/// <param name="index">0 based index of time_in_speed_zone</param>
+		/// <param name="timeInSpeedZone_">Nullable field value to be set</param>
+		public void SetTimeInSpeedZone(int index, float? timeInSpeedZone_)
+		{
+			SetFieldValue(66, index, timeInSpeedZone_, Fit.SubfieldIndexMainField);
+		}
+
+
+		/// <summary>
+		///
+		/// </summary>
+		/// <returns>returns number of elements in field TimeInCadenceZone</returns>
+		public int GetNumTimeInCadenceZone()
+		{
+			return GetNumFieldValues(67, Fit.SubfieldIndexMainField);
+		}
+
+		///<summary>
+		/// Retrieves the TimeInCadenceZone field
+		/// Units: s</summary>
+		/// <param name="index">0 based index of TimeInCadenceZone element to retrieve</param>
+		/// <returns>Returns nullable float representing the TimeInCadenceZone field</returns>
+		public float? GetTimeInCadenceZone(int index)
+		{
+			Object val = GetFieldValue(67, index, Fit.SubfieldIndexMainField);
+			if (val == null)
+			{
+				return null;
+			}
+
+			return (Convert.ToSingle(val));
+
+		}
+
+		/// <summary>
+		/// Set TimeInCadenceZone field
+		/// Units: s</summary>
+		/// <param name="index">0 based index of time_in_cadence_zone</param>
+		/// <param name="timeInCadenceZone_">Nullable field value to be set</param>
+		public void SetTimeInCadenceZone(int index, float? timeInCadenceZone_)
+		{
+			SetFieldValue(67, index, timeInCadenceZone_, Fit.SubfieldIndexMainField);
+		}
+
+
+		/// <summary>
+		///
+		/// </summary>
+		/// <returns>returns number of elements in field TimeInPowerZone</returns>
+		public int GetNumTimeInPowerZone()
+		{
+			return GetNumFieldValues(68, Fit.SubfieldIndexMainField);
+		}
+
+		///<summary>
+		/// Retrieves the TimeInPowerZone field
+		/// Units: s</summary>
+		/// <param name="index">0 based index of TimeInPowerZone element to retrieve</param>
+		/// <returns>Returns nullable float representing the TimeInPowerZone field</returns>
+		public float? GetTimeInPowerZone(int index)
+		{
+			Object val = GetFieldValue(68, index, Fit.SubfieldIndexMainField);
+			if (val == null)
+			{
+				return null;
+			}
+
+			return (Convert.ToSingle(val));
+
+		}
+
+		/// <summary>
+		/// Set TimeInPowerZone field
+		/// Units: s</summary>
+		/// <param name="index">0 based index of time_in_power_zone</param>
+		/// <param name="timeInPowerZone_">Nullable field value to be set</param>
+		public void SetTimeInPowerZone(int index, float? timeInPowerZone_)
+		{
+			SetFieldValue(68, index, timeInPowerZone_, Fit.SubfieldIndexMainField);
+		}
+
+		///<summary>
+		/// Retrieves the AvgLapTime field
+		/// Units: s</summary>
+		/// <returns>Returns nullable float representing the AvgLapTime field</returns>
+		public float? AvgLapTime
+		{
+			get
+			{
+				Object val = GetFieldValue(69, 0, Fit.SubfieldIndexMainField);
+				if (val == null)
+				{
+					return null;
+				}
+
+				return (Convert.ToSingle(val));
+
+			}
+			set
+			{
+				SetFieldValue(69, 0, value, Fit.SubfieldIndexMainField);
+			}
+		}
+
+		///<summary>
+		/// Retrieves the BestLapIndex field</summary>
+		/// <returns>Returns nullable ushort representing the BestLapIndex field</returns>
+		public ushort? BestLapIndex
+		{
+			get
+			{
+				Object val = GetFieldValue(70, 0, Fit.SubfieldIndexMainField);
+				if (val == null)
+				{
+					return null;
+				}
+
+				return (Convert.ToUInt16(val));
+
+			}
+			set
+			{
+				SetFieldValue(70, 0, value, Fit.SubfieldIndexMainField);
+			}
+		}
+
+		///<summary>
+		/// Retrieves the MinAltitude field
+		/// Units: m</summary>
+		/// <returns>Returns nullable float representing the MinAltitude field</returns>
+		public float? MinAltitude
+		{
+			get
+			{
+				Object val = GetFieldValue(71, 0, Fit.SubfieldIndexMainField);
+				if (val == null)
+				{
+					return null;
+				}
+
+				return (Convert.ToSingle(val));
+
+			}
+			set
+			{
+				SetFieldValue(71, 0, value, Fit.SubfieldIndexMainField);
+			}
+		}
+
+		///<summary>
+		/// Retrieves the PlayerScore field</summary>
+		/// <returns>Returns nullable ushort representing the PlayerScore field</returns>
+		public ushort? PlayerScore
+		{
+			get
+			{
+				Object val = GetFieldValue(82, 0, Fit.SubfieldIndexMainField);
+				if (val == null)
+				{
+					return null;
+				}
+
+				return (Convert.ToUInt16(val));
+
+			}
+			set
+			{
+				SetFieldValue(82, 0, value, Fit.SubfieldIndexMainField);
+			}
+		}
+
+		///<summary>
+		/// Retrieves the OpponentScore field</summary>
+		/// <returns>Returns nullable ushort representing the OpponentScore field</returns>
+		public ushort? OpponentScore
+		{
+			get
+			{
+				Object val = GetFieldValue(83, 0, Fit.SubfieldIndexMainField);
+				if (val == null)
+				{
+					return null;
+				}
+
+				return (Convert.ToUInt16(val));
+
+			}
+			set
+			{
+				SetFieldValue(83, 0, value, Fit.SubfieldIndexMainField);
+			}
+		}
+
+		///<summary>
+		/// Retrieves the OpponentName field</summary>
+		/// <returns>Returns byte[] representing the OpponentName field</returns>
+		public byte[] OpponentName
+		{
+			get
+			{
+				byte[] data = (byte[])GetFieldValue(84, 0, Fit.SubfieldIndexMainField);
+				return data.Take(data.Length - 1).ToArray();
+			}
+			set
+			{
+				SetFieldValue(84, 0, value, Fit.SubfieldIndexMainField);
+			}
+		}
+
+		///<summary>
+		/// Retrieves the OpponentName field</summary>
+		/// <returns>Returns String representing the OpponentName field</returns>
+		public String GetOpponentNameAsString()
+		{
+			byte[] data = (byte[])GetFieldValue(84, 0, Fit.SubfieldIndexMainField);
+			return data != null ? Encoding.UTF8.GetString(data, 0, data.Length - 1) : null;
+		}
+
+		///<summary>
+		/// Set OpponentName field</summary>
+		/// <param name="opponentName_"> field value to be set</param>
+		public void SetOpponentName(String opponentName_)
+		{
+			byte[] data = Encoding.UTF8.GetBytes(opponentName_);
+			byte[] zdata = new byte[data.Length + 1];
+			data.CopyTo(zdata, 0);
+			SetFieldValue(84, 0, zdata, Fit.SubfieldIndexMainField);
+		}
+
+
+		/// <summary>
+		///
+		/// </summary>
+		/// <returns>returns number of elements in field StrokeCount</returns>
+		public int GetNumStrokeCount()
+		{
+			return GetNumFieldValues(85, Fit.SubfieldIndexMainField);
+		}
+
+		///<summary>
+		/// Retrieves the StrokeCount field
+		/// Units: counts
+		/// Comment: stroke_type enum used as the index</summary>
+		/// <param name="index">0 based index of StrokeCount element to retrieve</param>
+		/// <returns>Returns nullable ushort representing the StrokeCount field</returns>
+		public ushort? GetStrokeCount(int index)
+		{
+			Object val = GetFieldValue(85, index, Fit.SubfieldIndexMainField);
+			if (val == null)
+			{
+				return null;
+			}
+
+			return (Convert.ToUInt16(val));
+
+		}
+
+		/// <summary>
+		/// Set StrokeCount field
+		/// Units: counts
+		/// Comment: stroke_type enum used as the index</summary>
+		/// <param name="index">0 based index of stroke_count</param>
+		/// <param name="strokeCount_">Nullable field value to be set</param>
+		public void SetStrokeCount(int index, ushort? strokeCount_)
+		{
+			SetFieldValue(85, index, strokeCount_, Fit.SubfieldIndexMainField);
+		}
+
+
+		/// <summary>
+		///
+		/// </summary>
+		/// <returns>returns number of elements in field ZoneCount</returns>
+		public int GetNumZoneCount()
+		{
+			return GetNumFieldValues(86, Fit.SubfieldIndexMainField);
+		}
+
+		///<summary>
+		/// Retrieves the ZoneCount field
+		/// Units: counts
+		/// Comment: zone number used as the index</summary>
+		/// <param name="index">0 based index of ZoneCount element to retrieve</param>
+		/// <returns>Returns nullable ushort representing the ZoneCount field</returns>
+		public ushort? GetZoneCount(int index)
+		{
+			Object val = GetFieldValue(86, index, Fit.SubfieldIndexMainField);
+			if (val == null)
+			{
+				return null;
+			}
+
+			return (Convert.ToUInt16(val));
+
+		}
+
+		/// <summary>
+		/// Set ZoneCount field
+		/// Units: counts
+		/// Comment: zone number used as the index</summary>
+		/// <param name="index">0 based index of zone_count</param>
+		/// <param name="zoneCount_">Nullable field value to be set</param>
+		public void SetZoneCount(int index, ushort? zoneCount_)
+		{
+			SetFieldValue(86, index, zoneCount_, Fit.SubfieldIndexMainField);
+		}
+
+		///<summary>
+		/// Retrieves the MaxBallSpeed field
+		/// Units: m/s</summary>
+		/// <returns>Returns nullable float representing the MaxBallSpeed field</returns>
+		public float? MaxBallSpeed
+		{
+			get
+			{
+				Object val = GetFieldValue(87, 0, Fit.SubfieldIndexMainField);
+				if (val == null)
+				{
+					return null;
+				}
+
+				return (Convert.ToSingle(val));
+
+			}
+			set
+			{
+				SetFieldValue(87, 0, value, Fit.SubfieldIndexMainField);
+			}
+		}
+
+		///<summary>
+		/// Retrieves the AvgBallSpeed field
+		/// Units: m/s</summary>
+		/// <returns>Returns nullable float representing the AvgBallSpeed field</returns>
+		public float? AvgBallSpeed
+		{
+			get
+			{
+				Object val = GetFieldValue(88, 0, Fit.SubfieldIndexMainField);
+				if (val == null)
+				{
+					return null;
+				}
+
+				return (Convert.ToSingle(val));
+
+			}
+			set
+			{
+				SetFieldValue(88, 0, value, Fit.SubfieldIndexMainField);
+			}
+		}
+
+		///<summary>
+		/// Retrieves the AvgVerticalOscillation field
+		/// Units: mm</summary>
+		/// <returns>Returns nullable float representing the AvgVerticalOscillation field</returns>
+		public float? AvgVerticalOscillation
+		{
+			get
+			{
+				Object val = GetFieldValue(89, 0, Fit.SubfieldIndexMainField);
+				if (val == null)
+				{
+					return null;
+				}
+
+				return (Convert.ToSingle(val));
+
+			}
+			set
+			{
+				SetFieldValue(89, 0, value, Fit.SubfieldIndexMainField);
+			}
+		}
+
+		///<summary>
+		/// Retrieves the AvgStanceTimePercent field
+		/// Units: percent</summary>
+		/// <returns>Returns nullable float representing the AvgStanceTimePercent field</returns>
+		public float? AvgStanceTimePercent
+		{
+			get
+			{
+				Object val = GetFieldValue(90, 0, Fit.SubfieldIndexMainField);
+				if (val == null)
+				{
+					return null;
+				}
+
+				return (Convert.ToSingle(val));
+
+			}
+			set
+			{
+				SetFieldValue(90, 0, value, Fit.SubfieldIndexMainField);
+			}
+		}
+
+		///<summary>
+		/// Retrieves the AvgStanceTime field
+		/// Units: ms</summary>
+		/// <returns>Returns nullable float representing the AvgStanceTime field</returns>
+		public float? AvgStanceTime
+		{
+			get
+			{
+				Object val = GetFieldValue(91, 0, Fit.SubfieldIndexMainField);
+				if (val == null)
+				{
+					return null;
+				}
+
+				return (Convert.ToSingle(val));
+
+			}
+			set
+			{
+				SetFieldValue(91, 0, value, Fit.SubfieldIndexMainField);
+			}
+		}
+
+		///<summary>
+		/// Retrieves the AvgFractionalCadence field
+		/// Units: rpm
+		/// Comment: fractional part of the avg_cadence</summary>
+		/// <returns>Returns nullable float representing the AvgFractionalCadence field</returns>
+		public float? AvgFractionalCadence
+		{
+			get
+			{
+				Object val = GetFieldValue(92, 0, Fit.SubfieldIndexMainField);
+				if (val == null)
+				{
+					return null;
+				}
+
+				return (Convert.ToSingle(val));
+
+			}
+			set
+			{
+				SetFieldValue(92, 0, value, Fit.SubfieldIndexMainField);
+			}
+		}
+
+		///<summary>
+		/// Retrieves the MaxFractionalCadence field
+		/// Units: rpm
+		/// Comment: fractional part of the max_cadence</summary>
+		/// <returns>Returns nullable float representing the MaxFractionalCadence field</returns>
+		public float? MaxFractionalCadence
+		{
+			get
+			{
+				Object val = GetFieldValue(93, 0, Fit.SubfieldIndexMainField);
+				if (val == null)
+				{
+					return null;
+				}
+
+				return (Convert.ToSingle(val));
+
+			}
+			set
+			{
+				SetFieldValue(93, 0, value, Fit.SubfieldIndexMainField);
+			}
+		}
+
+		///<summary>
+		/// Retrieves the TotalFractionalCycles field
+		/// Units: cycles
+		/// Comment: fractional part of the total_cycles</summary>
+		/// <returns>Returns nullable float representing the TotalFractionalCycles field</returns>
+		public float? TotalFractionalCycles
+		{
+			get
+			{
+				Object val = GetFieldValue(94, 0, Fit.SubfieldIndexMainField);
+				if (val == null)
+				{
+					return null;
+				}
+
+				return (Convert.ToSingle(val));
+
+			}
+			set
+			{
+				SetFieldValue(94, 0, value, Fit.SubfieldIndexMainField);
+			}
+		}
+
+
+		/// <summary>
+		///
+		/// </summary>
+		/// <returns>returns number of elements in field AvgTotalHemoglobinConc</returns>
+		public int GetNumAvgTotalHemoglobinConc()
+		{
+			return GetNumFieldValues(95, Fit.SubfieldIndexMainField);
+		}
+
+		///<summary>
+		/// Retrieves the AvgTotalHemoglobinConc field
+		/// Units: g/dL
+		/// Comment: Avg saturated and unsaturated hemoglobin</summary>
+		/// <param name="index">0 based index of AvgTotalHemoglobinConc element to retrieve</param>
+		/// <returns>Returns nullable float representing the AvgTotalHemoglobinConc field</returns>
+		public float? GetAvgTotalHemoglobinConc(int index)
+		{
+			Object val = GetFieldValue(95, index, Fit.SubfieldIndexMainField);
+			if (val == null)
+			{
+				return null;
+			}
+
+			return (Convert.ToSingle(val));
+
+		}
+
+		/// <summary>
+		/// Set AvgTotalHemoglobinConc field
+		/// Units: g/dL
+		/// Comment: Avg saturated and unsaturated hemoglobin</summary>
+		/// <param name="index">0 based index of avg_total_hemoglobin_conc</param>
+		/// <param name="avgTotalHemoglobinConc_">Nullable field value to be set</param>
+		public void SetAvgTotalHemoglobinConc(int index, float? avgTotalHemoglobinConc_)
+		{
+			SetFieldValue(95, index, avgTotalHemoglobinConc_, Fit.SubfieldIndexMainField);
+		}
+
+
+		/// <summary>
+		///
+		/// </summary>
+		/// <returns>returns number of elements in field MinTotalHemoglobinConc</returns>
+		public int GetNumMinTotalHemoglobinConc()
+		{
+			return GetNumFieldValues(96, Fit.SubfieldIndexMainField);
+		}
+
+		///<summary>
+		/// Retrieves the MinTotalHemoglobinConc field
+		/// Units: g/dL
+		/// Comment: Min saturated and unsaturated hemoglobin</summary>
+		/// <param name="index">0 based index of MinTotalHemoglobinConc element to retrieve</param>
+		/// <returns>Returns nullable float representing the MinTotalHemoglobinConc field</returns>
+		public float? GetMinTotalHemoglobinConc(int index)
+		{
+			Object val = GetFieldValue(96, index, Fit.SubfieldIndexMainField);
+			if (val == null)
+			{
+				return null;
+			}
+
+			return (Convert.ToSingle(val));
+
+		}
+
+		/// <summary>
+		/// Set MinTotalHemoglobinConc field
+		/// Units: g/dL
+		/// Comment: Min saturated and unsaturated hemoglobin</summary>
+		/// <param name="index">0 based index of min_total_hemoglobin_conc</param>
+		/// <param name="minTotalHemoglobinConc_">Nullable field value to be set</param>
+		public void SetMinTotalHemoglobinConc(int index, float? minTotalHemoglobinConc_)
+		{
+			SetFieldValue(96, index, minTotalHemoglobinConc_, Fit.SubfieldIndexMainField);
+		}
+
+
+		/// <summary>
+		///
+		/// </summary>
+		/// <returns>returns number of elements in field MaxTotalHemoglobinConc</returns>
+		public int GetNumMaxTotalHemoglobinConc()
+		{
+			return GetNumFieldValues(97, Fit.SubfieldIndexMainField);
+		}
+
+		///<summary>
+		/// Retrieves the MaxTotalHemoglobinConc field
+		/// Units: g/dL
+		/// Comment: Max saturated and unsaturated hemoglobin</summary>
+		/// <param name="index">0 based index of MaxTotalHemoglobinConc element to retrieve</param>
+		/// <returns>Returns nullable float representing the MaxTotalHemoglobinConc field</returns>
+		public float? GetMaxTotalHemoglobinConc(int index)
+		{
+			Object val = GetFieldValue(97, index, Fit.SubfieldIndexMainField);
+			if (val == null)
+			{
+				return null;
+			}
+
+			return (Convert.ToSingle(val));
+
+		}
+
+		/// <summary>
+		/// Set MaxTotalHemoglobinConc field
+		/// Units: g/dL
+		/// Comment: Max saturated and unsaturated hemoglobin</summary>
+		/// <param name="index">0 based index of max_total_hemoglobin_conc</param>
+		/// <param name="maxTotalHemoglobinConc_">Nullable field value to be set</param>
+		public void SetMaxTotalHemoglobinConc(int index, float? maxTotalHemoglobinConc_)
+		{
+			SetFieldValue(97, index, maxTotalHemoglobinConc_, Fit.SubfieldIndexMainField);
+		}
+
+
+		/// <summary>
+		///
+		/// </summary>
+		/// <returns>returns number of elements in field AvgSaturatedHemoglobinPercent</returns>
+		public int GetNumAvgSaturatedHemoglobinPercent()
+		{
+			return GetNumFieldValues(98, Fit.SubfieldIndexMainField);
+		}
+
+		///<summary>
+		/// Retrieves the AvgSaturatedHemoglobinPercent field
+		/// Units: %
+		/// Comment: Avg percentage of hemoglobin saturated with oxygen</summary>
+		/// <param name="index">0 based index of AvgSaturatedHemoglobinPercent element to retrieve</param>
+		/// <returns>Returns nullable float representing the AvgSaturatedHemoglobinPercent field</returns>
+		public float? GetAvgSaturatedHemoglobinPercent(int index)
+		{
+			Object val = GetFieldValue(98, index, Fit.SubfieldIndexMainField);
+			if (val == null)
+			{
+				return null;
+			}
+
+			return (Convert.ToSingle(val));
+
+		}
+
+		/// <summary>
+		/// Set AvgSaturatedHemoglobinPercent field
+		/// Units: %
+		/// Comment: Avg percentage of hemoglobin saturated with oxygen</summary>
+		/// <param name="index">0 based index of avg_saturated_hemoglobin_percent</param>
+		/// <param name="avgSaturatedHemoglobinPercent_">Nullable field value to be set</param>
+		public void SetAvgSaturatedHemoglobinPercent(int index, float? avgSaturatedHemoglobinPercent_)
+		{
+			SetFieldValue(98, index, avgSaturatedHemoglobinPercent_, Fit.SubfieldIndexMainField);
+		}
+
+
+		/// <summary>
+		///
+		/// </summary>
+		/// <returns>returns number of elements in field MinSaturatedHemoglobinPercent</returns>
+		public int GetNumMinSaturatedHemoglobinPercent()
+		{
+			return GetNumFieldValues(99, Fit.SubfieldIndexMainField);
+		}
+
+		///<summary>
+		/// Retrieves the MinSaturatedHemoglobinPercent field
+		/// Units: %
+		/// Comment: Min percentage of hemoglobin saturated with oxygen</summary>
+		/// <param name="index">0 based index of MinSaturatedHemoglobinPercent element to retrieve</param>
+		/// <returns>Returns nullable float representing the MinSaturatedHemoglobinPercent field</returns>
+		public float? GetMinSaturatedHemoglobinPercent(int index)
+		{
+			Object val = GetFieldValue(99, index, Fit.SubfieldIndexMainField);
+			if (val == null)
+			{
+				return null;
+			}
+
+			return (Convert.ToSingle(val));
+
+		}
+
+		/// <summary>
+		/// Set MinSaturatedHemoglobinPercent field
+		/// Units: %
+		/// Comment: Min percentage of hemoglobin saturated with oxygen</summary>
+		/// <param name="index">0 based index of min_saturated_hemoglobin_percent</param>
+		/// <param name="minSaturatedHemoglobinPercent_">Nullable field value to be set</param>
+		public void SetMinSaturatedHemoglobinPercent(int index, float? minSaturatedHemoglobinPercent_)
+		{
+			SetFieldValue(99, index, minSaturatedHemoglobinPercent_, Fit.SubfieldIndexMainField);
+		}
+
+
+		/// <summary>
+		///
+		/// </summary>
+		/// <returns>returns number of elements in field MaxSaturatedHemoglobinPercent</returns>
+		public int GetNumMaxSaturatedHemoglobinPercent()
+		{
+			return GetNumFieldValues(100, Fit.SubfieldIndexMainField);
+		}
+
+		///<summary>
+		/// Retrieves the MaxSaturatedHemoglobinPercent field
+		/// Units: %
+		/// Comment: Max percentage of hemoglobin saturated with oxygen</summary>
+		/// <param name="index">0 based index of MaxSaturatedHemoglobinPercent element to retrieve</param>
+		/// <returns>Returns nullable float representing the MaxSaturatedHemoglobinPercent field</returns>
+		public float? GetMaxSaturatedHemoglobinPercent(int index)
+		{
+			Object val = GetFieldValue(100, index, Fit.SubfieldIndexMainField);
+			if (val == null)
+			{
+				return null;
+			}
+
+			return (Convert.ToSingle(val));
+
+		}
+
+		/// <summary>
+		/// Set MaxSaturatedHemoglobinPercent field
+		/// Units: %
+		/// Comment: Max percentage of hemoglobin saturated with oxygen</summary>
+		/// <param name="index">0 based index of max_saturated_hemoglobin_percent</param>
+		/// <param name="maxSaturatedHemoglobinPercent_">Nullable field value to be set</param>
+		public void SetMaxSaturatedHemoglobinPercent(int index, float? maxSaturatedHemoglobinPercent_)
+		{
+			SetFieldValue(100, index, maxSaturatedHemoglobinPercent_, Fit.SubfieldIndexMainField);
+		}
+
+		///<summary>
+		/// Retrieves the AvgLeftTorqueEffectiveness field
+		/// Units: percent</summary>
+		/// <returns>Returns nullable float representing the AvgLeftTorqueEffectiveness field</returns>
+		public float? AvgLeftTorqueEffectiveness
+		{
+			get
+			{
+				Object val = GetFieldValue(101, 0, Fit.SubfieldIndexMainField);
+				if (val == null)
+				{
+					return null;
+				}
+
+				return (Convert.ToSingle(val));
+
+			}
+			set
+			{
+				SetFieldValue(101, 0, value, Fit.SubfieldIndexMainField);
+			}
+		}
+
+		///<summary>
+		/// Retrieves the AvgRightTorqueEffectiveness field
+		/// Units: percent</summary>
+		/// <returns>Returns nullable float representing the AvgRightTorqueEffectiveness field</returns>
+		public float? AvgRightTorqueEffectiveness
+		{
+			get
+			{
+				Object val = GetFieldValue(102, 0, Fit.SubfieldIndexMainField);
+				if (val == null)
+				{
+					return null;
+				}
+
+				return (Convert.ToSingle(val));
+
+			}
+			set
+			{
+				SetFieldValue(102, 0, value, Fit.SubfieldIndexMainField);
+			}
+		}
+
+		///<summary>
+		/// Retrieves the AvgLeftPedalSmoothness field
+		/// Units: percent</summary>
+		/// <returns>Returns nullable float representing the AvgLeftPedalSmoothness field</returns>
+		public float? AvgLeftPedalSmoothness
+		{
+			get
+			{
+				Object val = GetFieldValue(103, 0, Fit.SubfieldIndexMainField);
+				if (val == null)
+				{
+					return null;
+				}
+
+				return (Convert.ToSingle(val));
+
+			}
+			set
+			{
+				SetFieldValue(103, 0, value, Fit.SubfieldIndexMainField);
+			}
+		}
+
+		///<summary>
+		/// Retrieves the AvgRightPedalSmoothness field
+		/// Units: percent</summary>
+		/// <returns>Returns nullable float representing the AvgRightPedalSmoothness field</returns>
+		public float? AvgRightPedalSmoothness
+		{
+			get
+			{
+				Object val = GetFieldValue(104, 0, Fit.SubfieldIndexMainField);
+				if (val == null)
+				{
+					return null;
+				}
+
+				return (Convert.ToSingle(val));
+
+			}
+			set
+			{
+				SetFieldValue(104, 0, value, Fit.SubfieldIndexMainField);
+			}
+		}
+
+		///<summary>
+		/// Retrieves the AvgCombinedPedalSmoothness field
+		/// Units: percent</summary>
+		/// <returns>Returns nullable float representing the AvgCombinedPedalSmoothness field</returns>
+		public float? AvgCombinedPedalSmoothness
+		{
+			get
+			{
+				Object val = GetFieldValue(105, 0, Fit.SubfieldIndexMainField);
+				if (val == null)
+				{
+					return null;
+				}
+
+				return (Convert.ToSingle(val));
+
+			}
+			set
+			{
+				SetFieldValue(105, 0, value, Fit.SubfieldIndexMainField);
+			}
+		}
+
+		///<summary>
+		/// Retrieves the SportProfileName field
+		/// Comment: Sport name from associated sport mesg</summary>
+		/// <returns>Returns byte[] representing the SportProfileName field</returns>
+		public byte[] SportProfileName
+		{
+			get
+			{
+				byte[] data = (byte[])GetFieldValue(110, 0, Fit.SubfieldIndexMainField);
+				return data.Take(data.Length - 1).ToArray();
+			}
+			set
+			{
+				SetFieldValue(110, 0, value, Fit.SubfieldIndexMainField);
+			}
+		}
+
+		///<summary>
+		/// Retrieves the SportProfileName field
+		/// Comment: Sport name from associated sport mesg</summary>
+		/// <returns>Returns String representing the SportProfileName field</returns>
+		public String GetSportProfileNameAsString()
+		{
+			byte[] data = (byte[])GetFieldValue(110, 0, Fit.SubfieldIndexMainField);
+			return data != null ? Encoding.UTF8.GetString(data, 0, data.Length - 1) : null;
+		}
+
+		///<summary>
+		/// Set SportProfileName field
+		/// Comment: Sport name from associated sport mesg</summary>
+		/// <param name="sportProfileName_"> field value to be set</param>
+		public void SetSportProfileName(String sportProfileName_)
+		{
+			byte[] data = Encoding.UTF8.GetBytes(sportProfileName_);
+			byte[] zdata = new byte[data.Length + 1];
+			data.CopyTo(zdata, 0);
+			SetFieldValue(110, 0, zdata, Fit.SubfieldIndexMainField);
+		}
+
+		///<summary>
+		/// Retrieves the SportIndex field</summary>
+		/// <returns>Returns nullable byte representing the SportIndex field</returns>
+		public byte? SportIndex
+		{
+			get
+			{
+				Object val = GetFieldValue(111, 0, Fit.SubfieldIndexMainField);
+				if (val == null)
+				{
+					return null;
+				}
+
+				return (Convert.ToByte(val));
+
+			}
+			set
+			{
+				SetFieldValue(111, 0, value, Fit.SubfieldIndexMainField);
+			}
+		}
+
+		///<summary>
+		/// Retrieves the TimeStanding field
+		/// Units: s
+		/// Comment: Total time spend in the standing position</summary>
+		/// <returns>Returns nullable float representing the TimeStanding field</returns>
+		public float? TimeStanding
+		{
+			get
+			{
+				Object val = GetFieldValue(112, 0, Fit.SubfieldIndexMainField);
+				if (val == null)
+				{
+					return null;
+				}
+
+				return (Convert.ToSingle(val));
+
+			}
+			set
+			{
+				SetFieldValue(112, 0, value, Fit.SubfieldIndexMainField);
+			}
+		}
+
+		///<summary>
+		/// Retrieves the StandCount field
+		/// Comment: Number of transitions to the standing state</summary>
+		/// <returns>Returns nullable ushort representing the StandCount field</returns>
+		public ushort? StandCount
+		{
+			get
+			{
+				Object val = GetFieldValue(113, 0, Fit.SubfieldIndexMainField);
+				if (val == null)
+				{
+					return null;
+				}
+
+				return (Convert.ToUInt16(val));
+
+			}
+			set
+			{
+				SetFieldValue(113, 0, value, Fit.SubfieldIndexMainField);
+			}
+		}
+
+		///<summary>
+		/// Retrieves the AvgLeftPco field
+		/// Units: mm
+		/// Comment: Average platform center offset Left</summary>
+		/// <returns>Returns nullable sbyte representing the AvgLeftPco field</returns>
+		public sbyte? AvgLeftPco
+		{
+			get
+			{
+				Object val = GetFieldValue(114, 0, Fit.SubfieldIndexMainField);
+				if (val == null)
+				{
+					return null;
+				}
+
+				return (Convert.ToSByte(val));
+
+			}
+			set
+			{
+				SetFieldValue(114, 0, value, Fit.SubfieldIndexMainField);
+			}
+		}
+
+		///<summary>
+		/// Retrieves the AvgRightPco field
+		/// Units: mm
+		/// Comment: Average platform center offset Right</summary>
+		/// <returns>Returns nullable sbyte representing the AvgRightPco field</returns>
+		public sbyte? AvgRightPco
+		{
+			get
+			{
+				Object val = GetFieldValue(115, 0, Fit.SubfieldIndexMainField);
+				if (val == null)
+				{
+					return null;
+				}
+
+				return (Convert.ToSByte(val));
+
+			}
+			set
+			{
+				SetFieldValue(115, 0, value, Fit.SubfieldIndexMainField);
+			}
+		}
+
+
+		/// <summary>
+		///
+		/// </summary>
+		/// <returns>returns number of elements in field AvgLeftPowerPhase</returns>
+		public int GetNumAvgLeftPowerPhase()
+		{
+			return GetNumFieldValues(116, Fit.SubfieldIndexMainField);
+		}
+
+		///<summary>
+		/// Retrieves the AvgLeftPowerPhase field
+		/// Units: degrees
+		/// Comment: Average left power phase angles. Indexes defined by power_phase_type.</summary>
+		/// <param name="index">0 based index of AvgLeftPowerPhase element to retrieve</param>
+		/// <returns>Returns nullable float representing the AvgLeftPowerPhase field</returns>
+		public float? GetAvgLeftPowerPhase(int index)
+		{
+			Object val = GetFieldValue(116, index, Fit.SubfieldIndexMainField);
+			if (val == null)
+			{
+				return null;
+			}
+
+			return (Convert.ToSingle(val));
+
+		}
+
+		/// <summary>
+		/// Set AvgLeftPowerPhase field
+		/// Units: degrees
+		/// Comment: Average left power phase angles. Indexes defined by power_phase_type.</summary>
+		/// <param name="index">0 based index of avg_left_power_phase</param>
+		/// <param name="avgLeftPowerPhase_">Nullable field value to be set</param>
+		public void SetAvgLeftPowerPhase(int index, float? avgLeftPowerPhase_)
+		{
+			SetFieldValue(116, index, avgLeftPowerPhase_, Fit.SubfieldIndexMainField);
+		}
+
+
+		/// <summary>
+		///
+		/// </summary>
+		/// <returns>returns number of elements in field AvgLeftPowerPhasePeak</returns>
+		public int GetNumAvgLeftPowerPhasePeak()
+		{
+			return GetNumFieldValues(117, Fit.SubfieldIndexMainField);
+		}
+
+		///<summary>
+		/// Retrieves the AvgLeftPowerPhasePeak field
+		/// Units: degrees
+		/// Comment: Average left power phase peak angles. Data value indexes defined by power_phase_type.</summary>
+		/// <param name="index">0 based index of AvgLeftPowerPhasePeak element to retrieve</param>
+		/// <returns>Returns nullable float representing the AvgLeftPowerPhasePeak field</returns>
+		public float? GetAvgLeftPowerPhasePeak(int index)
+		{
+			Object val = GetFieldValue(117, index, Fit.SubfieldIndexMainField);
+			if (val == null)
+			{
+				return null;
+			}
+
+			return (Convert.ToSingle(val));
+
+		}
+
+		/// <summary>
+		/// Set AvgLeftPowerPhasePeak field
+		/// Units: degrees
+		/// Comment: Average left power phase peak angles. Data value indexes defined by power_phase_type.</summary>
+		/// <param name="index">0 based index of avg_left_power_phase_peak</param>
+		/// <param name="avgLeftPowerPhasePeak_">Nullable field value to be set</param>
+		public void SetAvgLeftPowerPhasePeak(int index, float? avgLeftPowerPhasePeak_)
+		{
+			SetFieldValue(117, index, avgLeftPowerPhasePeak_, Fit.SubfieldIndexMainField);
+		}
+
+
+		/// <summary>
+		///
+		/// </summary>
+		/// <returns>returns number of elements in field AvgRightPowerPhase</returns>
+		public int GetNumAvgRightPowerPhase()
+		{
+			return GetNumFieldValues(118, Fit.SubfieldIndexMainField);
+		}
+
+		///<summary>
+		/// Retrieves the AvgRightPowerPhase field
+		/// Units: degrees
+		/// Comment: Average right power phase angles. Data value indexes defined by power_phase_type.</summary>
+		/// <param name="index">0 based index of AvgRightPowerPhase element to retrieve</param>
+		/// <returns>Returns nullable float representing the AvgRightPowerPhase field</returns>
+		public float? GetAvgRightPowerPhase(int index)
+		{
+			Object val = GetFieldValue(118, index, Fit.SubfieldIndexMainField);
+			if (val == null)
+			{
+				return null;
+			}
+
+			return (Convert.ToSingle(val));
+
+		}
+
+		/// <summary>
+		/// Set AvgRightPowerPhase field
+		/// Units: degrees
+		/// Comment: Average right power phase angles. Data value indexes defined by power_phase_type.</summary>
+		/// <param name="index">0 based index of avg_right_power_phase</param>
+		/// <param name="avgRightPowerPhase_">Nullable field value to be set</param>
+		public void SetAvgRightPowerPhase(int index, float? avgRightPowerPhase_)
+		{
+			SetFieldValue(118, index, avgRightPowerPhase_, Fit.SubfieldIndexMainField);
+		}
+
+
+		/// <summary>
+		///
+		/// </summary>
+		/// <returns>returns number of elements in field AvgRightPowerPhasePeak</returns>
+		public int GetNumAvgRightPowerPhasePeak()
+		{
+			return GetNumFieldValues(119, Fit.SubfieldIndexMainField);
+		}
+
+		///<summary>
+		/// Retrieves the AvgRightPowerPhasePeak field
+		/// Units: degrees
+		/// Comment: Average right power phase peak angles data value indexes defined by power_phase_type.</summary>
+		/// <param name="index">0 based index of AvgRightPowerPhasePeak element to retrieve</param>
+		/// <returns>Returns nullable float representing the AvgRightPowerPhasePeak field</returns>
+		public float? GetAvgRightPowerPhasePeak(int index)
+		{
+			Object val = GetFieldValue(119, index, Fit.SubfieldIndexMainField);
+			if (val == null)
+			{
+				return null;
+			}
+
+			return (Convert.ToSingle(val));
+
+		}
+
+		/// <summary>
+		/// Set AvgRightPowerPhasePeak field
+		/// Units: degrees
+		/// Comment: Average right power phase peak angles data value indexes defined by power_phase_type.</summary>
+		/// <param name="index">0 based index of avg_right_power_phase_peak</param>
+		/// <param name="avgRightPowerPhasePeak_">Nullable field value to be set</param>
+		public void SetAvgRightPowerPhasePeak(int index, float? avgRightPowerPhasePeak_)
+		{
+			SetFieldValue(119, index, avgRightPowerPhasePeak_, Fit.SubfieldIndexMainField);
+		}
+
+
+		/// <summary>
+		///
+		/// </summary>
+		/// <returns>returns number of elements in field AvgPowerPosition</returns>
+		public int GetNumAvgPowerPosition()
+		{
+			return GetNumFieldValues(120, Fit.SubfieldIndexMainField);
+		}
+
+		///<summary>
+		/// Retrieves the AvgPowerPosition field
+		/// Units: watts
+		/// Comment: Average power by position. Data value indexes defined by rider_position_type.</summary>
+		/// <param name="index">0 based index of AvgPowerPosition element to retrieve</param>
+		/// <returns>Returns nullable ushort representing the AvgPowerPosition field</returns>
+		public ushort? GetAvgPowerPosition(int index)
+		{
+			Object val = GetFieldValue(120, index, Fit.SubfieldIndexMainField);
+			if (val == null)
+			{
+				return null;
+			}
+
+			return (Convert.ToUInt16(val));
+
+		}
+
+		/// <summary>
+		/// Set AvgPowerPosition field
+		/// Units: watts
+		/// Comment: Average power by position. Data value indexes defined by rider_position_type.</summary>
+		/// <param name="index">0 based index of avg_power_position</param>
+		/// <param name="avgPowerPosition_">Nullable field value to be set</param>
+		public void SetAvgPowerPosition(int index, ushort? avgPowerPosition_)
+		{
+			SetFieldValue(120, index, avgPowerPosition_, Fit.SubfieldIndexMainField);
+		}
+
+
+		/// <summary>
+		///
+		/// </summary>
+		/// <returns>returns number of elements in field MaxPowerPosition</returns>
+		public int GetNumMaxPowerPosition()
+		{
+			return GetNumFieldValues(121, Fit.SubfieldIndexMainField);
+		}
+
+		///<summary>
+		/// Retrieves the MaxPowerPosition field
+		/// Units: watts
+		/// Comment: Maximum power by position. Data value indexes defined by rider_position_type.</summary>
+		/// <param name="index">0 based index of MaxPowerPosition element to retrieve</param>
+		/// <returns>Returns nullable ushort representing the MaxPowerPosition field</returns>
+		public ushort? GetMaxPowerPosition(int index)
+		{
+			Object val = GetFieldValue(121, index, Fit.SubfieldIndexMainField);
+			if (val == null)
+			{
+				return null;
+			}
+
+			return (Convert.ToUInt16(val));
+
+		}
+
+		/// <summary>
+		/// Set MaxPowerPosition field
+		/// Units: watts
+		/// Comment: Maximum power by position. Data value indexes defined by rider_position_type.</summary>
+		/// <param name="index">0 based index of max_power_position</param>
+		/// <param name="maxPowerPosition_">Nullable field value to be set</param>
+		public void SetMaxPowerPosition(int index, ushort? maxPowerPosition_)
+		{
+			SetFieldValue(121, index, maxPowerPosition_, Fit.SubfieldIndexMainField);
+		}
+
+
+		/// <summary>
+		///
+		/// </summary>
+		/// <returns>returns number of elements in field AvgCadencePosition</returns>
+		public int GetNumAvgCadencePosition()
+		{
+			return GetNumFieldValues(122, Fit.SubfieldIndexMainField);
+		}
+
+		///<summary>
+		/// Retrieves the AvgCadencePosition field
+		/// Units: rpm
+		/// Comment: Average cadence by position. Data value indexes defined by rider_position_type.</summary>
+		/// <param name="index">0 based index of AvgCadencePosition element to retrieve</param>
+		/// <returns>Returns nullable byte representing the AvgCadencePosition field</returns>
+		public byte? GetAvgCadencePosition(int index)
+		{
+			Object val = GetFieldValue(122, index, Fit.SubfieldIndexMainField);
+			if (val == null)
+			{
+				return null;
+			}
+
+			return (Convert.ToByte(val));
+
+		}
+
+		/// <summary>
+		/// Set AvgCadencePosition field
+		/// Units: rpm
+		/// Comment: Average cadence by position. Data value indexes defined by rider_position_type.</summary>
+		/// <param name="index">0 based index of avg_cadence_position</param>
+		/// <param name="avgCadencePosition_">Nullable field value to be set</param>
+		public void SetAvgCadencePosition(int index, byte? avgCadencePosition_)
+		{
+			SetFieldValue(122, index, avgCadencePosition_, Fit.SubfieldIndexMainField);
+		}
+
+
+		/// <summary>
+		///
+		/// </summary>
+		/// <returns>returns number of elements in field MaxCadencePosition</returns>
+		public int GetNumMaxCadencePosition()
+		{
+			return GetNumFieldValues(123, Fit.SubfieldIndexMainField);
+		}
+
+		///<summary>
+		/// Retrieves the MaxCadencePosition field
+		/// Units: rpm
+		/// Comment: Maximum cadence by position. Data value indexes defined by rider_position_type.</summary>
+		/// <param name="index">0 based index of MaxCadencePosition element to retrieve</param>
+		/// <returns>Returns nullable byte representing the MaxCadencePosition field</returns>
+		public byte? GetMaxCadencePosition(int index)
+		{
+			Object val = GetFieldValue(123, index, Fit.SubfieldIndexMainField);
+			if (val == null)
+			{
+				return null;
+			}
+
+			return (Convert.ToByte(val));
+
+		}
+
+		/// <summary>
+		/// Set MaxCadencePosition field
+		/// Units: rpm
+		/// Comment: Maximum cadence by position. Data value indexes defined by rider_position_type.</summary>
+		/// <param name="index">0 based index of max_cadence_position</param>
+		/// <param name="maxCadencePosition_">Nullable field value to be set</param>
+		public void SetMaxCadencePosition(int index, byte? maxCadencePosition_)
+		{
+			SetFieldValue(123, index, maxCadencePosition_, Fit.SubfieldIndexMainField);
+		}
+
+		///<summary>
+		/// Retrieves the EnhancedAvgSpeed field
+		/// Units: m/s
+		/// Comment: total_distance / total_timer_time</summary>
+		/// <returns>Returns nullable float representing the EnhancedAvgSpeed field</returns>
+		public float? EnhancedAvgSpeed
+		{
+			get
+			{
+				Object val = GetFieldValue(124, 0, Fit.SubfieldIndexMainField);
+				if (val == null)
+				{
+					return null;
+				}
+
+				return (Convert.ToSingle(val));
+
+			}
+			set
+			{
+				SetFieldValue(124, 0, value, Fit.SubfieldIndexMainField);
+			}
+		}
+
+		///<summary>
+		/// Retrieves the EnhancedMaxSpeed field
+		/// Units: m/s</summary>
+		/// <returns>Returns nullable float representing the EnhancedMaxSpeed field</returns>
+		public float? EnhancedMaxSpeed
+		{
+			get
+			{
+				Object val = GetFieldValue(125, 0, Fit.SubfieldIndexMainField);
+				if (val == null)
+				{
+					return null;
+				}
+
+				return (Convert.ToSingle(val));
+
+			}
+			set
+			{
+				SetFieldValue(125, 0, value, Fit.SubfieldIndexMainField);
+			}
+		}
+
+		///<summary>
+		/// Retrieves the EnhancedAvgAltitude field
+		/// Units: m</summary>
+		/// <returns>Returns nullable float representing the EnhancedAvgAltitude field</returns>
+		public float? EnhancedAvgAltitude
+		{
+			get
+			{
+				Object val = GetFieldValue(126, 0, Fit.SubfieldIndexMainField);
+				if (val == null)
+				{
+					return null;
+				}
+
+				return (Convert.ToSingle(val));
+
+			}
+			set
+			{
+				SetFieldValue(126, 0, value, Fit.SubfieldIndexMainField);
+			}
+		}
+
+		///<summary>
+		/// Retrieves the EnhancedMinAltitude field
+		/// Units: m</summary>
+		/// <returns>Returns nullable float representing the EnhancedMinAltitude field</returns>
+		public float? EnhancedMinAltitude
+		{
+			get
+			{
+				Object val = GetFieldValue(127, 0, Fit.SubfieldIndexMainField);
+				if (val == null)
+				{
+					return null;
+				}
+
+				return (Convert.ToSingle(val));
+
+			}
+			set
+			{
+				SetFieldValue(127, 0, value, Fit.SubfieldIndexMainField);
+			}
+		}
+
+		///<summary>
+		/// Retrieves the EnhancedMaxAltitude field
+		/// Units: m</summary>
+		/// <returns>Returns nullable float representing the EnhancedMaxAltitude field</returns>
+		public float? EnhancedMaxAltitude
+		{
+			get
+			{
+				Object val = GetFieldValue(128, 0, Fit.SubfieldIndexMainField);
+				if (val == null)
+				{
+					return null;
+				}
+
+				return (Convert.ToSingle(val));
+
+			}
+			set
+			{
+				SetFieldValue(128, 0, value, Fit.SubfieldIndexMainField);
+			}
+		}
+
+		///<summary>
+		/// Retrieves the AvgLevMotorPower field
+		/// Units: watts
+		/// Comment: lev average motor power during session</summary>
+		/// <returns>Returns nullable ushort representing the AvgLevMotorPower field</returns>
+		public ushort? AvgLevMotorPower
+		{
+			get
+			{
+				Object val = GetFieldValue(129, 0, Fit.SubfieldIndexMainField);
+				if (val == null)
+				{
+					return null;
+				}
+
+				return (Convert.ToUInt16(val));
+
+			}
+			set
+			{
+				SetFieldValue(129, 0, value, Fit.SubfieldIndexMainField);
+			}
+		}
+
+		///<summary>
+		/// Retrieves the MaxLevMotorPower field
+		/// Units: watts
+		/// Comment: lev maximum motor power during session</summary>
+		/// <returns>Returns nullable ushort representing the MaxLevMotorPower field</returns>
+		public ushort? MaxLevMotorPower
+		{
+			get
+			{
+				Object val = GetFieldValue(130, 0, Fit.SubfieldIndexMainField);
+				if (val == null)
+				{
+					return null;
+				}
+
+				return (Convert.ToUInt16(val));
+
+			}
+			set
+			{
+				SetFieldValue(130, 0, value, Fit.SubfieldIndexMainField);
+			}
+		}
+
+		///<summary>
+		/// Retrieves the LevBatteryConsumption field
+		/// Units: percent
+		/// Comment: lev battery consumption during session</summary>
+		/// <returns>Returns nullable float representing the LevBatteryConsumption field</returns>
+		public float? LevBatteryConsumption
+		{
+			get
+			{
+				Object val = GetFieldValue(131, 0, Fit.SubfieldIndexMainField);
+				if (val == null)
+				{
+					return null;
+				}
+
+				return (Convert.ToSingle(val));
+
+			}
+			set
+			{
+				SetFieldValue(131, 0, value, Fit.SubfieldIndexMainField);
+			}
+		}
+
+		///<summary>
+		/// Retrieves the AvgVerticalRatio field
+		/// Units: percent</summary>
+		/// <returns>Returns nullable float representing the AvgVerticalRatio field</returns>
+		public float? AvgVerticalRatio
+		{
+			get
+			{
+				Object val = GetFieldValue(132, 0, Fit.SubfieldIndexMainField);
+				if (val == null)
+				{
+					return null;
+				}
+
+				return (Convert.ToSingle(val));
+
+			}
+			set
+			{
+				SetFieldValue(132, 0, value, Fit.SubfieldIndexMainField);
+			}
+		}
+
+		///<summary>
+		/// Retrieves the AvgStanceTimeBalance field
+		/// Units: percent</summary>
+		/// <returns>Returns nullable float representing the AvgStanceTimeBalance field</returns>
+		public float? AvgStanceTimeBalance
+		{
+			get
+			{
+				Object val = GetFieldValue(133, 0, Fit.SubfieldIndexMainField);
+				if (val == null)
+				{
+					return null;
+				}
+
+				return (Convert.ToSingle(val));
+
+			}
+			set
+			{
+				SetFieldValue(133, 0, value, Fit.SubfieldIndexMainField);
+			}
+		}
+
+		///<summary>
+		/// Retrieves the AvgStepLength field
+		/// Units: mm</summary>
+		/// <returns>Returns nullable float representing the AvgStepLength field</returns>
+		public float? AvgStepLength
+		{
+			get
+			{
+				Object val = GetFieldValue(134, 0, Fit.SubfieldIndexMainField);
+				if (val == null)
+				{
+					return null;
+				}
+
+				return (Convert.ToSingle(val));
+
+			}
+			set
+			{
+				SetFieldValue(134, 0, value, Fit.SubfieldIndexMainField);
+			}
+		}
+
+		///<summary>
+		/// Retrieves the TotalAnaerobicTrainingEffect field</summary>
+		/// <returns>Returns nullable float representing the TotalAnaerobicTrainingEffect field</returns>
+		public float? TotalAnaerobicTrainingEffect
+		{
+			get
+			{
+				Object val = GetFieldValue(137, 0, Fit.SubfieldIndexMainField);
+				if (val == null)
+				{
+					return null;
+				}
+
+				return (Convert.ToSingle(val));
+
+			}
+			set
+			{
+				SetFieldValue(137, 0, value, Fit.SubfieldIndexMainField);
+			}
+		}
+
+		///<summary>
+		/// Retrieves the AvgVam field
+		/// Units: m/s</summary>
+		/// <returns>Returns nullable float representing the AvgVam field</returns>
+		public float? AvgVam
+		{
+			get
+			{
+				Object val = GetFieldValue(139, 0, Fit.SubfieldIndexMainField);
+				if (val == null)
+				{
+					return null;
+				}
+
+				return (Convert.ToSingle(val));
+
+			}
+			set
+			{
+				SetFieldValue(139, 0, value, Fit.SubfieldIndexMainField);
+			}
+		}
+
+		///<summary>
+		/// Retrieves the AvgDepth field
+		/// Units: m
+		/// Comment: 0 if above water</summary>
+		/// <returns>Returns nullable float representing the AvgDepth field</returns>
+		public float? AvgDepth
+		{
+			get
+			{
+				Object val = GetFieldValue(140, 0, Fit.SubfieldIndexMainField);
+				if (val == null)
+				{
+					return null;
+				}
+
+				return (Convert.ToSingle(val));
+
+			}
+			set
+			{
+				SetFieldValue(140, 0, value, Fit.SubfieldIndexMainField);
+			}
+		}
+
+		///<summary>
+		/// Retrieves the MaxDepth field
+		/// Units: m
+		/// Comment: 0 if above water</summary>
+		/// <returns>Returns nullable float representing the MaxDepth field</returns>
+		public float? MaxDepth
+		{
+			get
+			{
+				Object val = GetFieldValue(141, 0, Fit.SubfieldIndexMainField);
+				if (val == null)
+				{
+					return null;
+				}
+
+				return (Convert.ToSingle(val));
+
+			}
+			set
+			{
+				SetFieldValue(141, 0, value, Fit.SubfieldIndexMainField);
+			}
+		}
+
+		///<summary>
+		/// Retrieves the SurfaceInterval field
+		/// Units: s
+		/// Comment: Time since end of last dive</summary>
+		/// <returns>Returns nullable uint representing the SurfaceInterval field</returns>
+		public uint? SurfaceInterval
+		{
+			get
+			{
+				Object val = GetFieldValue(142, 0, Fit.SubfieldIndexMainField);
+				if (val == null)
+				{
+					return null;
+				}
+
+				return (Convert.ToUInt32(val));
+
+			}
+			set
+			{
+				SetFieldValue(142, 0, value, Fit.SubfieldIndexMainField);
+			}
+		}
+
+		///<summary>
+		/// Retrieves the StartCns field
+		/// Units: percent</summary>
+		/// <returns>Returns nullable byte representing the StartCns field</returns>
+		public byte? StartCns
+		{
+			get
+			{
+				Object val = GetFieldValue(143, 0, Fit.SubfieldIndexMainField);
+				if (val == null)
+				{
+					return null;
+				}
+
+				return (Convert.ToByte(val));
+
+			}
+			set
+			{
+				SetFieldValue(143, 0, value, Fit.SubfieldIndexMainField);
+			}
+		}
+
+		///<summary>
+		/// Retrieves the EndCns field
+		/// Units: percent</summary>
+		/// <returns>Returns nullable byte representing the EndCns field</returns>
+		public byte? EndCns
+		{
+			get
+			{
+				Object val = GetFieldValue(144, 0, Fit.SubfieldIndexMainField);
+				if (val == null)
+				{
+					return null;
+				}
+
+				return (Convert.ToByte(val));
+
+			}
+			set
+			{
+				SetFieldValue(144, 0, value, Fit.SubfieldIndexMainField);
+			}
+		}
+
+		///<summary>
+		/// Retrieves the StartN2 field
+		/// Units: percent</summary>
+		/// <returns>Returns nullable ushort representing the StartN2 field</returns>
+		public ushort? StartN2
+		{
+			get
+			{
+				Object val = GetFieldValue(145, 0, Fit.SubfieldIndexMainField);
+				if (val == null)
+				{
+					return null;
+				}
+
+				return (Convert.ToUInt16(val));
+
+			}
+			set
+			{
+				SetFieldValue(145, 0, value, Fit.SubfieldIndexMainField);
+			}
+		}
+
+		///<summary>
+		/// Retrieves the EndN2 field
+		/// Units: percent</summary>
+		/// <returns>Returns nullable ushort representing the EndN2 field</returns>
+		public ushort? EndN2
+		{
+			get
+			{
+				Object val = GetFieldValue(146, 0, Fit.SubfieldIndexMainField);
+				if (val == null)
+				{
+					return null;
+				}
+
+				return (Convert.ToUInt16(val));
+
+			}
+			set
+			{
+				SetFieldValue(146, 0, value, Fit.SubfieldIndexMainField);
+			}
+		}
+
+		///<summary>
+		/// Retrieves the AvgRespirationRate field</summary>
+		/// <returns>Returns nullable byte representing the AvgRespirationRate field</returns>
+		public byte? AvgRespirationRate
+		{
+			get
+			{
+				Object val = GetFieldValue(147, 0, Fit.SubfieldIndexMainField);
+				if (val == null)
+				{
+					return null;
+				}
+
+				return (Convert.ToByte(val));
+
+			}
+			set
+			{
+				SetFieldValue(147, 0, value, Fit.SubfieldIndexMainField);
+			}
+		}
+
+		///<summary>
+		/// Retrieves the MaxRespirationRate field</summary>
+		/// <returns>Returns nullable byte representing the MaxRespirationRate field</returns>
+		public byte? MaxRespirationRate
+		{
+			get
+			{
+				Object val = GetFieldValue(148, 0, Fit.SubfieldIndexMainField);
+				if (val == null)
+				{
+					return null;
+				}
+
+				return (Convert.ToByte(val));
+
+			}
+			set
+			{
+				SetFieldValue(148, 0, value, Fit.SubfieldIndexMainField);
+			}
+		}
+
+		///<summary>
+		/// Retrieves the MinRespirationRate field</summary>
+		/// <returns>Returns nullable byte representing the MinRespirationRate field</returns>
+		public byte? MinRespirationRate
+		{
+			get
+			{
+				Object val = GetFieldValue(149, 0, Fit.SubfieldIndexMainField);
+				if (val == null)
+				{
+					return null;
+				}
+
+				return (Convert.ToByte(val));
+
+			}
+			set
+			{
+				SetFieldValue(149, 0, value, Fit.SubfieldIndexMainField);
+			}
+		}
+
+		///<summary>
+		/// Retrieves the MinTemperature field
+		/// Units: C</summary>
+		/// <returns>Returns nullable sbyte representing the MinTemperature field</returns>
+		public sbyte? MinTemperature
+		{
+			get
+			{
+				Object val = GetFieldValue(150, 0, Fit.SubfieldIndexMainField);
+				if (val == null)
+				{
+					return null;
+				}
+
+				return (Convert.ToSByte(val));
+
+			}
+			set
+			{
+				SetFieldValue(150, 0, value, Fit.SubfieldIndexMainField);
+			}
+		}
+
+		///<summary>
+		/// Retrieves the O2Toxicity field
+		/// Units: OTUs</summary>
+		/// <returns>Returns nullable ushort representing the O2Toxicity field</returns>
+		public ushort? O2Toxicity
+		{
+			get
+			{
+				Object val = GetFieldValue(155, 0, Fit.SubfieldIndexMainField);
+				if (val == null)
+				{
+					return null;
+				}
+
+				return (Convert.ToUInt16(val));
+
+			}
+			set
+			{
+				SetFieldValue(155, 0, value, Fit.SubfieldIndexMainField);
+			}
+		}
+
+		///<summary>
+		/// Retrieves the DiveNumber field</summary>
+		/// <returns>Returns nullable uint representing the DiveNumber field</returns>
+		public uint? DiveNumber
+		{
+			get
+			{
+				Object val = GetFieldValue(156, 0, Fit.SubfieldIndexMainField);
+				if (val == null)
+				{
+					return null;
+				}
+
+				return (Convert.ToUInt32(val));
+
+			}
+			set
+			{
+				SetFieldValue(156, 0, value, Fit.SubfieldIndexMainField);
+			}
+		}
+
+		///<summary>
+		/// Retrieves the TrainingLoadPeak field</summary>
+		/// <returns>Returns nullable float representing the TrainingLoadPeak field</returns>
+		public float? TrainingLoadPeak
+		{
+			get
+			{
+				Object val = GetFieldValue(168, 0, Fit.SubfieldIndexMainField);
+				if (val == null)
+				{
+					return null;
+				}
+
+				return (Convert.ToSingle(val));
+
+			}
+			set
+			{
+				SetFieldValue(168, 0, value, Fit.SubfieldIndexMainField);
+			}
+		}
+
+		///<summary>
+		/// Retrieves the EnhancedAvgRespirationRate field
+		/// Units: Breaths/min</summary>
+		/// <returns>Returns nullable float representing the EnhancedAvgRespirationRate field</returns>
+		public float? EnhancedAvgRespirationRate
+		{
+			get
+			{
+				Object val = GetFieldValue(169, 0, Fit.SubfieldIndexMainField);
+				if (val == null)
+				{
+					return null;
+				}
+
+				return (Convert.ToSingle(val));
+
+			}
+			set
+			{
+				SetFieldValue(169, 0, value, Fit.SubfieldIndexMainField);
+			}
+		}
+
+		///<summary>
+		/// Retrieves the EnhancedMaxRespirationRate field
+		/// Units: Breaths/min</summary>
+		/// <returns>Returns nullable float representing the EnhancedMaxRespirationRate field</returns>
+		public float? EnhancedMaxRespirationRate
+		{
+			get
+			{
+				Object val = GetFieldValue(170, 0, Fit.SubfieldIndexMainField);
+				if (val == null)
+				{
+					return null;
+				}
+
+				return (Convert.ToSingle(val));
+
+			}
+			set
+			{
+				SetFieldValue(170, 0, value, Fit.SubfieldIndexMainField);
+			}
+		}
+
+		///<summary>
+		/// Retrieves the EnhancedMinRespirationRate field</summary>
+		/// <returns>Returns nullable float representing the EnhancedMinRespirationRate field</returns>
+		public float? EnhancedMinRespirationRate
+		{
+			get
+			{
+				Object val = GetFieldValue(180, 0, Fit.SubfieldIndexMainField);
+				if (val == null)
+				{
+					return null;
+				}
+
+				return (Convert.ToSingle(val));
+
+			}
+			set
+			{
+				SetFieldValue(180, 0, value, Fit.SubfieldIndexMainField);
+			}
+		}
+
+		///<summary>
+		/// Retrieves the TotalGrit field
+		/// Units: kGrit
+		/// Comment: The grit score estimates how challenging a route could be for a cyclist in terms of time spent going over sharp turns or large grade slopes.</summary>
+		/// <returns>Returns nullable float representing the TotalGrit field</returns>
+		public float? TotalGrit
+		{
+			get
+			{
+				Object val = GetFieldValue(181, 0, Fit.SubfieldIndexMainField);
+				if (val == null)
+				{
+					return null;
+				}
+
+				return (Convert.ToSingle(val));
+
+			}
+			set
+			{
+				SetFieldValue(181, 0, value, Fit.SubfieldIndexMainField);
+			}
+		}
+
+		///<summary>
+		/// Retrieves the TotalFlow field
+		/// Units: Flow
+		/// Comment: The flow score estimates how long distance wise a cyclist deaccelerates over intervals where deacceleration is unnecessary such as smooth turns or small grade angle intervals.</summary>
+		/// <returns>Returns nullable float representing the TotalFlow field</returns>
+		public float? TotalFlow
+		{
+			get
+			{
+				Object val = GetFieldValue(182, 0, Fit.SubfieldIndexMainField);
+				if (val == null)
+				{
+					return null;
+				}
+
+				return (Convert.ToSingle(val));
+
+			}
+			set
+			{
+				SetFieldValue(182, 0, value, Fit.SubfieldIndexMainField);
+			}
+		}
+
+		///<summary>
+		/// Retrieves the JumpCount field</summary>
+		/// <returns>Returns nullable ushort representing the JumpCount field</returns>
+		public ushort? JumpCount
+		{
+			get
+			{
+				Object val = GetFieldValue(183, 0, Fit.SubfieldIndexMainField);
+				if (val == null)
+				{
+					return null;
+				}
+
+				return (Convert.ToUInt16(val));
+
+			}
+			set
+			{
+				SetFieldValue(183, 0, value, Fit.SubfieldIndexMainField);
+			}
+		}
+
+		///<summary>
+		/// Retrieves the AvgGrit field
+		/// Units: kGrit
+		/// Comment: The grit score estimates how challenging a route could be for a cyclist in terms of time spent going over sharp turns or large grade slopes.</summary>
+		/// <returns>Returns nullable float representing the AvgGrit field</returns>
+		public float? AvgGrit
+		{
+			get
+			{
+				Object val = GetFieldValue(186, 0, Fit.SubfieldIndexMainField);
+				if (val == null)
+				{
+					return null;
+				}
+
+				return (Convert.ToSingle(val));
+
+			}
+			set
+			{
+				SetFieldValue(186, 0, value, Fit.SubfieldIndexMainField);
+			}
+		}
+
+		///<summary>
+		/// Retrieves the AvgFlow field
+		/// Units: Flow
+		/// Comment: The flow score estimates how long distance wise a cyclist deaccelerates over intervals where deacceleration is unnecessary such as smooth turns or small grade angle intervals.</summary>
+		/// <returns>Returns nullable float representing the AvgFlow field</returns>
+		public float? AvgFlow
+		{
+			get
+			{
+				Object val = GetFieldValue(187, 0, Fit.SubfieldIndexMainField);
+				if (val == null)
+				{
+					return null;
+				}
+
+				return (Convert.ToSingle(val));
+
+			}
+			set
+			{
+				SetFieldValue(187, 0, value, Fit.SubfieldIndexMainField);
+			}
+		}
+
+		///<summary>
+		/// Retrieves the WorkoutFeel field
+		/// Comment: A 0-100 scale representing how a user felt while performing a workout. Low values are considered feeling bad, while high values are good.</summary>
+		/// <returns>Returns nullable byte representing the WorkoutFeel field</returns>
+		public byte? WorkoutFeel
+		{
+			get
+			{
+				Object val = GetFieldValue(192, 0, Fit.SubfieldIndexMainField);
+				if (val == null)
+				{
+					return null;
+				}
+
+				return (Convert.ToByte(val));
+
+			}
+			set
+			{
+				SetFieldValue(192, 0, value, Fit.SubfieldIndexMainField);
+			}
+		}
+
+		///<summary>
+		/// Retrieves the WorkoutRpe field
+		/// Comment: Common Borg CR10 / 0-10 RPE scale, multiplied 10x.. Aggregate score for all workouts in a single session.</summary>
+		/// <returns>Returns nullable byte representing the WorkoutRpe field</returns>
+		public byte? WorkoutRpe
+		{
+			get
+			{
+				Object val = GetFieldValue(193, 0, Fit.SubfieldIndexMainField);
+				if (val == null)
+				{
+					return null;
+				}
+
+				return (Convert.ToByte(val));
+
+			}
+			set
+			{
+				SetFieldValue(193, 0, value, Fit.SubfieldIndexMainField);
+			}
+		}
+
+		///<summary>
+		/// Retrieves the AvgSpo2 field
+		/// Units: percent
+		/// Comment: Average SPO2 for the monitoring session</summary>
+		/// <returns>Returns nullable byte representing the AvgSpo2 field</returns>
+		public byte? AvgSpo2
+		{
+			get
+			{
+				Object val = GetFieldValue(194, 0, Fit.SubfieldIndexMainField);
+				if (val == null)
+				{
+					return null;
+				}
+
+				return (Convert.ToByte(val));
+
+			}
+			set
+			{
+				SetFieldValue(194, 0, value, Fit.SubfieldIndexMainField);
+			}
+		}
+
+		///<summary>
+		/// Retrieves the AvgStress field
+		/// Units: percent
+		/// Comment: Average stress for the monitoring session</summary>
+		/// <returns>Returns nullable byte representing the AvgStress field</returns>
+		public byte? AvgStress
+		{
+			get
+			{
+				Object val = GetFieldValue(195, 0, Fit.SubfieldIndexMainField);
+				if (val == null)
+				{
+					return null;
+				}
+
+				return (Convert.ToByte(val));
+
+			}
+			set
+			{
+				SetFieldValue(195, 0, value, Fit.SubfieldIndexMainField);
+			}
+		}
+
+		///<summary>
+		/// Retrieves the SdrrHrv field
+		/// Units: mS
+		/// Comment: Standard deviation of R-R interval (SDRR) - Heart rate variability measure most useful for wellness users.</summary>
+		/// <returns>Returns nullable byte representing the SdrrHrv field</returns>
+		public byte? SdrrHrv
+		{
+			get
+			{
+				Object val = GetFieldValue(197, 0, Fit.SubfieldIndexMainField);
+				if (val == null)
+				{
+					return null;
+				}
+
+				return (Convert.ToByte(val));
+
+			}
+			set
+			{
+				SetFieldValue(197, 0, value, Fit.SubfieldIndexMainField);
+			}
+		}
+
+		///<summary>
+		/// Retrieves the RmssdHrv field
+		/// Units: mS
+		/// Comment: Root mean square successive difference (RMSSD) - Heart rate variability measure most useful for athletes</summary>
+		/// <returns>Returns nullable byte representing the RmssdHrv field</returns>
+		public byte? RmssdHrv
+		{
+			get
+			{
+				Object val = GetFieldValue(198, 0, Fit.SubfieldIndexMainField);
+				if (val == null)
+				{
+					return null;
+				}
+
+				return (Convert.ToByte(val));
+
+			}
+			set
+			{
+				SetFieldValue(198, 0, value, Fit.SubfieldIndexMainField);
+			}
+		}
+
+		///<summary>
+		/// Retrieves the TotalFractionalAscent field
+		/// Units: m
+		/// Comment: fractional part of total_ascent</summary>
+		/// <returns>Returns nullable float representing the TotalFractionalAscent field</returns>
+		public float? TotalFractionalAscent
+		{
+			get
+			{
+				Object val = GetFieldValue(199, 0, Fit.SubfieldIndexMainField);
+				if (val == null)
+				{
+					return null;
+				}
+
+				return (Convert.ToSingle(val));
+
+			}
+			set
+			{
+				SetFieldValue(199, 0, value, Fit.SubfieldIndexMainField);
+			}
+		}
+
+		///<summary>
+		/// Retrieves the TotalFractionalDescent field
+		/// Units: m
+		/// Comment: fractional part of total_descent</summary>
+		/// <returns>Returns nullable float representing the TotalFractionalDescent field</returns>
+		public float? TotalFractionalDescent
+		{
+			get
+			{
+				Object val = GetFieldValue(200, 0, Fit.SubfieldIndexMainField);
+				if (val == null)
+				{
+					return null;
+				}
+
+				return (Convert.ToSingle(val));
+
+			}
+			set
+			{
+				SetFieldValue(200, 0, value, Fit.SubfieldIndexMainField);
+			}
+		}
+
+		///<summary>
+		/// Retrieves the AvgCoreTemperature field
+		/// Units: C</summary>
+		/// <returns>Returns nullable float representing the AvgCoreTemperature field</returns>
+		public float? AvgCoreTemperature
+		{
+			get
+			{
+				Object val = GetFieldValue(208, 0, Fit.SubfieldIndexMainField);
+				if (val == null)
+				{
+					return null;
+				}
+
+				return (Convert.ToSingle(val));
+
+			}
+			set
+			{
+				SetFieldValue(208, 0, value, Fit.SubfieldIndexMainField);
+			}
+		}
+
+		///<summary>
+		/// Retrieves the MinCoreTemperature field
+		/// Units: C</summary>
+		/// <returns>Returns nullable float representing the MinCoreTemperature field</returns>
+		public float? MinCoreTemperature
+		{
+			get
+			{
+				Object val = GetFieldValue(209, 0, Fit.SubfieldIndexMainField);
+				if (val == null)
+				{
+					return null;
+				}
+
+				return (Convert.ToSingle(val));
+
+			}
+			set
+			{
+				SetFieldValue(209, 0, value, Fit.SubfieldIndexMainField);
+			}
+		}
+
+		///<summary>
+		/// Retrieves the MaxCoreTemperature field
+		/// Units: C</summary>
+		/// <returns>Returns nullable float representing the MaxCoreTemperature field</returns>
+		public float? MaxCoreTemperature
+		{
+			get
+			{
+				Object val = GetFieldValue(210, 0, Fit.SubfieldIndexMainField);
+				if (val == null)
+				{
+					return null;
+				}
+
+				return (Convert.ToSingle(val));
+
+			}
+			set
+			{
+				SetFieldValue(210, 0, value, Fit.SubfieldIndexMainField);
+			}
+		}
+
+		#endregion // Methods
+	} // Class
 } // namespace

--- a/Dynastream/Fit/Profile/Mesgs/SetMesg.cs
+++ b/Dynastream/Fit/Profile/Mesgs/SetMesg.cs
@@ -21,335 +21,320 @@ using System.Linq;
 
 namespace Dynastream.Fit
 {
-    /// <summary>
-    /// Implements the Set profile message.
-    /// </summary>
-    public class SetMesg : Mesg
-    {
-        #region Fields
-        #endregion
+	/// <summary>
+	/// Implements the Set profile message.
+	/// </summary>
+	public class SetMesg : Mesg
+	{
+		#region Fields
+		#endregion
 
-        /// <summary>
-        /// Field Numbers for <see cref="SetMesg"/>
-        /// </summary>
-        public sealed class FieldDefNum
-        {
-            public const byte Timestamp = 254;
-            public const byte Duration = 0;
-            public const byte Repetitions = 3;
-            public const byte Weight = 4;
-            public const byte SetType = 5;
-            public const byte StartTime = 6;
-            public const byte Category = 7;
-            public const byte CategorySubtype = 8;
-            public const byte WeightDisplayUnit = 9;
-            public const byte MessageIndex = 10;
-            public const byte WktStepIndex = 11;
-            public const byte Invalid = Fit.FieldNumInvalid;
-        }
+		/// <summary>
+		/// Field Numbers for <see cref="SetMesg"/>
+		/// </summary>
+		public sealed class FieldDefNum
+		{
+			public const byte Timestamp = 254;
+			public const byte Duration = 0;
+			public const byte Repetitions = 3;
+			public const byte Weight = 4;
+			public const byte SetType = 5;
+			public const byte StartTime = 6;
+			public const byte Category = 7;
+			public const byte CategorySubtype = 8;
+			public const byte WeightDisplayUnit = 9;
+			public const byte MessageIndex = 10;
+			public const byte WktStepIndex = 11;
+			public const byte Invalid = Fit.FieldNumInvalid;
+		}
 
-        #region Constructors
-        public SetMesg() : base(Profile.GetMesg(MesgNum.Set))
-        {
-        }
+		#region Constructors
+		public SetMesg() : base(Profile.GetMesg(MesgNum.Set))
+		{
+		}
 
-        public SetMesg(Mesg mesg) : base(mesg)
-        {
-        }
-        #endregion // Constructors
+		public SetMesg(Mesg mesg) : base(mesg)
+		{
+		}
+		#endregion // Constructors
 
-        #region Methods
-        ///<summary>
-        /// Retrieves the Timestamp field
-        /// Comment: Timestamp of the set</summary>
-        /// <returns>Returns DateTime representing the Timestamp field</returns>
-        public DateTime GetTimestamp()
-        {
-            Object val = GetFieldValue(254, 0, Fit.SubfieldIndexMainField);
-            if(val == null)
-            {
-                return null;
-            }
+		#region Methods
+		///<summary>
+		/// Retrieves the Timestamp field
+		/// Comment: Timestamp of the set</summary>
+		/// <returns>Returns DateTime representing the Timestamp field</returns>
+		public DateTime Timestamp
+		{
+			get
+			{
+				Object val = GetFieldValue(254, 0, Fit.SubfieldIndexMainField);
+				if (val == null)
+				{
+					return null;
+				}
 
-            return TimestampToDateTime(Convert.ToUInt32(val));
-            
-        }
+				return TimestampToDateTime(Convert.ToUInt32(val));
 
-        /// <summary>
-        /// Set Timestamp field
-        /// Comment: Timestamp of the set</summary>
-        /// <param name="timestamp_">Nullable field value to be set</param>
-        public void SetTimestamp(DateTime timestamp_)
-        {
-            SetFieldValue(254, 0, timestamp_.GetTimeStamp(), Fit.SubfieldIndexMainField);
-        }
-        
-        ///<summary>
-        /// Retrieves the Duration field
-        /// Units: s</summary>
-        /// <returns>Returns nullable float representing the Duration field</returns>
-        public float? GetDuration()
-        {
-            Object val = GetFieldValue(0, 0, Fit.SubfieldIndexMainField);
-            if(val == null)
-            {
-                return null;
-            }
+			}
+			set
+			{
+				SetFieldValue(254, 0, value.GetTimeStamp(), Fit.SubfieldIndexMainField);
+			}
+		}
 
-            return (Convert.ToSingle(val));
-            
-        }
+		///<summary>
+		/// Retrieves the Duration field
+		/// Units: s</summary>
+		/// <returns>Returns nullable float representing the Duration field</returns>
+		public float? Duration
+		{
+			get
+			{
+				Object val = GetFieldValue(0, 0, Fit.SubfieldIndexMainField);
+				if (val == null)
+				{
+					return null;
+				}
 
-        /// <summary>
-        /// Set Duration field
-        /// Units: s</summary>
-        /// <param name="duration_">Nullable field value to be set</param>
-        public void SetDuration(float? duration_)
-        {
-            SetFieldValue(0, 0, duration_, Fit.SubfieldIndexMainField);
-        }
-        
-        ///<summary>
-        /// Retrieves the Repetitions field
-        /// Comment: # of repitions of the movement</summary>
-        /// <returns>Returns nullable ushort representing the Repetitions field</returns>
-        public ushort? GetRepetitions()
-        {
-            Object val = GetFieldValue(3, 0, Fit.SubfieldIndexMainField);
-            if(val == null)
-            {
-                return null;
-            }
+				return (Convert.ToSingle(val));
 
-            return (Convert.ToUInt16(val));
-            
-        }
+			}
+			set
+			{
+				SetFieldValue(0, 0, value, Fit.SubfieldIndexMainField);
+			}
+		}
 
-        /// <summary>
-        /// Set Repetitions field
-        /// Comment: # of repitions of the movement</summary>
-        /// <param name="repetitions_">Nullable field value to be set</param>
-        public void SetRepetitions(ushort? repetitions_)
-        {
-            SetFieldValue(3, 0, repetitions_, Fit.SubfieldIndexMainField);
-        }
-        
-        ///<summary>
-        /// Retrieves the Weight field
-        /// Units: kg
-        /// Comment: Amount of weight applied for the set</summary>
-        /// <returns>Returns nullable float representing the Weight field</returns>
-        public float? GetWeight()
-        {
-            Object val = GetFieldValue(4, 0, Fit.SubfieldIndexMainField);
-            if(val == null)
-            {
-                return null;
-            }
+		///<summary>
+		/// Retrieves the Repetitions field
+		/// Comment: # of repitions of the movement</summary>
+		/// <returns>Returns nullable ushort representing the Repetitions field</returns>
+		public ushort? Repetitions
+		{
+			get
+			{
+				Object val = GetFieldValue(3, 0, Fit.SubfieldIndexMainField);
+				if (val == null)
+				{
+					return null;
+				}
 
-            return (Convert.ToSingle(val));
-            
-        }
+				return (Convert.ToUInt16(val));
 
-        /// <summary>
-        /// Set Weight field
-        /// Units: kg
-        /// Comment: Amount of weight applied for the set</summary>
-        /// <param name="weight_">Nullable field value to be set</param>
-        public void SetWeight(float? weight_)
-        {
-            SetFieldValue(4, 0, weight_, Fit.SubfieldIndexMainField);
-        }
-        
-        ///<summary>
-        /// Retrieves the SetType field</summary>
-        /// <returns>Returns nullable byte representing the SetType field</returns>
-        public byte? GetSetType()
-        {
-            Object val = GetFieldValue(5, 0, Fit.SubfieldIndexMainField);
-            if(val == null)
-            {
-                return null;
-            }
+			}
+			set
+			{
+				SetFieldValue(3, 0, value, Fit.SubfieldIndexMainField);
+			}
+		}
 
-            return (Convert.ToByte(val));
-            
-        }
+		///<summary>
+		/// Retrieves the Weight field
+		/// Units: kg
+		/// Comment: Amount of weight applied for the set</summary>
+		/// <returns>Returns nullable float representing the Weight field</returns>
+		public float? Weight
+		{
+			get
+			{
+				Object val = GetFieldValue(4, 0, Fit.SubfieldIndexMainField);
+				if (val == null)
+				{
+					return null;
+				}
 
-        /// <summary>
-        /// Set SetType field</summary>
-        /// <param name="setType_">Nullable field value to be set</param>
-        public void SetSetType(byte? setType_)
-        {
-            SetFieldValue(5, 0, setType_, Fit.SubfieldIndexMainField);
-        }
-        
-        ///<summary>
-        /// Retrieves the StartTime field
-        /// Comment: Start time of the set</summary>
-        /// <returns>Returns DateTime representing the StartTime field</returns>
-        public DateTime GetStartTime()
-        {
-            Object val = GetFieldValue(6, 0, Fit.SubfieldIndexMainField);
-            if(val == null)
-            {
-                return null;
-            }
+				return (Convert.ToSingle(val));
 
-            return TimestampToDateTime(Convert.ToUInt32(val));
-            
-        }
+			}
+			set
+			{
+				SetFieldValue(4, 0, value, Fit.SubfieldIndexMainField);
+			}
+		}
 
-        /// <summary>
-        /// Set StartTime field
-        /// Comment: Start time of the set</summary>
-        /// <param name="startTime_">Nullable field value to be set</param>
-        public void SetStartTime(DateTime startTime_)
-        {
-            SetFieldValue(6, 0, startTime_.GetTimeStamp(), Fit.SubfieldIndexMainField);
-        }
-        
-        
-        /// <summary>
-        ///
-        /// </summary>
-        /// <returns>returns number of elements in field Category</returns>
-        public int GetNumCategory()
-        {
-            return GetNumFieldValues(7, Fit.SubfieldIndexMainField);
-        }
+		///<summary>
+		/// Retrieves the SetType field</summary>
+		/// <returns>Returns nullable byte representing the SetType field</returns>
+		public byte? SetType
+		{
+			get
+			{
+				Object val = GetFieldValue(5, 0, Fit.SubfieldIndexMainField);
+				if (val == null)
+				{
+					return null;
+				}
 
-        ///<summary>
-        /// Retrieves the Category field</summary>
-        /// <param name="index">0 based index of Category element to retrieve</param>
-        /// <returns>Returns nullable ushort representing the Category field</returns>
-        public ushort? GetCategory(int index)
-        {
-            Object val = GetFieldValue(7, index, Fit.SubfieldIndexMainField);
-            if(val == null)
-            {
-                return null;
-            }
+				return (Convert.ToByte(val));
 
-            return (Convert.ToUInt16(val));
-            
-        }
+			}
+			set
+			{
+				SetFieldValue(5, 0, value, Fit.SubfieldIndexMainField);
+			}
+		}
 
-        /// <summary>
-        /// Set Category field</summary>
-        /// <param name="index">0 based index of category</param>
-        /// <param name="category_">Nullable field value to be set</param>
-        public void SetCategory(int index, ushort? category_)
-        {
-            SetFieldValue(7, index, category_, Fit.SubfieldIndexMainField);
-        }
-        
-        
-        /// <summary>
-        ///
-        /// </summary>
-        /// <returns>returns number of elements in field CategorySubtype</returns>
-        public int GetNumCategorySubtype()
-        {
-            return GetNumFieldValues(8, Fit.SubfieldIndexMainField);
-        }
+		///<summary>
+		/// Retrieves the StartTime field
+		/// Comment: Start time of the set</summary>
+		/// <returns>Returns DateTime representing the StartTime field</returns>
+		public DateTime StartTime
+		{
+			get
+			{
+				Object val = GetFieldValue(6, 0, Fit.SubfieldIndexMainField);
+				if (val == null)
+				{
+					return null;
+				}
 
-        ///<summary>
-        /// Retrieves the CategorySubtype field
-        /// Comment: Based on the associated category, see [category]_exercise_names</summary>
-        /// <param name="index">0 based index of CategorySubtype element to retrieve</param>
-        /// <returns>Returns nullable ushort representing the CategorySubtype field</returns>
-        public ushort? GetCategorySubtype(int index)
-        {
-            Object val = GetFieldValue(8, index, Fit.SubfieldIndexMainField);
-            if(val == null)
-            {
-                return null;
-            }
+				return TimestampToDateTime(Convert.ToUInt32(val));
 
-            return (Convert.ToUInt16(val));
-            
-        }
+			}
+			set
+			{
+				SetFieldValue(6, 0, value.GetTimeStamp(), Fit.SubfieldIndexMainField);
+			}
+		}
 
-        /// <summary>
-        /// Set CategorySubtype field
-        /// Comment: Based on the associated category, see [category]_exercise_names</summary>
-        /// <param name="index">0 based index of category_subtype</param>
-        /// <param name="categorySubtype_">Nullable field value to be set</param>
-        public void SetCategorySubtype(int index, ushort? categorySubtype_)
-        {
-            SetFieldValue(8, index, categorySubtype_, Fit.SubfieldIndexMainField);
-        }
-        
-        ///<summary>
-        /// Retrieves the WeightDisplayUnit field</summary>
-        /// <returns>Returns nullable ushort representing the WeightDisplayUnit field</returns>
-        public ushort? GetWeightDisplayUnit()
-        {
-            Object val = GetFieldValue(9, 0, Fit.SubfieldIndexMainField);
-            if(val == null)
-            {
-                return null;
-            }
 
-            return (Convert.ToUInt16(val));
-            
-        }
+		/// <summary>
+		///
+		/// </summary>
+		/// <returns>returns number of elements in field Category</returns>
+		public int GetNumCategory()
+		{
+			return GetNumFieldValues(7, Fit.SubfieldIndexMainField);
+		}
 
-        /// <summary>
-        /// Set WeightDisplayUnit field</summary>
-        /// <param name="weightDisplayUnit_">Nullable field value to be set</param>
-        public void SetWeightDisplayUnit(ushort? weightDisplayUnit_)
-        {
-            SetFieldValue(9, 0, weightDisplayUnit_, Fit.SubfieldIndexMainField);
-        }
-        
-        ///<summary>
-        /// Retrieves the MessageIndex field</summary>
-        /// <returns>Returns nullable ushort representing the MessageIndex field</returns>
-        public ushort? GetMessageIndex()
-        {
-            Object val = GetFieldValue(10, 0, Fit.SubfieldIndexMainField);
-            if(val == null)
-            {
-                return null;
-            }
+		///<summary>
+		/// Retrieves the Category field</summary>
+		/// <param name="index">0 based index of Category element to retrieve</param>
+		/// <returns>Returns nullable ushort representing the Category field</returns>
+		public ushort? GetCategory(int index)
+		{
+			Object val = GetFieldValue(7, index, Fit.SubfieldIndexMainField);
+			if (val == null)
+			{
+				return null;
+			}
 
-            return (Convert.ToUInt16(val));
-            
-        }
+			return (Convert.ToUInt16(val));
 
-        /// <summary>
-        /// Set MessageIndex field</summary>
-        /// <param name="messageIndex_">Nullable field value to be set</param>
-        public void SetMessageIndex(ushort? messageIndex_)
-        {
-            SetFieldValue(10, 0, messageIndex_, Fit.SubfieldIndexMainField);
-        }
-        
-        ///<summary>
-        /// Retrieves the WktStepIndex field</summary>
-        /// <returns>Returns nullable ushort representing the WktStepIndex field</returns>
-        public ushort? GetWktStepIndex()
-        {
-            Object val = GetFieldValue(11, 0, Fit.SubfieldIndexMainField);
-            if(val == null)
-            {
-                return null;
-            }
+		}
 
-            return (Convert.ToUInt16(val));
-            
-        }
+		/// <summary>
+		/// Set Category field</summary>
+		/// <param name="index">0 based index of category</param>
+		/// <param name="category_">Nullable field value to be set</param>
+		public void SetCategory(int index, ushort? category_)
+		{
+			SetFieldValue(7, index, category_, Fit.SubfieldIndexMainField);
+		}
 
-        /// <summary>
-        /// Set WktStepIndex field</summary>
-        /// <param name="wktStepIndex_">Nullable field value to be set</param>
-        public void SetWktStepIndex(ushort? wktStepIndex_)
-        {
-            SetFieldValue(11, 0, wktStepIndex_, Fit.SubfieldIndexMainField);
-        }
-        
-        #endregion // Methods
-    } // Class
+
+		/// <summary>
+		///
+		/// </summary>
+		/// <returns>returns number of elements in field CategorySubtype</returns>
+		public int GetNumCategorySubtype()
+		{
+			return GetNumFieldValues(8, Fit.SubfieldIndexMainField);
+		}
+
+		///<summary>
+		/// Retrieves the CategorySubtype field
+		/// Comment: Based on the associated category, see [category]_exercise_names</summary>
+		/// <param name="index">0 based index of CategorySubtype element to retrieve</param>
+		/// <returns>Returns nullable ushort representing the CategorySubtype field</returns>
+		public ushort? GetCategorySubtype(int index)
+		{
+			Object val = GetFieldValue(8, index, Fit.SubfieldIndexMainField);
+			if (val == null)
+			{
+				return null;
+			}
+
+			return (Convert.ToUInt16(val));
+
+		}
+
+		/// <summary>
+		/// Set CategorySubtype field
+		/// Comment: Based on the associated category, see [category]_exercise_names</summary>
+		/// <param name="index">0 based index of category_subtype</param>
+		/// <param name="categorySubtype_">Nullable field value to be set</param>
+		public void SetCategorySubtype(int index, ushort? categorySubtype_)
+		{
+			SetFieldValue(8, index, categorySubtype_, Fit.SubfieldIndexMainField);
+		}
+
+		///<summary>
+		/// Retrieves the WeightDisplayUnit field</summary>
+		/// <returns>Returns nullable ushort representing the WeightDisplayUnit field</returns>
+		public ushort? WeightDisplayUnit
+		{
+			get
+			{
+				Object val = GetFieldValue(9, 0, Fit.SubfieldIndexMainField);
+				if (val == null)
+				{
+					return null;
+				}
+
+				return (Convert.ToUInt16(val));
+
+			}
+			set
+			{
+				SetFieldValue(9, 0, value, Fit.SubfieldIndexMainField);
+			}
+		}
+
+		///<summary>
+		/// Retrieves the MessageIndex field</summary>
+		/// <returns>Returns nullable ushort representing the MessageIndex field</returns>
+		public ushort? MessageIndex
+		{
+			get
+			{
+				Object val = GetFieldValue(10, 0, Fit.SubfieldIndexMainField);
+				if (val == null)
+				{
+					return null;
+				}
+
+				return (Convert.ToUInt16(val));
+
+			}
+			set
+			{
+				SetFieldValue(10, 0, value, Fit.SubfieldIndexMainField);
+			}
+		}
+
+		///<summary>
+		/// Retrieves the WktStepIndex field</summary>
+		/// <returns>Returns nullable ushort representing the WktStepIndex field</returns>
+		public ushort? WktStepIndex
+		{
+			get
+			{
+				Object val = GetFieldValue(11, 0, Fit.SubfieldIndexMainField);
+				if (val == null)
+				{
+					return null;
+				}
+
+				return (Convert.ToUInt16(val));
+
+			}
+			set
+			{
+				SetFieldValue(11, 0, value, Fit.SubfieldIndexMainField);
+			}
+		}
+
+		#endregion // Methods
+	} // Class
 } // namespace

--- a/Dynastream/Fit/Profile/Mesgs/SkinTempOvernightMesg.cs
+++ b/Dynastream/Fit/Profile/Mesgs/SkinTempOvernightMesg.cs
@@ -21,159 +21,151 @@ using System.Linq;
 
 namespace Dynastream.Fit
 {
-    /// <summary>
-    /// Implements the SkinTempOvernight profile message.
-    /// </summary>
-    public class SkinTempOvernightMesg : Mesg
-    {
-        #region Fields
-        #endregion
+	/// <summary>
+	/// Implements the SkinTempOvernight profile message.
+	/// </summary>
+	public class SkinTempOvernightMesg : Mesg
+	{
+		#region Fields
+		#endregion
 
-        /// <summary>
-        /// Field Numbers for <see cref="SkinTempOvernightMesg"/>
-        /// </summary>
-        public sealed class FieldDefNum
-        {
-            public const byte Timestamp = 253;
-            public const byte LocalTimestamp = 0;
-            public const byte AverageDeviation = 1;
-            public const byte Average7DayDeviation = 2;
-            public const byte NightlyValue = 4;
-            public const byte Invalid = Fit.FieldNumInvalid;
-        }
+		/// <summary>
+		/// Field Numbers for <see cref="SkinTempOvernightMesg"/>
+		/// </summary>
+		public sealed class FieldDefNum
+		{
+			public const byte Timestamp = 253;
+			public const byte LocalTimestamp = 0;
+			public const byte AverageDeviation = 1;
+			public const byte Average7DayDeviation = 2;
+			public const byte NightlyValue = 4;
+			public const byte Invalid = Fit.FieldNumInvalid;
+		}
 
-        #region Constructors
-        public SkinTempOvernightMesg() : base(Profile.GetMesg(MesgNum.SkinTempOvernight))
-        {
-        }
+		#region Constructors
+		public SkinTempOvernightMesg() : base(Profile.GetMesg(MesgNum.SkinTempOvernight))
+		{
+		}
 
-        public SkinTempOvernightMesg(Mesg mesg) : base(mesg)
-        {
-        }
-        #endregion // Constructors
+		public SkinTempOvernightMesg(Mesg mesg) : base(mesg)
+		{
+		}
+		#endregion // Constructors
 
-        #region Methods
-        ///<summary>
-        /// Retrieves the Timestamp field</summary>
-        /// <returns>Returns DateTime representing the Timestamp field</returns>
-        public DateTime GetTimestamp()
-        {
-            Object val = GetFieldValue(253, 0, Fit.SubfieldIndexMainField);
-            if(val == null)
-            {
-                return null;
-            }
+		#region Methods
+		///<summary>
+		/// Retrieves the Timestamp field</summary>
+		/// <returns>Returns DateTime representing the Timestamp field</returns>
+		public DateTime Timestamp
+		{
+			get
+			{
+				Object val = GetFieldValue(253, 0, Fit.SubfieldIndexMainField);
+				if (val == null)
+				{
+					return null;
+				}
 
-            return TimestampToDateTime(Convert.ToUInt32(val));
-            
-        }
+				return TimestampToDateTime(Convert.ToUInt32(val));
 
-        /// <summary>
-        /// Set Timestamp field</summary>
-        /// <param name="timestamp_">Nullable field value to be set</param>
-        public void SetTimestamp(DateTime timestamp_)
-        {
-            SetFieldValue(253, 0, timestamp_.GetTimeStamp(), Fit.SubfieldIndexMainField);
-        }
-        
-        ///<summary>
-        /// Retrieves the LocalTimestamp field</summary>
-        /// <returns>Returns nullable uint representing the LocalTimestamp field</returns>
-        public uint? GetLocalTimestamp()
-        {
-            Object val = GetFieldValue(0, 0, Fit.SubfieldIndexMainField);
-            if(val == null)
-            {
-                return null;
-            }
+			}
+			set
+			{
+				SetFieldValue(253, 0, value.GetTimeStamp(), Fit.SubfieldIndexMainField);
+			}
+		}
 
-            return (Convert.ToUInt32(val));
-            
-        }
+		///<summary>
+		/// Retrieves the LocalTimestamp field</summary>
+		/// <returns>Returns nullable uint representing the LocalTimestamp field</returns>
+		public uint? LocalTimestamp
+		{
+			get
+			{
+				Object val = GetFieldValue(0, 0, Fit.SubfieldIndexMainField);
+				if (val == null)
+				{
+					return null;
+				}
 
-        /// <summary>
-        /// Set LocalTimestamp field</summary>
-        /// <param name="localTimestamp_">Nullable field value to be set</param>
-        public void SetLocalTimestamp(uint? localTimestamp_)
-        {
-            SetFieldValue(0, 0, localTimestamp_, Fit.SubfieldIndexMainField);
-        }
-        
-        ///<summary>
-        /// Retrieves the AverageDeviation field
-        /// Comment: The average overnight deviation from baseline temperature in degrees C</summary>
-        /// <returns>Returns nullable float representing the AverageDeviation field</returns>
-        public float? GetAverageDeviation()
-        {
-            Object val = GetFieldValue(1, 0, Fit.SubfieldIndexMainField);
-            if(val == null)
-            {
-                return null;
-            }
+				return (Convert.ToUInt32(val));
 
-            return (Convert.ToSingle(val));
-            
-        }
+			}
+			set
+			{
+				SetFieldValue(0, 0, value, Fit.SubfieldIndexMainField);
+			}
+		}
 
-        /// <summary>
-        /// Set AverageDeviation field
-        /// Comment: The average overnight deviation from baseline temperature in degrees C</summary>
-        /// <param name="averageDeviation_">Nullable field value to be set</param>
-        public void SetAverageDeviation(float? averageDeviation_)
-        {
-            SetFieldValue(1, 0, averageDeviation_, Fit.SubfieldIndexMainField);
-        }
-        
-        ///<summary>
-        /// Retrieves the Average7DayDeviation field
-        /// Comment: The average 7 day overnight deviation from baseline temperature in degrees C</summary>
-        /// <returns>Returns nullable float representing the Average7DayDeviation field</returns>
-        public float? GetAverage7DayDeviation()
-        {
-            Object val = GetFieldValue(2, 0, Fit.SubfieldIndexMainField);
-            if(val == null)
-            {
-                return null;
-            }
+		///<summary>
+		/// Retrieves the AverageDeviation field
+		/// Comment: The average overnight deviation from baseline temperature in degrees C</summary>
+		/// <returns>Returns nullable float representing the AverageDeviation field</returns>
+		public float? AverageDeviation
+		{
+			get
+			{
+				Object val = GetFieldValue(1, 0, Fit.SubfieldIndexMainField);
+				if (val == null)
+				{
+					return null;
+				}
 
-            return (Convert.ToSingle(val));
-            
-        }
+				return (Convert.ToSingle(val));
 
-        /// <summary>
-        /// Set Average7DayDeviation field
-        /// Comment: The average 7 day overnight deviation from baseline temperature in degrees C</summary>
-        /// <param name="average7DayDeviation_">Nullable field value to be set</param>
-        public void SetAverage7DayDeviation(float? average7DayDeviation_)
-        {
-            SetFieldValue(2, 0, average7DayDeviation_, Fit.SubfieldIndexMainField);
-        }
-        
-        ///<summary>
-        /// Retrieves the NightlyValue field
-        /// Comment: Final overnight temperature value</summary>
-        /// <returns>Returns nullable float representing the NightlyValue field</returns>
-        public float? GetNightlyValue()
-        {
-            Object val = GetFieldValue(4, 0, Fit.SubfieldIndexMainField);
-            if(val == null)
-            {
-                return null;
-            }
+			}
+			set
+			{
+				SetFieldValue(1, 0, value, Fit.SubfieldIndexMainField);
+			}
+		}
 
-            return (Convert.ToSingle(val));
-            
-        }
+		///<summary>
+		/// Retrieves the Average7DayDeviation field
+		/// Comment: The average 7 day overnight deviation from baseline temperature in degrees C</summary>
+		/// <returns>Returns nullable float representing the Average7DayDeviation field</returns>
+		public float? Average7DayDeviation
+		{
+			get
+			{
+				Object val = GetFieldValue(2, 0, Fit.SubfieldIndexMainField);
+				if (val == null)
+				{
+					return null;
+				}
 
-        /// <summary>
-        /// Set NightlyValue field
-        /// Comment: Final overnight temperature value</summary>
-        /// <param name="nightlyValue_">Nullable field value to be set</param>
-        public void SetNightlyValue(float? nightlyValue_)
-        {
-            SetFieldValue(4, 0, nightlyValue_, Fit.SubfieldIndexMainField);
-        }
-        
-        #endregion // Methods
-    } // Class
+				return (Convert.ToSingle(val));
+
+			}
+			set
+			{
+				SetFieldValue(2, 0, value, Fit.SubfieldIndexMainField);
+			}
+		}
+
+		///<summary>
+		/// Retrieves the NightlyValue field
+		/// Comment: Final overnight temperature value</summary>
+		/// <returns>Returns nullable float representing the NightlyValue field</returns>
+		public float? NightlyValue
+		{
+			get
+			{
+				Object val = GetFieldValue(4, 0, Fit.SubfieldIndexMainField);
+				if (val == null)
+				{
+					return null;
+				}
+
+				return (Convert.ToSingle(val));
+
+			}
+			set
+			{
+				SetFieldValue(4, 0, value, Fit.SubfieldIndexMainField);
+			}
+		}
+
+		#endregion // Methods
+	} // Class
 } // namespace

--- a/Dynastream/Fit/Profile/Mesgs/SlaveDeviceMesg.cs
+++ b/Dynastream/Fit/Profile/Mesgs/SlaveDeviceMesg.cs
@@ -21,137 +21,131 @@ using System.Linq;
 
 namespace Dynastream.Fit
 {
-    /// <summary>
-    /// Implements the SlaveDevice profile message.
-    /// </summary>
-    public class SlaveDeviceMesg : Mesg
-    {
-        #region Fields
-        static class ProductSubfield
-        {
-            public static ushort FaveroProduct = 0;
-            public static ushort GarminProduct = 1;
-            public static ushort Subfields = 2;
-            public static ushort Active = Fit.SubfieldIndexActiveSubfield;
-            public static ushort MainField = Fit.SubfieldIndexMainField;
-        }
-        #endregion
+	/// <summary>
+	/// Implements the SlaveDevice profile message.
+	/// </summary>
+	public class SlaveDeviceMesg : Mesg
+	{
+		#region Fields
+		static class ProductSubfield
+		{
+			public static ushort FaveroProduct = 0;
+			public static ushort GarminProduct = 1;
+			public static ushort Subfields = 2;
+			public static ushort Active = Fit.SubfieldIndexActiveSubfield;
+			public static ushort MainField = Fit.SubfieldIndexMainField;
+		}
+		#endregion
 
-        /// <summary>
-        /// Field Numbers for <see cref="SlaveDeviceMesg"/>
-        /// </summary>
-        public sealed class FieldDefNum
-        {
-            public const byte Manufacturer = 0;
-            public const byte Product = 1;
-            public const byte Invalid = Fit.FieldNumInvalid;
-        }
+		/// <summary>
+		/// Field Numbers for <see cref="SlaveDeviceMesg"/>
+		/// </summary>
+		public sealed class FieldDefNum
+		{
+			public const byte Manufacturer = 0;
+			public const byte Product = 1;
+			public const byte Invalid = Fit.FieldNumInvalid;
+		}
 
-        #region Constructors
-        public SlaveDeviceMesg() : base(Profile.GetMesg(MesgNum.SlaveDevice))
-        {
-        }
+		#region Constructors
+		public SlaveDeviceMesg() : base(Profile.GetMesg(MesgNum.SlaveDevice))
+		{
+		}
 
-        public SlaveDeviceMesg(Mesg mesg) : base(mesg)
-        {
-        }
-        #endregion // Constructors
+		public SlaveDeviceMesg(Mesg mesg) : base(mesg)
+		{
+		}
+		#endregion // Constructors
 
-        #region Methods
-        ///<summary>
-        /// Retrieves the Manufacturer field</summary>
-        /// <returns>Returns nullable ushort representing the Manufacturer field</returns>
-        public ushort? GetManufacturer()
-        {
-            Object val = GetFieldValue(0, 0, Fit.SubfieldIndexMainField);
-            if(val == null)
-            {
-                return null;
-            }
+		#region Methods
+		///<summary>
+		/// Retrieves the Manufacturer field</summary>
+		/// <returns>Returns nullable ushort representing the Manufacturer field</returns>
+		public ushort? Manufacturer
+		{
+			get
+			{
+				Object val = GetFieldValue(0, 0, Fit.SubfieldIndexMainField);
+				if (val == null)
+				{
+					return null;
+				}
 
-            return (Convert.ToUInt16(val));
-            
-        }
+				return (Convert.ToUInt16(val));
 
-        /// <summary>
-        /// Set Manufacturer field</summary>
-        /// <param name="manufacturer_">Nullable field value to be set</param>
-        public void SetManufacturer(ushort? manufacturer_)
-        {
-            SetFieldValue(0, 0, manufacturer_, Fit.SubfieldIndexMainField);
-        }
-        
-        ///<summary>
-        /// Retrieves the Product field</summary>
-        /// <returns>Returns nullable ushort representing the Product field</returns>
-        public ushort? GetProduct()
-        {
-            Object val = GetFieldValue(1, 0, Fit.SubfieldIndexMainField);
-            if(val == null)
-            {
-                return null;
-            }
+			}
+			set
+			{
+				SetFieldValue(0, 0, value, Fit.SubfieldIndexMainField);
+			}
+		}
 
-            return (Convert.ToUInt16(val));
-            
-        }
+		///<summary>
+		/// Retrieves the Product field</summary>
+		/// <returns>Returns nullable ushort representing the Product field</returns>
+		public ushort? Product
+		{
+			get
+			{
+				Object val = GetFieldValue(1, 0, Fit.SubfieldIndexMainField);
+				if (val == null)
+				{
+					return null;
+				}
 
-        /// <summary>
-        /// Set Product field</summary>
-        /// <param name="product_">Nullable field value to be set</param>
-        public void SetProduct(ushort? product_)
-        {
-            SetFieldValue(1, 0, product_, Fit.SubfieldIndexMainField);
-        }
-        
+				return (Convert.ToUInt16(val));
 
-        /// <summary>
-        /// Retrieves the FaveroProduct subfield</summary>
-        /// <returns>Nullable ushort representing the FaveroProduct subfield</returns>
-        public ushort? GetFaveroProduct()
-        {
-            Object val = GetFieldValue(1, 0, ProductSubfield.FaveroProduct);
-            if(val == null)
-            {
-                return null;
-            }
+			}
+			set
+			{
+				SetFieldValue(1, 0, value, Fit.SubfieldIndexMainField);
+			}
+		}
 
-            return (Convert.ToUInt16(val));
-            
-        }
 
-        /// <summary>
-        ///
-        /// Set FaveroProduct subfield</summary>
-        /// <param name="faveroProduct">Subfield value to be set</param>
-        public void SetFaveroProduct(ushort? faveroProduct)
-        {
-            SetFieldValue(1, 0, faveroProduct, ProductSubfield.FaveroProduct);
-        }
+		/// <summary>
+		/// Retrieves the FaveroProduct subfield</summary>
+		/// <returns>Nullable ushort representing the FaveroProduct subfield</returns>
+		public ushort? FaveroProduct
+		{
+			get
+			{
+				Object val = GetFieldValue(1, 0, ProductSubfield.FaveroProduct);
+				if (val == null)
+				{
+					return null;
+				}
 
-        /// <summary>
-        /// Retrieves the GarminProduct subfield</summary>
-        /// <returns>Nullable ushort representing the GarminProduct subfield</returns>
-        public ushort? GetGarminProduct()
-        {
-            Object val = GetFieldValue(1, 0, ProductSubfield.GarminProduct);
-            if(val == null)
-            {
-                return null;
-            }
+				return (Convert.ToUInt16(val));
 
-            return (Convert.ToUInt16(val));
-            
-        }
+			}
+			set
+			{
+				SetFieldValue(1, 0, value, ProductSubfield.FaveroProduct);
+			}
+		}
 
-        /// <summary>
-        ///
-        /// Set GarminProduct subfield</summary>
-        /// <param name="garminProduct">Subfield value to be set</param>
-        public void SetGarminProduct(ushort? garminProduct)
-        {
-            SetFieldValue(1, 0, garminProduct, ProductSubfield.GarminProduct);
-        }
-        #endregion // Methods
-    } // Class
+		/// <summary>
+		/// Retrieves the GarminProduct subfield</summary>
+		/// <returns>Nullable ushort representing the GarminProduct subfield</returns>
+		public ushort? GarminProduct
+		{
+			get
+			{
+				Object val = GetFieldValue(1, 0, ProductSubfield.GarminProduct);
+				if (val == null)
+				{
+					return null;
+				}
+
+				return (Convert.ToUInt16(val));
+
+			}
+			set
+			{
+				SetFieldValue(1, 0, value, ProductSubfield.GarminProduct);
+			}
+		}
+		#endregion // Methods
+	} // Class
 } // namespace

--- a/Dynastream/Fit/Profile/Mesgs/SleepAssessmentMesg.cs
+++ b/Dynastream/Fit/Profile/Mesgs/SleepAssessmentMesg.cs
@@ -21,397 +21,369 @@ using System.Linq;
 
 namespace Dynastream.Fit
 {
-    /// <summary>
-    /// Implements the SleepAssessment profile message.
-    /// </summary>
-    public class SleepAssessmentMesg : Mesg
-    {
-        #region Fields
-        #endregion
+	/// <summary>
+	/// Implements the SleepAssessment profile message.
+	/// </summary>
+	public class SleepAssessmentMesg : Mesg
+	{
+		#region Fields
+		#endregion
 
-        /// <summary>
-        /// Field Numbers for <see cref="SleepAssessmentMesg"/>
-        /// </summary>
-        public sealed class FieldDefNum
-        {
-            public const byte CombinedAwakeScore = 0;
-            public const byte AwakeTimeScore = 1;
-            public const byte AwakeningsCountScore = 2;
-            public const byte DeepSleepScore = 3;
-            public const byte SleepDurationScore = 4;
-            public const byte LightSleepScore = 5;
-            public const byte OverallSleepScore = 6;
-            public const byte SleepQualityScore = 7;
-            public const byte SleepRecoveryScore = 8;
-            public const byte RemSleepScore = 9;
-            public const byte SleepRestlessnessScore = 10;
-            public const byte AwakeningsCount = 11;
-            public const byte InterruptionsScore = 14;
-            public const byte AverageStressDuringSleep = 15;
-            public const byte Invalid = Fit.FieldNumInvalid;
-        }
+		/// <summary>
+		/// Field Numbers for <see cref="SleepAssessmentMesg"/>
+		/// </summary>
+		public sealed class FieldDefNum
+		{
+			public const byte CombinedAwakeScore = 0;
+			public const byte AwakeTimeScore = 1;
+			public const byte AwakeningsCountScore = 2;
+			public const byte DeepSleepScore = 3;
+			public const byte SleepDurationScore = 4;
+			public const byte LightSleepScore = 5;
+			public const byte OverallSleepScore = 6;
+			public const byte SleepQualityScore = 7;
+			public const byte SleepRecoveryScore = 8;
+			public const byte RemSleepScore = 9;
+			public const byte SleepRestlessnessScore = 10;
+			public const byte AwakeningsCount = 11;
+			public const byte InterruptionsScore = 14;
+			public const byte AverageStressDuringSleep = 15;
+			public const byte Invalid = Fit.FieldNumInvalid;
+		}
 
-        #region Constructors
-        public SleepAssessmentMesg() : base(Profile.GetMesg(MesgNum.SleepAssessment))
-        {
-        }
+		#region Constructors
+		public SleepAssessmentMesg() : base(Profile.GetMesg(MesgNum.SleepAssessment))
+		{
+		}
 
-        public SleepAssessmentMesg(Mesg mesg) : base(mesg)
-        {
-        }
-        #endregion // Constructors
+		public SleepAssessmentMesg(Mesg mesg) : base(mesg)
+		{
+		}
+		#endregion // Constructors
 
-        #region Methods
-        ///<summary>
-        /// Retrieves the CombinedAwakeScore field
-        /// Comment: Average of awake_time_score and awakenings_count_score. If valid: 0 (worst) to 100 (best). If unknown: FIT_UINT8_INVALID.</summary>
-        /// <returns>Returns nullable byte representing the CombinedAwakeScore field</returns>
-        public byte? GetCombinedAwakeScore()
-        {
-            Object val = GetFieldValue(0, 0, Fit.SubfieldIndexMainField);
-            if(val == null)
-            {
-                return null;
-            }
+		#region Methods
+		///<summary>
+		/// Retrieves the CombinedAwakeScore field
+		/// Comment: Average of awake_time_score and awakenings_count_score. If valid: 0 (worst) to 100 (best). If unknown: FIT_UINT8_INVALID.</summary>
+		/// <returns>Returns nullable byte representing the CombinedAwakeScore field</returns>
+		public byte? CombinedAwakeScore
+		{
+			get
+			{
+				Object val = GetFieldValue(0, 0, Fit.SubfieldIndexMainField);
+				if (val == null)
+				{
+					return null;
+				}
 
-            return (Convert.ToByte(val));
-            
-        }
+				return (Convert.ToByte(val));
 
-        /// <summary>
-        /// Set CombinedAwakeScore field
-        /// Comment: Average of awake_time_score and awakenings_count_score. If valid: 0 (worst) to 100 (best). If unknown: FIT_UINT8_INVALID.</summary>
-        /// <param name="combinedAwakeScore_">Nullable field value to be set</param>
-        public void SetCombinedAwakeScore(byte? combinedAwakeScore_)
-        {
-            SetFieldValue(0, 0, combinedAwakeScore_, Fit.SubfieldIndexMainField);
-        }
-        
-        ///<summary>
-        /// Retrieves the AwakeTimeScore field
-        /// Comment: Score that evaluates the total time spent awake between sleep. If valid: 0 (worst) to 100 (best). If unknown: FIT_UINT8_INVALID.</summary>
-        /// <returns>Returns nullable byte representing the AwakeTimeScore field</returns>
-        public byte? GetAwakeTimeScore()
-        {
-            Object val = GetFieldValue(1, 0, Fit.SubfieldIndexMainField);
-            if(val == null)
-            {
-                return null;
-            }
+			}
+			set
+			{
+				SetFieldValue(0, 0, value, Fit.SubfieldIndexMainField);
+			}
+		}
 
-            return (Convert.ToByte(val));
-            
-        }
+		///<summary>
+		/// Retrieves the AwakeTimeScore field
+		/// Comment: Score that evaluates the total time spent awake between sleep. If valid: 0 (worst) to 100 (best). If unknown: FIT_UINT8_INVALID.</summary>
+		/// <returns>Returns nullable byte representing the AwakeTimeScore field</returns>
+		public byte? AwakeTimeScore
+		{
+			get
+			{
+				Object val = GetFieldValue(1, 0, Fit.SubfieldIndexMainField);
+				if (val == null)
+				{
+					return null;
+				}
 
-        /// <summary>
-        /// Set AwakeTimeScore field
-        /// Comment: Score that evaluates the total time spent awake between sleep. If valid: 0 (worst) to 100 (best). If unknown: FIT_UINT8_INVALID.</summary>
-        /// <param name="awakeTimeScore_">Nullable field value to be set</param>
-        public void SetAwakeTimeScore(byte? awakeTimeScore_)
-        {
-            SetFieldValue(1, 0, awakeTimeScore_, Fit.SubfieldIndexMainField);
-        }
-        
-        ///<summary>
-        /// Retrieves the AwakeningsCountScore field
-        /// Comment: Score that evaluates the number of awakenings that interrupt sleep. If valid: 0 (worst) to 100 (best). If unknown: FIT_UINT8_INVALID.</summary>
-        /// <returns>Returns nullable byte representing the AwakeningsCountScore field</returns>
-        public byte? GetAwakeningsCountScore()
-        {
-            Object val = GetFieldValue(2, 0, Fit.SubfieldIndexMainField);
-            if(val == null)
-            {
-                return null;
-            }
+				return (Convert.ToByte(val));
 
-            return (Convert.ToByte(val));
-            
-        }
+			}
+			set
+			{
+				SetFieldValue(1, 0, value, Fit.SubfieldIndexMainField);
+			}
+		}
 
-        /// <summary>
-        /// Set AwakeningsCountScore field
-        /// Comment: Score that evaluates the number of awakenings that interrupt sleep. If valid: 0 (worst) to 100 (best). If unknown: FIT_UINT8_INVALID.</summary>
-        /// <param name="awakeningsCountScore_">Nullable field value to be set</param>
-        public void SetAwakeningsCountScore(byte? awakeningsCountScore_)
-        {
-            SetFieldValue(2, 0, awakeningsCountScore_, Fit.SubfieldIndexMainField);
-        }
-        
-        ///<summary>
-        /// Retrieves the DeepSleepScore field
-        /// Comment: Score that evaluates the amount of deep sleep. If valid: 0 (worst) to 100 (best). If unknown: FIT_UINT8_INVALID.</summary>
-        /// <returns>Returns nullable byte representing the DeepSleepScore field</returns>
-        public byte? GetDeepSleepScore()
-        {
-            Object val = GetFieldValue(3, 0, Fit.SubfieldIndexMainField);
-            if(val == null)
-            {
-                return null;
-            }
+		///<summary>
+		/// Retrieves the AwakeningsCountScore field
+		/// Comment: Score that evaluates the number of awakenings that interrupt sleep. If valid: 0 (worst) to 100 (best). If unknown: FIT_UINT8_INVALID.</summary>
+		/// <returns>Returns nullable byte representing the AwakeningsCountScore field</returns>
+		public byte? AwakeningsCountScore
+		{
+			get
+			{
+				Object val = GetFieldValue(2, 0, Fit.SubfieldIndexMainField);
+				if (val == null)
+				{
+					return null;
+				}
 
-            return (Convert.ToByte(val));
-            
-        }
+				return (Convert.ToByte(val));
 
-        /// <summary>
-        /// Set DeepSleepScore field
-        /// Comment: Score that evaluates the amount of deep sleep. If valid: 0 (worst) to 100 (best). If unknown: FIT_UINT8_INVALID.</summary>
-        /// <param name="deepSleepScore_">Nullable field value to be set</param>
-        public void SetDeepSleepScore(byte? deepSleepScore_)
-        {
-            SetFieldValue(3, 0, deepSleepScore_, Fit.SubfieldIndexMainField);
-        }
-        
-        ///<summary>
-        /// Retrieves the SleepDurationScore field
-        /// Comment: Score that evaluates the quality of sleep based on sleep stages, heart-rate variability and possible awakenings during the night. If valid: 0 (worst) to 100 (best). If unknown: FIT_UINT8_INVALID.</summary>
-        /// <returns>Returns nullable byte representing the SleepDurationScore field</returns>
-        public byte? GetSleepDurationScore()
-        {
-            Object val = GetFieldValue(4, 0, Fit.SubfieldIndexMainField);
-            if(val == null)
-            {
-                return null;
-            }
+			}
+			set
+			{
+				SetFieldValue(2, 0, value, Fit.SubfieldIndexMainField);
+			}
+		}
 
-            return (Convert.ToByte(val));
-            
-        }
+		///<summary>
+		/// Retrieves the DeepSleepScore field
+		/// Comment: Score that evaluates the amount of deep sleep. If valid: 0 (worst) to 100 (best). If unknown: FIT_UINT8_INVALID.</summary>
+		/// <returns>Returns nullable byte representing the DeepSleepScore field</returns>
+		public byte? DeepSleepScore
+		{
+			get
+			{
+				Object val = GetFieldValue(3, 0, Fit.SubfieldIndexMainField);
+				if (val == null)
+				{
+					return null;
+				}
 
-        /// <summary>
-        /// Set SleepDurationScore field
-        /// Comment: Score that evaluates the quality of sleep based on sleep stages, heart-rate variability and possible awakenings during the night. If valid: 0 (worst) to 100 (best). If unknown: FIT_UINT8_INVALID.</summary>
-        /// <param name="sleepDurationScore_">Nullable field value to be set</param>
-        public void SetSleepDurationScore(byte? sleepDurationScore_)
-        {
-            SetFieldValue(4, 0, sleepDurationScore_, Fit.SubfieldIndexMainField);
-        }
-        
-        ///<summary>
-        /// Retrieves the LightSleepScore field
-        /// Comment: Score that evaluates the amount of light sleep. If valid: 0 (worst) to 100 (best). If unknown: FIT_UINT8_INVALID.</summary>
-        /// <returns>Returns nullable byte representing the LightSleepScore field</returns>
-        public byte? GetLightSleepScore()
-        {
-            Object val = GetFieldValue(5, 0, Fit.SubfieldIndexMainField);
-            if(val == null)
-            {
-                return null;
-            }
+				return (Convert.ToByte(val));
 
-            return (Convert.ToByte(val));
-            
-        }
+			}
+			set
+			{
+				SetFieldValue(3, 0, value, Fit.SubfieldIndexMainField);
+			}
+		}
 
-        /// <summary>
-        /// Set LightSleepScore field
-        /// Comment: Score that evaluates the amount of light sleep. If valid: 0 (worst) to 100 (best). If unknown: FIT_UINT8_INVALID.</summary>
-        /// <param name="lightSleepScore_">Nullable field value to be set</param>
-        public void SetLightSleepScore(byte? lightSleepScore_)
-        {
-            SetFieldValue(5, 0, lightSleepScore_, Fit.SubfieldIndexMainField);
-        }
-        
-        ///<summary>
-        /// Retrieves the OverallSleepScore field
-        /// Comment: Total score that summarizes the overall quality of sleep, combining sleep duration and quality. If valid: 0 (worst) to 100 (best). If unknown: FIT_UINT8_INVALID.</summary>
-        /// <returns>Returns nullable byte representing the OverallSleepScore field</returns>
-        public byte? GetOverallSleepScore()
-        {
-            Object val = GetFieldValue(6, 0, Fit.SubfieldIndexMainField);
-            if(val == null)
-            {
-                return null;
-            }
+		///<summary>
+		/// Retrieves the SleepDurationScore field
+		/// Comment: Score that evaluates the quality of sleep based on sleep stages, heart-rate variability and possible awakenings during the night. If valid: 0 (worst) to 100 (best). If unknown: FIT_UINT8_INVALID.</summary>
+		/// <returns>Returns nullable byte representing the SleepDurationScore field</returns>
+		public byte? SleepDurationScore
+		{
+			get
+			{
+				Object val = GetFieldValue(4, 0, Fit.SubfieldIndexMainField);
+				if (val == null)
+				{
+					return null;
+				}
 
-            return (Convert.ToByte(val));
-            
-        }
+				return (Convert.ToByte(val));
 
-        /// <summary>
-        /// Set OverallSleepScore field
-        /// Comment: Total score that summarizes the overall quality of sleep, combining sleep duration and quality. If valid: 0 (worst) to 100 (best). If unknown: FIT_UINT8_INVALID.</summary>
-        /// <param name="overallSleepScore_">Nullable field value to be set</param>
-        public void SetOverallSleepScore(byte? overallSleepScore_)
-        {
-            SetFieldValue(6, 0, overallSleepScore_, Fit.SubfieldIndexMainField);
-        }
-        
-        ///<summary>
-        /// Retrieves the SleepQualityScore field
-        /// Comment: Score that evaluates the quality of sleep based on sleep stages, heart-rate variability and possible awakenings during the night. If valid: 0 (worst) to 100 (best). If unknown: FIT_UINT8_INVALID.</summary>
-        /// <returns>Returns nullable byte representing the SleepQualityScore field</returns>
-        public byte? GetSleepQualityScore()
-        {
-            Object val = GetFieldValue(7, 0, Fit.SubfieldIndexMainField);
-            if(val == null)
-            {
-                return null;
-            }
+			}
+			set
+			{
+				SetFieldValue(4, 0, value, Fit.SubfieldIndexMainField);
+			}
+		}
 
-            return (Convert.ToByte(val));
-            
-        }
+		///<summary>
+		/// Retrieves the LightSleepScore field
+		/// Comment: Score that evaluates the amount of light sleep. If valid: 0 (worst) to 100 (best). If unknown: FIT_UINT8_INVALID.</summary>
+		/// <returns>Returns nullable byte representing the LightSleepScore field</returns>
+		public byte? LightSleepScore
+		{
+			get
+			{
+				Object val = GetFieldValue(5, 0, Fit.SubfieldIndexMainField);
+				if (val == null)
+				{
+					return null;
+				}
 
-        /// <summary>
-        /// Set SleepQualityScore field
-        /// Comment: Score that evaluates the quality of sleep based on sleep stages, heart-rate variability and possible awakenings during the night. If valid: 0 (worst) to 100 (best). If unknown: FIT_UINT8_INVALID.</summary>
-        /// <param name="sleepQualityScore_">Nullable field value to be set</param>
-        public void SetSleepQualityScore(byte? sleepQualityScore_)
-        {
-            SetFieldValue(7, 0, sleepQualityScore_, Fit.SubfieldIndexMainField);
-        }
-        
-        ///<summary>
-        /// Retrieves the SleepRecoveryScore field
-        /// Comment: Score that evaluates stress and recovery during sleep. If valid: 0 (worst) to 100 (best). If unknown: FIT_UINT8_INVALID.</summary>
-        /// <returns>Returns nullable byte representing the SleepRecoveryScore field</returns>
-        public byte? GetSleepRecoveryScore()
-        {
-            Object val = GetFieldValue(8, 0, Fit.SubfieldIndexMainField);
-            if(val == null)
-            {
-                return null;
-            }
+				return (Convert.ToByte(val));
 
-            return (Convert.ToByte(val));
-            
-        }
+			}
+			set
+			{
+				SetFieldValue(5, 0, value, Fit.SubfieldIndexMainField);
+			}
+		}
 
-        /// <summary>
-        /// Set SleepRecoveryScore field
-        /// Comment: Score that evaluates stress and recovery during sleep. If valid: 0 (worst) to 100 (best). If unknown: FIT_UINT8_INVALID.</summary>
-        /// <param name="sleepRecoveryScore_">Nullable field value to be set</param>
-        public void SetSleepRecoveryScore(byte? sleepRecoveryScore_)
-        {
-            SetFieldValue(8, 0, sleepRecoveryScore_, Fit.SubfieldIndexMainField);
-        }
-        
-        ///<summary>
-        /// Retrieves the RemSleepScore field
-        /// Comment: Score that evaluates the amount of REM sleep. If valid: 0 (worst) to 100 (best). If unknown: FIT_UINT8_INVALID.</summary>
-        /// <returns>Returns nullable byte representing the RemSleepScore field</returns>
-        public byte? GetRemSleepScore()
-        {
-            Object val = GetFieldValue(9, 0, Fit.SubfieldIndexMainField);
-            if(val == null)
-            {
-                return null;
-            }
+		///<summary>
+		/// Retrieves the OverallSleepScore field
+		/// Comment: Total score that summarizes the overall quality of sleep, combining sleep duration and quality. If valid: 0 (worst) to 100 (best). If unknown: FIT_UINT8_INVALID.</summary>
+		/// <returns>Returns nullable byte representing the OverallSleepScore field</returns>
+		public byte? OverallSleepScore
+		{
+			get
+			{
+				Object val = GetFieldValue(6, 0, Fit.SubfieldIndexMainField);
+				if (val == null)
+				{
+					return null;
+				}
 
-            return (Convert.ToByte(val));
-            
-        }
+				return (Convert.ToByte(val));
 
-        /// <summary>
-        /// Set RemSleepScore field
-        /// Comment: Score that evaluates the amount of REM sleep. If valid: 0 (worst) to 100 (best). If unknown: FIT_UINT8_INVALID.</summary>
-        /// <param name="remSleepScore_">Nullable field value to be set</param>
-        public void SetRemSleepScore(byte? remSleepScore_)
-        {
-            SetFieldValue(9, 0, remSleepScore_, Fit.SubfieldIndexMainField);
-        }
-        
-        ///<summary>
-        /// Retrieves the SleepRestlessnessScore field
-        /// Comment: Score that evaluates the amount of restlessness during sleep. If valid: 0 (worst) to 100 (best). If unknown: FIT_UINT8_INVALID.</summary>
-        /// <returns>Returns nullable byte representing the SleepRestlessnessScore field</returns>
-        public byte? GetSleepRestlessnessScore()
-        {
-            Object val = GetFieldValue(10, 0, Fit.SubfieldIndexMainField);
-            if(val == null)
-            {
-                return null;
-            }
+			}
+			set
+			{
+				SetFieldValue(6, 0, value, Fit.SubfieldIndexMainField);
+			}
+		}
 
-            return (Convert.ToByte(val));
-            
-        }
+		///<summary>
+		/// Retrieves the SleepQualityScore field
+		/// Comment: Score that evaluates the quality of sleep based on sleep stages, heart-rate variability and possible awakenings during the night. If valid: 0 (worst) to 100 (best). If unknown: FIT_UINT8_INVALID.</summary>
+		/// <returns>Returns nullable byte representing the SleepQualityScore field</returns>
+		public byte? SleepQualityScore
+		{
+			get
+			{
+				Object val = GetFieldValue(7, 0, Fit.SubfieldIndexMainField);
+				if (val == null)
+				{
+					return null;
+				}
 
-        /// <summary>
-        /// Set SleepRestlessnessScore field
-        /// Comment: Score that evaluates the amount of restlessness during sleep. If valid: 0 (worst) to 100 (best). If unknown: FIT_UINT8_INVALID.</summary>
-        /// <param name="sleepRestlessnessScore_">Nullable field value to be set</param>
-        public void SetSleepRestlessnessScore(byte? sleepRestlessnessScore_)
-        {
-            SetFieldValue(10, 0, sleepRestlessnessScore_, Fit.SubfieldIndexMainField);
-        }
-        
-        ///<summary>
-        /// Retrieves the AwakeningsCount field
-        /// Comment: The number of awakenings during sleep.</summary>
-        /// <returns>Returns nullable byte representing the AwakeningsCount field</returns>
-        public byte? GetAwakeningsCount()
-        {
-            Object val = GetFieldValue(11, 0, Fit.SubfieldIndexMainField);
-            if(val == null)
-            {
-                return null;
-            }
+				return (Convert.ToByte(val));
 
-            return (Convert.ToByte(val));
-            
-        }
+			}
+			set
+			{
+				SetFieldValue(7, 0, value, Fit.SubfieldIndexMainField);
+			}
+		}
 
-        /// <summary>
-        /// Set AwakeningsCount field
-        /// Comment: The number of awakenings during sleep.</summary>
-        /// <param name="awakeningsCount_">Nullable field value to be set</param>
-        public void SetAwakeningsCount(byte? awakeningsCount_)
-        {
-            SetFieldValue(11, 0, awakeningsCount_, Fit.SubfieldIndexMainField);
-        }
-        
-        ///<summary>
-        /// Retrieves the InterruptionsScore field
-        /// Comment: Score that evaluates the sleep interruptions. If valid: 0 (worst) to 100 (best). If unknown: FIT_UINT8_INVALID.</summary>
-        /// <returns>Returns nullable byte representing the InterruptionsScore field</returns>
-        public byte? GetInterruptionsScore()
-        {
-            Object val = GetFieldValue(14, 0, Fit.SubfieldIndexMainField);
-            if(val == null)
-            {
-                return null;
-            }
+		///<summary>
+		/// Retrieves the SleepRecoveryScore field
+		/// Comment: Score that evaluates stress and recovery during sleep. If valid: 0 (worst) to 100 (best). If unknown: FIT_UINT8_INVALID.</summary>
+		/// <returns>Returns nullable byte representing the SleepRecoveryScore field</returns>
+		public byte? SleepRecoveryScore
+		{
+			get
+			{
+				Object val = GetFieldValue(8, 0, Fit.SubfieldIndexMainField);
+				if (val == null)
+				{
+					return null;
+				}
 
-            return (Convert.ToByte(val));
-            
-        }
+				return (Convert.ToByte(val));
 
-        /// <summary>
-        /// Set InterruptionsScore field
-        /// Comment: Score that evaluates the sleep interruptions. If valid: 0 (worst) to 100 (best). If unknown: FIT_UINT8_INVALID.</summary>
-        /// <param name="interruptionsScore_">Nullable field value to be set</param>
-        public void SetInterruptionsScore(byte? interruptionsScore_)
-        {
-            SetFieldValue(14, 0, interruptionsScore_, Fit.SubfieldIndexMainField);
-        }
-        
-        ///<summary>
-        /// Retrieves the AverageStressDuringSleep field
-        /// Comment: Excludes stress during awake periods in the sleep window</summary>
-        /// <returns>Returns nullable float representing the AverageStressDuringSleep field</returns>
-        public float? GetAverageStressDuringSleep()
-        {
-            Object val = GetFieldValue(15, 0, Fit.SubfieldIndexMainField);
-            if(val == null)
-            {
-                return null;
-            }
+			}
+			set
+			{
+				SetFieldValue(8, 0, value, Fit.SubfieldIndexMainField);
+			}
+		}
 
-            return (Convert.ToSingle(val));
-            
-        }
+		///<summary>
+		/// Retrieves the RemSleepScore field
+		/// Comment: Score that evaluates the amount of REM sleep. If valid: 0 (worst) to 100 (best). If unknown: FIT_UINT8_INVALID.</summary>
+		/// <returns>Returns nullable byte representing the RemSleepScore field</returns>
+		public byte? RemSleepScore
+		{
+			get
+			{
+				Object val = GetFieldValue(9, 0, Fit.SubfieldIndexMainField);
+				if (val == null)
+				{
+					return null;
+				}
 
-        /// <summary>
-        /// Set AverageStressDuringSleep field
-        /// Comment: Excludes stress during awake periods in the sleep window</summary>
-        /// <param name="averageStressDuringSleep_">Nullable field value to be set</param>
-        public void SetAverageStressDuringSleep(float? averageStressDuringSleep_)
-        {
-            SetFieldValue(15, 0, averageStressDuringSleep_, Fit.SubfieldIndexMainField);
-        }
-        
-        #endregion // Methods
-    } // Class
+				return (Convert.ToByte(val));
+
+			}
+			set
+			{
+				SetFieldValue(9, 0, value, Fit.SubfieldIndexMainField);
+			}
+		}
+
+		///<summary>
+		/// Retrieves the SleepRestlessnessScore field
+		/// Comment: Score that evaluates the amount of restlessness during sleep. If valid: 0 (worst) to 100 (best). If unknown: FIT_UINT8_INVALID.</summary>
+		/// <returns>Returns nullable byte representing the SleepRestlessnessScore field</returns>
+		public byte? SleepRestlessnessScore
+		{
+			get
+			{
+				Object val = GetFieldValue(10, 0, Fit.SubfieldIndexMainField);
+				if (val == null)
+				{
+					return null;
+				}
+
+				return (Convert.ToByte(val));
+
+			}
+			set
+			{
+				SetFieldValue(10, 0, value, Fit.SubfieldIndexMainField);
+			}
+		}
+
+		///<summary>
+		/// Retrieves the AwakeningsCount field
+		/// Comment: The number of awakenings during sleep.</summary>
+		/// <returns>Returns nullable byte representing the AwakeningsCount field</returns>
+		public byte? AwakeningsCount
+		{
+			get
+			{
+				Object val = GetFieldValue(11, 0, Fit.SubfieldIndexMainField);
+				if (val == null)
+				{
+					return null;
+				}
+
+				return (Convert.ToByte(val));
+
+			}
+			set
+			{
+				SetFieldValue(11, 0, value, Fit.SubfieldIndexMainField);
+			}
+		}
+
+		///<summary>
+		/// Retrieves the InterruptionsScore field
+		/// Comment: Score that evaluates the sleep interruptions. If valid: 0 (worst) to 100 (best). If unknown: FIT_UINT8_INVALID.</summary>
+		/// <returns>Returns nullable byte representing the InterruptionsScore field</returns>
+		public byte? InterruptionsScore
+		{
+			get
+			{
+				Object val = GetFieldValue(14, 0, Fit.SubfieldIndexMainField);
+				if (val == null)
+				{
+					return null;
+				}
+
+				return (Convert.ToByte(val));
+
+			}
+			set
+			{
+				SetFieldValue(14, 0, value, Fit.SubfieldIndexMainField);
+			}
+		}
+
+		///<summary>
+		/// Retrieves the AverageStressDuringSleep field
+		/// Comment: Excludes stress during awake periods in the sleep window</summary>
+		/// <returns>Returns nullable float representing the AverageStressDuringSleep field</returns>
+		public float? AverageStressDuringSleep
+		{
+			get
+			{
+				Object val = GetFieldValue(15, 0, Fit.SubfieldIndexMainField);
+				if (val == null)
+				{
+					return null;
+				}
+
+				return (Convert.ToSingle(val));
+
+			}
+			set
+			{
+				SetFieldValue(15, 0, value, Fit.SubfieldIndexMainField);
+			}
+		}
+
+		#endregion // Methods
+	} // Class
 } // namespace

--- a/Dynastream/Fit/Profile/Mesgs/SleepLevelMesg.cs
+++ b/Dynastream/Fit/Profile/Mesgs/SleepLevelMesg.cs
@@ -21,78 +21,75 @@ using System.Linq;
 
 namespace Dynastream.Fit
 {
-    /// <summary>
-    /// Implements the SleepLevel profile message.
-    /// </summary>
-    public class SleepLevelMesg : Mesg
-    {
-        #region Fields
-        #endregion
+	/// <summary>
+	/// Implements the SleepLevel profile message.
+	/// </summary>
+	public class SleepLevelMesg : Mesg
+	{
+		#region Fields
+		#endregion
 
-        /// <summary>
-        /// Field Numbers for <see cref="SleepLevelMesg"/>
-        /// </summary>
-        public sealed class FieldDefNum
-        {
-            public const byte Timestamp = 253;
-            public const byte SleepLevel = 0;
-            public const byte Invalid = Fit.FieldNumInvalid;
-        }
+		/// <summary>
+		/// Field Numbers for <see cref="SleepLevelMesg"/>
+		/// </summary>
+		public sealed class FieldDefNum
+		{
+			public const byte Timestamp = 253;
+			public const byte SleepLevel = 0;
+			public const byte Invalid = Fit.FieldNumInvalid;
+		}
 
-        #region Constructors
-        public SleepLevelMesg() : base(Profile.GetMesg(MesgNum.SleepLevel))
-        {
-        }
+		#region Constructors
+		public SleepLevelMesg() : base(Profile.GetMesg(MesgNum.SleepLevel))
+		{
+		}
 
-        public SleepLevelMesg(Mesg mesg) : base(mesg)
-        {
-        }
-        #endregion // Constructors
+		public SleepLevelMesg(Mesg mesg) : base(mesg)
+		{
+		}
+		#endregion // Constructors
 
-        #region Methods
-        ///<summary>
-        /// Retrieves the Timestamp field
-        /// Units: s</summary>
-        /// <returns>Returns DateTime representing the Timestamp field</returns>
-        public DateTime GetTimestamp()
-        {
-            Object val = GetFieldValue(253, 0, Fit.SubfieldIndexMainField);
-            if(val == null)
-            {
-                return null;
-            }
+		#region Methods
+		///<summary>
+		/// Retrieves the Timestamp field
+		/// Units: s</summary>
+		/// <returns>Returns DateTime representing the Timestamp field</returns>
+		public DateTime Timestamp
+		{
+			get
+			{
+				Object val = GetFieldValue(253, 0, Fit.SubfieldIndexMainField);
+				if (val == null)
+				{
+					return null;
+				}
 
-            return TimestampToDateTime(Convert.ToUInt32(val));
-            
-        }
+				return TimestampToDateTime(Convert.ToUInt32(val));
 
-        /// <summary>
-        /// Set Timestamp field
-        /// Units: s</summary>
-        /// <param name="timestamp_">Nullable field value to be set</param>
-        public void SetTimestamp(DateTime timestamp_)
-        {
-            SetFieldValue(253, 0, timestamp_.GetTimeStamp(), Fit.SubfieldIndexMainField);
-        }
-        
-        ///<summary>
-        /// Retrieves the SleepLevel field</summary>
-        /// <returns>Returns nullable SleepLevel enum representing the SleepLevel field</returns>
-        public SleepLevel? GetSleepLevel()
-        {
-            object obj = GetFieldValue(0, 0, Fit.SubfieldIndexMainField);
-            SleepLevel? value = obj == null ? (SleepLevel?)null : (SleepLevel)obj;
-            return value;
-        }
+			}
+			set
+			{
+				SetFieldValue(253, 0, value.GetTimeStamp(), Fit.SubfieldIndexMainField);
+			}
+		}
 
-        /// <summary>
-        /// Set SleepLevel field</summary>
-        /// <param name="sleepLevel_">Nullable field value to be set</param>
-        public void SetSleepLevel(SleepLevel? sleepLevel_)
-        {
-            SetFieldValue(0, 0, sleepLevel_, Fit.SubfieldIndexMainField);
-        }
-        
-        #endregion // Methods
-    } // Class
+		///<summary>
+		/// Retrieves the SleepLevel field</summary>
+		/// <returns>Returns nullable SleepLevel enum representing the SleepLevel field</returns>
+		public SleepLevel? SleepLevel
+		{
+			get
+			{
+				object obj = GetFieldValue(0, 0, Fit.SubfieldIndexMainField);
+				SleepLevel? value = obj == null ? (SleepLevel?)null : (SleepLevel)obj;
+				return value;
+			}
+			set
+			{
+				SetFieldValue(0, 0, value, Fit.SubfieldIndexMainField);
+			}
+		}
+
+		#endregion // Methods
+	} // Class
 } // namespace

--- a/Dynastream/Fit/Profile/Mesgs/SoftwareMesg.cs
+++ b/Dynastream/Fit/Profile/Mesgs/SoftwareMesg.cs
@@ -21,120 +21,116 @@ using System.Linq;
 
 namespace Dynastream.Fit
 {
-    /// <summary>
-    /// Implements the Software profile message.
-    /// </summary>
-    public class SoftwareMesg : Mesg
-    {
-        #region Fields
-        #endregion
+	/// <summary>
+	/// Implements the Software profile message.
+	/// </summary>
+	public class SoftwareMesg : Mesg
+	{
+		#region Fields
+		#endregion
 
-        /// <summary>
-        /// Field Numbers for <see cref="SoftwareMesg"/>
-        /// </summary>
-        public sealed class FieldDefNum
-        {
-            public const byte MessageIndex = 254;
-            public const byte Version = 3;
-            public const byte PartNumber = 5;
-            public const byte Invalid = Fit.FieldNumInvalid;
-        }
+		/// <summary>
+		/// Field Numbers for <see cref="SoftwareMesg"/>
+		/// </summary>
+		public sealed class FieldDefNum
+		{
+			public const byte MessageIndex = 254;
+			public const byte Version = 3;
+			public const byte PartNumber = 5;
+			public const byte Invalid = Fit.FieldNumInvalid;
+		}
 
-        #region Constructors
-        public SoftwareMesg() : base(Profile.GetMesg(MesgNum.Software))
-        {
-        }
+		#region Constructors
+		public SoftwareMesg() : base(Profile.GetMesg(MesgNum.Software))
+		{
+		}
 
-        public SoftwareMesg(Mesg mesg) : base(mesg)
-        {
-        }
-        #endregion // Constructors
+		public SoftwareMesg(Mesg mesg) : base(mesg)
+		{
+		}
+		#endregion // Constructors
 
-        #region Methods
-        ///<summary>
-        /// Retrieves the MessageIndex field</summary>
-        /// <returns>Returns nullable ushort representing the MessageIndex field</returns>
-        public ushort? GetMessageIndex()
-        {
-            Object val = GetFieldValue(254, 0, Fit.SubfieldIndexMainField);
-            if(val == null)
-            {
-                return null;
-            }
+		#region Methods
+		///<summary>
+		/// Retrieves the MessageIndex field</summary>
+		/// <returns>Returns nullable ushort representing the MessageIndex field</returns>
+		public ushort? MessageIndex
+		{
+			get
+			{
+				Object val = GetFieldValue(254, 0, Fit.SubfieldIndexMainField);
+				if (val == null)
+				{
+					return null;
+				}
 
-            return (Convert.ToUInt16(val));
-            
-        }
+				return (Convert.ToUInt16(val));
 
-        /// <summary>
-        /// Set MessageIndex field</summary>
-        /// <param name="messageIndex_">Nullable field value to be set</param>
-        public void SetMessageIndex(ushort? messageIndex_)
-        {
-            SetFieldValue(254, 0, messageIndex_, Fit.SubfieldIndexMainField);
-        }
-        
-        ///<summary>
-        /// Retrieves the Version field</summary>
-        /// <returns>Returns nullable float representing the Version field</returns>
-        public float? GetVersion()
-        {
-            Object val = GetFieldValue(3, 0, Fit.SubfieldIndexMainField);
-            if(val == null)
-            {
-                return null;
-            }
+			}
+			set
+			{
+				SetFieldValue(254, 0, value, Fit.SubfieldIndexMainField);
+			}
+		}
 
-            return (Convert.ToSingle(val));
-            
-        }
+		///<summary>
+		/// Retrieves the Version field</summary>
+		/// <returns>Returns nullable float representing the Version field</returns>
+		public float? Version
+		{
+			get
+			{
+				Object val = GetFieldValue(3, 0, Fit.SubfieldIndexMainField);
+				if (val == null)
+				{
+					return null;
+				}
 
-        /// <summary>
-        /// Set Version field</summary>
-        /// <param name="version_">Nullable field value to be set</param>
-        public void SetVersion(float? version_)
-        {
-            SetFieldValue(3, 0, version_, Fit.SubfieldIndexMainField);
-        }
-        
-        ///<summary>
-        /// Retrieves the PartNumber field</summary>
-        /// <returns>Returns byte[] representing the PartNumber field</returns>
-        public byte[] GetPartNumber()
-        {
-            byte[] data = (byte[])GetFieldValue(5, 0, Fit.SubfieldIndexMainField);
-            return data.Take(data.Length - 1).ToArray();
-        }
+				return (Convert.ToSingle(val));
 
-        ///<summary>
-        /// Retrieves the PartNumber field</summary>
-        /// <returns>Returns String representing the PartNumber field</returns>
-        public String GetPartNumberAsString()
-        {
-            byte[] data = (byte[])GetFieldValue(5, 0, Fit.SubfieldIndexMainField);
-            return data != null ? Encoding.UTF8.GetString(data, 0, data.Length - 1) : null;
-        }
+			}
+			set
+			{
+				SetFieldValue(3, 0, value, Fit.SubfieldIndexMainField);
+			}
+		}
 
-        ///<summary>
-        /// Set PartNumber field</summary>
-        /// <param name="partNumber_"> field value to be set</param>
-        public void SetPartNumber(String partNumber_)
-        {
-            byte[] data = Encoding.UTF8.GetBytes(partNumber_);
-            byte[] zdata = new byte[data.Length + 1];
-            data.CopyTo(zdata, 0);
-            SetFieldValue(5, 0, zdata, Fit.SubfieldIndexMainField);
-        }
+		///<summary>
+		/// Retrieves the PartNumber field</summary>
+		/// <returns>Returns byte[] representing the PartNumber field</returns>
+		public byte[] PartNumber
+		{
+			get
+			{
+				byte[] data = (byte[])GetFieldValue(5, 0, Fit.SubfieldIndexMainField);
+				return data.Take(data.Length - 1).ToArray();
+			}
+			set
+			{
+				SetFieldValue(5, 0, value, Fit.SubfieldIndexMainField);
+			}
+		}
 
-        
-        /// <summary>
-        /// Set PartNumber field</summary>
-        /// <param name="partNumber_">field value to be set</param>
-        public void SetPartNumber(byte[] partNumber_)
-        {
-            SetFieldValue(5, 0, partNumber_, Fit.SubfieldIndexMainField);
-        }
-        
-        #endregion // Methods
-    } // Class
+		///<summary>
+		/// Retrieves the PartNumber field</summary>
+		/// <returns>Returns String representing the PartNumber field</returns>
+		public String GetPartNumberAsString()
+		{
+			byte[] data = (byte[])GetFieldValue(5, 0, Fit.SubfieldIndexMainField);
+			return data != null ? Encoding.UTF8.GetString(data, 0, data.Length - 1) : null;
+		}
+
+		///<summary>
+		/// Set PartNumber field</summary>
+		/// <param name="partNumber_"> field value to be set</param>
+		public void SetPartNumber(String partNumber_)
+		{
+			byte[] data = Encoding.UTF8.GetBytes(partNumber_);
+			byte[] zdata = new byte[data.Length + 1];
+			data.CopyTo(zdata, 0);
+			SetFieldValue(5, 0, zdata, Fit.SubfieldIndexMainField);
+		}
+
+		#endregion // Methods
+	} // Class
 } // namespace

--- a/Dynastream/Fit/Profile/Mesgs/SpeedZoneMesg.cs
+++ b/Dynastream/Fit/Profile/Mesgs/SpeedZoneMesg.cs
@@ -21,122 +21,117 @@ using System.Linq;
 
 namespace Dynastream.Fit
 {
-    /// <summary>
-    /// Implements the SpeedZone profile message.
-    /// </summary>
-    public class SpeedZoneMesg : Mesg
-    {
-        #region Fields
-        #endregion
+	/// <summary>
+	/// Implements the SpeedZone profile message.
+	/// </summary>
+	public class SpeedZoneMesg : Mesg
+	{
+		#region Fields
+		#endregion
 
-        /// <summary>
-        /// Field Numbers for <see cref="SpeedZoneMesg"/>
-        /// </summary>
-        public sealed class FieldDefNum
-        {
-            public const byte MessageIndex = 254;
-            public const byte HighValue = 0;
-            public const byte Name = 1;
-            public const byte Invalid = Fit.FieldNumInvalid;
-        }
+		/// <summary>
+		/// Field Numbers for <see cref="SpeedZoneMesg"/>
+		/// </summary>
+		public sealed class FieldDefNum
+		{
+			public const byte MessageIndex = 254;
+			public const byte HighValue = 0;
+			public const byte Name = 1;
+			public const byte Invalid = Fit.FieldNumInvalid;
+		}
 
-        #region Constructors
-        public SpeedZoneMesg() : base(Profile.GetMesg(MesgNum.SpeedZone))
-        {
-        }
+		#region Constructors
+		public SpeedZoneMesg() : base(Profile.GetMesg(MesgNum.SpeedZone))
+		{
+		}
 
-        public SpeedZoneMesg(Mesg mesg) : base(mesg)
-        {
-        }
-        #endregion // Constructors
+		public SpeedZoneMesg(Mesg mesg) : base(mesg)
+		{
+		}
+		#endregion // Constructors
 
-        #region Methods
-        ///<summary>
-        /// Retrieves the MessageIndex field</summary>
-        /// <returns>Returns nullable ushort representing the MessageIndex field</returns>
-        public ushort? GetMessageIndex()
-        {
-            Object val = GetFieldValue(254, 0, Fit.SubfieldIndexMainField);
-            if(val == null)
-            {
-                return null;
-            }
+		#region Methods
+		///<summary>
+		/// Retrieves the MessageIndex field</summary>
+		/// <returns>Returns nullable ushort representing the MessageIndex field</returns>
+		public ushort? MessageIndex
+		{
+			get
+			{
+				Object val = GetFieldValue(254, 0, Fit.SubfieldIndexMainField);
+				if (val == null)
+				{
+					return null;
+				}
 
-            return (Convert.ToUInt16(val));
-            
-        }
+				return (Convert.ToUInt16(val));
 
-        /// <summary>
-        /// Set MessageIndex field</summary>
-        /// <param name="messageIndex_">Nullable field value to be set</param>
-        public void SetMessageIndex(ushort? messageIndex_)
-        {
-            SetFieldValue(254, 0, messageIndex_, Fit.SubfieldIndexMainField);
-        }
-        
-        ///<summary>
-        /// Retrieves the HighValue field
-        /// Units: m/s</summary>
-        /// <returns>Returns nullable float representing the HighValue field</returns>
-        public float? GetHighValue()
-        {
-            Object val = GetFieldValue(0, 0, Fit.SubfieldIndexMainField);
-            if(val == null)
-            {
-                return null;
-            }
+			}
+			set
+			{
+				SetFieldValue(254, 0, value, Fit.SubfieldIndexMainField);
+			}
+		}
 
-            return (Convert.ToSingle(val));
-            
-        }
+		///<summary>
+		/// Retrieves the HighValue field
+		/// Units: m/s</summary>
+		/// <returns>Returns nullable float representing the HighValue field</returns>
+		public float? HighValue
+		{
+			get
+			{
+				Object val = GetFieldValue(0, 0, Fit.SubfieldIndexMainField);
+				if (val == null)
+				{
+					return null;
+				}
 
-        /// <summary>
-        /// Set HighValue field
-        /// Units: m/s</summary>
-        /// <param name="highValue_">Nullable field value to be set</param>
-        public void SetHighValue(float? highValue_)
-        {
-            SetFieldValue(0, 0, highValue_, Fit.SubfieldIndexMainField);
-        }
-        
-        ///<summary>
-        /// Retrieves the Name field</summary>
-        /// <returns>Returns byte[] representing the Name field</returns>
-        public byte[] GetName()
-        {
-            byte[] data = (byte[])GetFieldValue(1, 0, Fit.SubfieldIndexMainField);
-            return data.Take(data.Length - 1).ToArray();
-        }
+				return (Convert.ToSingle(val));
 
-        ///<summary>
-        /// Retrieves the Name field</summary>
-        /// <returns>Returns String representing the Name field</returns>
-        public String GetNameAsString()
-        {
-            byte[] data = (byte[])GetFieldValue(1, 0, Fit.SubfieldIndexMainField);
-            return data != null ? Encoding.UTF8.GetString(data, 0, data.Length - 1) : null;
-        }
+			}
+			set
+			{
+				SetFieldValue(0, 0, value, Fit.SubfieldIndexMainField);
+			}
+		}
 
-        ///<summary>
-        /// Set Name field</summary>
-        /// <param name="name_"> field value to be set</param>
-        public void SetName(String name_)
-        {
-            byte[] data = Encoding.UTF8.GetBytes(name_);
-            byte[] zdata = new byte[data.Length + 1];
-            data.CopyTo(zdata, 0);
-            SetFieldValue(1, 0, zdata, Fit.SubfieldIndexMainField);
-        }
+		///<summary>
+		/// Retrieves the Name field</summary>
+		/// <returns>Returns byte[] representing the Name field</returns>
+		public byte[] Name
+		{
+			get
+			{
+				byte[] data = (byte[])GetFieldValue(1, 0, Fit.SubfieldIndexMainField);
+				return data.Take(data.Length - 1).ToArray();
+			}
+			set
+			{
+				SetFieldValue(1, 0, value, Fit.SubfieldIndexMainField);
+			}
+		}
 
-        
-        /// <summary>
-        /// Set Name field</summary>
-        /// <param name="name_">field value to be set</param>
-        public void SetName(byte[] name_)
-        {
-            SetFieldValue(1, 0, name_, Fit.SubfieldIndexMainField);
-        }
-        
-        #endregion // Methods
-    } // Class
+		///<summary>
+		/// Retrieves the Name field</summary>
+		/// <returns>Returns String representing the Name field</returns>
+		public String GetNameAsString()
+		{
+			byte[] data = (byte[])GetFieldValue(1, 0, Fit.SubfieldIndexMainField);
+			return data != null ? Encoding.UTF8.GetString(data, 0, data.Length - 1) : null;
+		}
+
+		///<summary>
+		/// Set Name field</summary>
+		/// <param name="name_"> field value to be set</param>
+		public void SetName(String name_)
+		{
+			byte[] data = Encoding.UTF8.GetBytes(name_);
+			byte[] zdata = new byte[data.Length + 1];
+			data.CopyTo(zdata, 0);
+			SetFieldValue(1, 0, zdata, Fit.SubfieldIndexMainField);
+		}
+
+		#endregion // Methods
+	} // Class
 } // namespace

--- a/Dynastream/Fit/Profile/Mesgs/SplitMesg.cs
+++ b/Dynastream/Fit/Profile/Mesgs/SplitMesg.cs
@@ -21,514 +21,480 @@ using System.Linq;
 
 namespace Dynastream.Fit
 {
-    /// <summary>
-    /// Implements the Split profile message.
-    /// </summary>
-    public class SplitMesg : Mesg
-    {
-        #region Fields
-        #endregion
+	/// <summary>
+	/// Implements the Split profile message.
+	/// </summary>
+	public class SplitMesg : Mesg
+	{
+		#region Fields
+		#endregion
 
-        /// <summary>
-        /// Field Numbers for <see cref="SplitMesg"/>
-        /// </summary>
-        public sealed class FieldDefNum
-        {
-            public const byte MessageIndex = 254;
-            public const byte SplitType = 0;
-            public const byte TotalElapsedTime = 1;
-            public const byte TotalTimerTime = 2;
-            public const byte TotalDistance = 3;
-            public const byte AvgSpeed = 4;
-            public const byte StartTime = 9;
-            public const byte TotalAscent = 13;
-            public const byte TotalDescent = 14;
-            public const byte StartPositionLat = 21;
-            public const byte StartPositionLong = 22;
-            public const byte EndPositionLat = 23;
-            public const byte EndPositionLong = 24;
-            public const byte MaxSpeed = 25;
-            public const byte AvgVertSpeed = 26;
-            public const byte EndTime = 27;
-            public const byte TotalCalories = 28;
-            public const byte StartElevation = 74;
-            public const byte TotalMovingTime = 110;
-            public const byte Invalid = Fit.FieldNumInvalid;
-        }
+		/// <summary>
+		/// Field Numbers for <see cref="SplitMesg"/>
+		/// </summary>
+		public sealed class FieldDefNum
+		{
+			public const byte MessageIndex = 254;
+			public const byte SplitType = 0;
+			public const byte TotalElapsedTime = 1;
+			public const byte TotalTimerTime = 2;
+			public const byte TotalDistance = 3;
+			public const byte AvgSpeed = 4;
+			public const byte StartTime = 9;
+			public const byte TotalAscent = 13;
+			public const byte TotalDescent = 14;
+			public const byte StartPositionLat = 21;
+			public const byte StartPositionLong = 22;
+			public const byte EndPositionLat = 23;
+			public const byte EndPositionLong = 24;
+			public const byte MaxSpeed = 25;
+			public const byte AvgVertSpeed = 26;
+			public const byte EndTime = 27;
+			public const byte TotalCalories = 28;
+			public const byte StartElevation = 74;
+			public const byte TotalMovingTime = 110;
+			public const byte Invalid = Fit.FieldNumInvalid;
+		}
 
-        #region Constructors
-        public SplitMesg() : base(Profile.GetMesg(MesgNum.Split))
-        {
-        }
+		#region Constructors
+		public SplitMesg() : base(Profile.GetMesg(MesgNum.Split))
+		{
+		}
 
-        public SplitMesg(Mesg mesg) : base(mesg)
-        {
-        }
-        #endregion // Constructors
+		public SplitMesg(Mesg mesg) : base(mesg)
+		{
+		}
+		#endregion // Constructors
 
-        #region Methods
-        ///<summary>
-        /// Retrieves the MessageIndex field</summary>
-        /// <returns>Returns nullable ushort representing the MessageIndex field</returns>
-        public ushort? GetMessageIndex()
-        {
-            Object val = GetFieldValue(254, 0, Fit.SubfieldIndexMainField);
-            if(val == null)
-            {
-                return null;
-            }
+		#region Methods
+		///<summary>
+		/// Retrieves the MessageIndex field</summary>
+		/// <returns>Returns nullable ushort representing the MessageIndex field</returns>
+		public ushort? MessageIndex
+		{
+			get
+			{
+				Object val = GetFieldValue(254, 0, Fit.SubfieldIndexMainField);
+				if (val == null)
+				{
+					return null;
+				}
 
-            return (Convert.ToUInt16(val));
-            
-        }
+				return (Convert.ToUInt16(val));
 
-        /// <summary>
-        /// Set MessageIndex field</summary>
-        /// <param name="messageIndex_">Nullable field value to be set</param>
-        public void SetMessageIndex(ushort? messageIndex_)
-        {
-            SetFieldValue(254, 0, messageIndex_, Fit.SubfieldIndexMainField);
-        }
-        
-        ///<summary>
-        /// Retrieves the SplitType field</summary>
-        /// <returns>Returns nullable SplitType enum representing the SplitType field</returns>
-        public SplitType? GetSplitType()
-        {
-            object obj = GetFieldValue(0, 0, Fit.SubfieldIndexMainField);
-            SplitType? value = obj == null ? (SplitType?)null : (SplitType)obj;
-            return value;
-        }
+			}
+			set
+			{
+				SetFieldValue(254, 0, value, Fit.SubfieldIndexMainField);
+			}
+		}
 
-        /// <summary>
-        /// Set SplitType field</summary>
-        /// <param name="splitType_">Nullable field value to be set</param>
-        public void SetSplitType(SplitType? splitType_)
-        {
-            SetFieldValue(0, 0, splitType_, Fit.SubfieldIndexMainField);
-        }
-        
-        ///<summary>
-        /// Retrieves the TotalElapsedTime field
-        /// Units: s</summary>
-        /// <returns>Returns nullable float representing the TotalElapsedTime field</returns>
-        public float? GetTotalElapsedTime()
-        {
-            Object val = GetFieldValue(1, 0, Fit.SubfieldIndexMainField);
-            if(val == null)
-            {
-                return null;
-            }
+		///<summary>
+		/// Retrieves the SplitType field</summary>
+		/// <returns>Returns nullable SplitType enum representing the SplitType field</returns>
+		public SplitType? SplitType
+		{
+			get
+			{
+				object obj = GetFieldValue(0, 0, Fit.SubfieldIndexMainField);
+				SplitType? value = obj == null ? (SplitType?)null : (SplitType)obj;
+				return value;
+			}
+			set
+			{
+				SetFieldValue(0, 0, value, Fit.SubfieldIndexMainField);
+			}
+		}
 
-            return (Convert.ToSingle(val));
-            
-        }
+		///<summary>
+		/// Retrieves the TotalElapsedTime field
+		/// Units: s</summary>
+		/// <returns>Returns nullable float representing the TotalElapsedTime field</returns>
+		public float? TotalElapsedTime
+		{
+			get
+			{
+				Object val = GetFieldValue(1, 0, Fit.SubfieldIndexMainField);
+				if (val == null)
+				{
+					return null;
+				}
 
-        /// <summary>
-        /// Set TotalElapsedTime field
-        /// Units: s</summary>
-        /// <param name="totalElapsedTime_">Nullable field value to be set</param>
-        public void SetTotalElapsedTime(float? totalElapsedTime_)
-        {
-            SetFieldValue(1, 0, totalElapsedTime_, Fit.SubfieldIndexMainField);
-        }
-        
-        ///<summary>
-        /// Retrieves the TotalTimerTime field
-        /// Units: s</summary>
-        /// <returns>Returns nullable float representing the TotalTimerTime field</returns>
-        public float? GetTotalTimerTime()
-        {
-            Object val = GetFieldValue(2, 0, Fit.SubfieldIndexMainField);
-            if(val == null)
-            {
-                return null;
-            }
+				return (Convert.ToSingle(val));
 
-            return (Convert.ToSingle(val));
-            
-        }
+			}
+			set
+			{
+				SetFieldValue(1, 0, value, Fit.SubfieldIndexMainField);
+			}
+		}
 
-        /// <summary>
-        /// Set TotalTimerTime field
-        /// Units: s</summary>
-        /// <param name="totalTimerTime_">Nullable field value to be set</param>
-        public void SetTotalTimerTime(float? totalTimerTime_)
-        {
-            SetFieldValue(2, 0, totalTimerTime_, Fit.SubfieldIndexMainField);
-        }
-        
-        ///<summary>
-        /// Retrieves the TotalDistance field
-        /// Units: m</summary>
-        /// <returns>Returns nullable float representing the TotalDistance field</returns>
-        public float? GetTotalDistance()
-        {
-            Object val = GetFieldValue(3, 0, Fit.SubfieldIndexMainField);
-            if(val == null)
-            {
-                return null;
-            }
+		///<summary>
+		/// Retrieves the TotalTimerTime field
+		/// Units: s</summary>
+		/// <returns>Returns nullable float representing the TotalTimerTime field</returns>
+		public float? TotalTimerTime
+		{
+			get
+			{
+				Object val = GetFieldValue(2, 0, Fit.SubfieldIndexMainField);
+				if (val == null)
+				{
+					return null;
+				}
 
-            return (Convert.ToSingle(val));
-            
-        }
+				return (Convert.ToSingle(val));
 
-        /// <summary>
-        /// Set TotalDistance field
-        /// Units: m</summary>
-        /// <param name="totalDistance_">Nullable field value to be set</param>
-        public void SetTotalDistance(float? totalDistance_)
-        {
-            SetFieldValue(3, 0, totalDistance_, Fit.SubfieldIndexMainField);
-        }
-        
-        ///<summary>
-        /// Retrieves the AvgSpeed field
-        /// Units: m/s</summary>
-        /// <returns>Returns nullable float representing the AvgSpeed field</returns>
-        public float? GetAvgSpeed()
-        {
-            Object val = GetFieldValue(4, 0, Fit.SubfieldIndexMainField);
-            if(val == null)
-            {
-                return null;
-            }
+			}
+			set
+			{
+				SetFieldValue(2, 0, value, Fit.SubfieldIndexMainField);
+			}
+		}
 
-            return (Convert.ToSingle(val));
-            
-        }
+		///<summary>
+		/// Retrieves the TotalDistance field
+		/// Units: m</summary>
+		/// <returns>Returns nullable float representing the TotalDistance field</returns>
+		public float? TotalDistance
+		{
+			get
+			{
+				Object val = GetFieldValue(3, 0, Fit.SubfieldIndexMainField);
+				if (val == null)
+				{
+					return null;
+				}
 
-        /// <summary>
-        /// Set AvgSpeed field
-        /// Units: m/s</summary>
-        /// <param name="avgSpeed_">Nullable field value to be set</param>
-        public void SetAvgSpeed(float? avgSpeed_)
-        {
-            SetFieldValue(4, 0, avgSpeed_, Fit.SubfieldIndexMainField);
-        }
-        
-        ///<summary>
-        /// Retrieves the StartTime field</summary>
-        /// <returns>Returns DateTime representing the StartTime field</returns>
-        public DateTime GetStartTime()
-        {
-            Object val = GetFieldValue(9, 0, Fit.SubfieldIndexMainField);
-            if(val == null)
-            {
-                return null;
-            }
+				return (Convert.ToSingle(val));
 
-            return TimestampToDateTime(Convert.ToUInt32(val));
-            
-        }
+			}
+			set
+			{
+				SetFieldValue(3, 0, value, Fit.SubfieldIndexMainField);
+			}
+		}
 
-        /// <summary>
-        /// Set StartTime field</summary>
-        /// <param name="startTime_">Nullable field value to be set</param>
-        public void SetStartTime(DateTime startTime_)
-        {
-            SetFieldValue(9, 0, startTime_.GetTimeStamp(), Fit.SubfieldIndexMainField);
-        }
-        
-        ///<summary>
-        /// Retrieves the TotalAscent field
-        /// Units: m</summary>
-        /// <returns>Returns nullable ushort representing the TotalAscent field</returns>
-        public ushort? GetTotalAscent()
-        {
-            Object val = GetFieldValue(13, 0, Fit.SubfieldIndexMainField);
-            if(val == null)
-            {
-                return null;
-            }
+		///<summary>
+		/// Retrieves the AvgSpeed field
+		/// Units: m/s</summary>
+		/// <returns>Returns nullable float representing the AvgSpeed field</returns>
+		public float? AvgSpeed
+		{
+			get
+			{
+				Object val = GetFieldValue(4, 0, Fit.SubfieldIndexMainField);
+				if (val == null)
+				{
+					return null;
+				}
 
-            return (Convert.ToUInt16(val));
-            
-        }
+				return (Convert.ToSingle(val));
 
-        /// <summary>
-        /// Set TotalAscent field
-        /// Units: m</summary>
-        /// <param name="totalAscent_">Nullable field value to be set</param>
-        public void SetTotalAscent(ushort? totalAscent_)
-        {
-            SetFieldValue(13, 0, totalAscent_, Fit.SubfieldIndexMainField);
-        }
-        
-        ///<summary>
-        /// Retrieves the TotalDescent field
-        /// Units: m</summary>
-        /// <returns>Returns nullable ushort representing the TotalDescent field</returns>
-        public ushort? GetTotalDescent()
-        {
-            Object val = GetFieldValue(14, 0, Fit.SubfieldIndexMainField);
-            if(val == null)
-            {
-                return null;
-            }
+			}
+			set
+			{
+				SetFieldValue(4, 0, value, Fit.SubfieldIndexMainField);
+			}
+		}
 
-            return (Convert.ToUInt16(val));
-            
-        }
+		///<summary>
+		/// Retrieves the StartTime field</summary>
+		/// <returns>Returns DateTime representing the StartTime field</returns>
+		public DateTime StartTime
+		{
+			get
+			{
+				Object val = GetFieldValue(9, 0, Fit.SubfieldIndexMainField);
+				if (val == null)
+				{
+					return null;
+				}
 
-        /// <summary>
-        /// Set TotalDescent field
-        /// Units: m</summary>
-        /// <param name="totalDescent_">Nullable field value to be set</param>
-        public void SetTotalDescent(ushort? totalDescent_)
-        {
-            SetFieldValue(14, 0, totalDescent_, Fit.SubfieldIndexMainField);
-        }
-        
-        ///<summary>
-        /// Retrieves the StartPositionLat field
-        /// Units: semicircles</summary>
-        /// <returns>Returns nullable int representing the StartPositionLat field</returns>
-        public int? GetStartPositionLat()
-        {
-            Object val = GetFieldValue(21, 0, Fit.SubfieldIndexMainField);
-            if(val == null)
-            {
-                return null;
-            }
+				return TimestampToDateTime(Convert.ToUInt32(val));
 
-            return (Convert.ToInt32(val));
-            
-        }
+			}
+			set
+			{
+				SetFieldValue(9, 0, value.GetTimeStamp(), Fit.SubfieldIndexMainField);
+			}
+		}
 
-        /// <summary>
-        /// Set StartPositionLat field
-        /// Units: semicircles</summary>
-        /// <param name="startPositionLat_">Nullable field value to be set</param>
-        public void SetStartPositionLat(int? startPositionLat_)
-        {
-            SetFieldValue(21, 0, startPositionLat_, Fit.SubfieldIndexMainField);
-        }
-        
-        ///<summary>
-        /// Retrieves the StartPositionLong field
-        /// Units: semicircles</summary>
-        /// <returns>Returns nullable int representing the StartPositionLong field</returns>
-        public int? GetStartPositionLong()
-        {
-            Object val = GetFieldValue(22, 0, Fit.SubfieldIndexMainField);
-            if(val == null)
-            {
-                return null;
-            }
+		///<summary>
+		/// Retrieves the TotalAscent field
+		/// Units: m</summary>
+		/// <returns>Returns nullable ushort representing the TotalAscent field</returns>
+		public ushort? TotalAscent
+		{
+			get
+			{
+				Object val = GetFieldValue(13, 0, Fit.SubfieldIndexMainField);
+				if (val == null)
+				{
+					return null;
+				}
 
-            return (Convert.ToInt32(val));
-            
-        }
+				return (Convert.ToUInt16(val));
 
-        /// <summary>
-        /// Set StartPositionLong field
-        /// Units: semicircles</summary>
-        /// <param name="startPositionLong_">Nullable field value to be set</param>
-        public void SetStartPositionLong(int? startPositionLong_)
-        {
-            SetFieldValue(22, 0, startPositionLong_, Fit.SubfieldIndexMainField);
-        }
-        
-        ///<summary>
-        /// Retrieves the EndPositionLat field
-        /// Units: semicircles</summary>
-        /// <returns>Returns nullable int representing the EndPositionLat field</returns>
-        public int? GetEndPositionLat()
-        {
-            Object val = GetFieldValue(23, 0, Fit.SubfieldIndexMainField);
-            if(val == null)
-            {
-                return null;
-            }
+			}
+			set
+			{
+				SetFieldValue(13, 0, value, Fit.SubfieldIndexMainField);
+			}
+		}
 
-            return (Convert.ToInt32(val));
-            
-        }
+		///<summary>
+		/// Retrieves the TotalDescent field
+		/// Units: m</summary>
+		/// <returns>Returns nullable ushort representing the TotalDescent field</returns>
+		public ushort? TotalDescent
+		{
+			get
+			{
+				Object val = GetFieldValue(14, 0, Fit.SubfieldIndexMainField);
+				if (val == null)
+				{
+					return null;
+				}
 
-        /// <summary>
-        /// Set EndPositionLat field
-        /// Units: semicircles</summary>
-        /// <param name="endPositionLat_">Nullable field value to be set</param>
-        public void SetEndPositionLat(int? endPositionLat_)
-        {
-            SetFieldValue(23, 0, endPositionLat_, Fit.SubfieldIndexMainField);
-        }
-        
-        ///<summary>
-        /// Retrieves the EndPositionLong field
-        /// Units: semicircles</summary>
-        /// <returns>Returns nullable int representing the EndPositionLong field</returns>
-        public int? GetEndPositionLong()
-        {
-            Object val = GetFieldValue(24, 0, Fit.SubfieldIndexMainField);
-            if(val == null)
-            {
-                return null;
-            }
+				return (Convert.ToUInt16(val));
 
-            return (Convert.ToInt32(val));
-            
-        }
+			}
+			set
+			{
+				SetFieldValue(14, 0, value, Fit.SubfieldIndexMainField);
+			}
+		}
 
-        /// <summary>
-        /// Set EndPositionLong field
-        /// Units: semicircles</summary>
-        /// <param name="endPositionLong_">Nullable field value to be set</param>
-        public void SetEndPositionLong(int? endPositionLong_)
-        {
-            SetFieldValue(24, 0, endPositionLong_, Fit.SubfieldIndexMainField);
-        }
-        
-        ///<summary>
-        /// Retrieves the MaxSpeed field
-        /// Units: m/s</summary>
-        /// <returns>Returns nullable float representing the MaxSpeed field</returns>
-        public float? GetMaxSpeed()
-        {
-            Object val = GetFieldValue(25, 0, Fit.SubfieldIndexMainField);
-            if(val == null)
-            {
-                return null;
-            }
+		///<summary>
+		/// Retrieves the StartPositionLat field
+		/// Units: semicircles</summary>
+		/// <returns>Returns nullable int representing the StartPositionLat field</returns>
+		public int? StartPositionLat
+		{
+			get
+			{
+				Object val = GetFieldValue(21, 0, Fit.SubfieldIndexMainField);
+				if (val == null)
+				{
+					return null;
+				}
 
-            return (Convert.ToSingle(val));
-            
-        }
+				return (Convert.ToInt32(val));
 
-        /// <summary>
-        /// Set MaxSpeed field
-        /// Units: m/s</summary>
-        /// <param name="maxSpeed_">Nullable field value to be set</param>
-        public void SetMaxSpeed(float? maxSpeed_)
-        {
-            SetFieldValue(25, 0, maxSpeed_, Fit.SubfieldIndexMainField);
-        }
-        
-        ///<summary>
-        /// Retrieves the AvgVertSpeed field
-        /// Units: m/s</summary>
-        /// <returns>Returns nullable float representing the AvgVertSpeed field</returns>
-        public float? GetAvgVertSpeed()
-        {
-            Object val = GetFieldValue(26, 0, Fit.SubfieldIndexMainField);
-            if(val == null)
-            {
-                return null;
-            }
+			}
+			set
+			{
+				SetFieldValue(21, 0, value, Fit.SubfieldIndexMainField);
+			}
+		}
 
-            return (Convert.ToSingle(val));
-            
-        }
+		///<summary>
+		/// Retrieves the StartPositionLong field
+		/// Units: semicircles</summary>
+		/// <returns>Returns nullable int representing the StartPositionLong field</returns>
+		public int? StartPositionLong
+		{
+			get
+			{
+				Object val = GetFieldValue(22, 0, Fit.SubfieldIndexMainField);
+				if (val == null)
+				{
+					return null;
+				}
 
-        /// <summary>
-        /// Set AvgVertSpeed field
-        /// Units: m/s</summary>
-        /// <param name="avgVertSpeed_">Nullable field value to be set</param>
-        public void SetAvgVertSpeed(float? avgVertSpeed_)
-        {
-            SetFieldValue(26, 0, avgVertSpeed_, Fit.SubfieldIndexMainField);
-        }
-        
-        ///<summary>
-        /// Retrieves the EndTime field</summary>
-        /// <returns>Returns DateTime representing the EndTime field</returns>
-        public DateTime GetEndTime()
-        {
-            Object val = GetFieldValue(27, 0, Fit.SubfieldIndexMainField);
-            if(val == null)
-            {
-                return null;
-            }
+				return (Convert.ToInt32(val));
 
-            return TimestampToDateTime(Convert.ToUInt32(val));
-            
-        }
+			}
+			set
+			{
+				SetFieldValue(22, 0, value, Fit.SubfieldIndexMainField);
+			}
+		}
 
-        /// <summary>
-        /// Set EndTime field</summary>
-        /// <param name="endTime_">Nullable field value to be set</param>
-        public void SetEndTime(DateTime endTime_)
-        {
-            SetFieldValue(27, 0, endTime_.GetTimeStamp(), Fit.SubfieldIndexMainField);
-        }
-        
-        ///<summary>
-        /// Retrieves the TotalCalories field
-        /// Units: kcal</summary>
-        /// <returns>Returns nullable uint representing the TotalCalories field</returns>
-        public uint? GetTotalCalories()
-        {
-            Object val = GetFieldValue(28, 0, Fit.SubfieldIndexMainField);
-            if(val == null)
-            {
-                return null;
-            }
+		///<summary>
+		/// Retrieves the EndPositionLat field
+		/// Units: semicircles</summary>
+		/// <returns>Returns nullable int representing the EndPositionLat field</returns>
+		public int? EndPositionLat
+		{
+			get
+			{
+				Object val = GetFieldValue(23, 0, Fit.SubfieldIndexMainField);
+				if (val == null)
+				{
+					return null;
+				}
 
-            return (Convert.ToUInt32(val));
-            
-        }
+				return (Convert.ToInt32(val));
 
-        /// <summary>
-        /// Set TotalCalories field
-        /// Units: kcal</summary>
-        /// <param name="totalCalories_">Nullable field value to be set</param>
-        public void SetTotalCalories(uint? totalCalories_)
-        {
-            SetFieldValue(28, 0, totalCalories_, Fit.SubfieldIndexMainField);
-        }
-        
-        ///<summary>
-        /// Retrieves the StartElevation field
-        /// Units: m</summary>
-        /// <returns>Returns nullable float representing the StartElevation field</returns>
-        public float? GetStartElevation()
-        {
-            Object val = GetFieldValue(74, 0, Fit.SubfieldIndexMainField);
-            if(val == null)
-            {
-                return null;
-            }
+			}
+			set
+			{
+				SetFieldValue(23, 0, value, Fit.SubfieldIndexMainField);
+			}
+		}
 
-            return (Convert.ToSingle(val));
-            
-        }
+		///<summary>
+		/// Retrieves the EndPositionLong field
+		/// Units: semicircles</summary>
+		/// <returns>Returns nullable int representing the EndPositionLong field</returns>
+		public int? EndPositionLong
+		{
+			get
+			{
+				Object val = GetFieldValue(24, 0, Fit.SubfieldIndexMainField);
+				if (val == null)
+				{
+					return null;
+				}
 
-        /// <summary>
-        /// Set StartElevation field
-        /// Units: m</summary>
-        /// <param name="startElevation_">Nullable field value to be set</param>
-        public void SetStartElevation(float? startElevation_)
-        {
-            SetFieldValue(74, 0, startElevation_, Fit.SubfieldIndexMainField);
-        }
-        
-        ///<summary>
-        /// Retrieves the TotalMovingTime field
-        /// Units: s</summary>
-        /// <returns>Returns nullable float representing the TotalMovingTime field</returns>
-        public float? GetTotalMovingTime()
-        {
-            Object val = GetFieldValue(110, 0, Fit.SubfieldIndexMainField);
-            if(val == null)
-            {
-                return null;
-            }
+				return (Convert.ToInt32(val));
 
-            return (Convert.ToSingle(val));
-            
-        }
+			}
+			set
+			{
+				SetFieldValue(24, 0, value, Fit.SubfieldIndexMainField);
+			}
+		}
 
-        /// <summary>
-        /// Set TotalMovingTime field
-        /// Units: s</summary>
-        /// <param name="totalMovingTime_">Nullable field value to be set</param>
-        public void SetTotalMovingTime(float? totalMovingTime_)
-        {
-            SetFieldValue(110, 0, totalMovingTime_, Fit.SubfieldIndexMainField);
-        }
-        
-        #endregion // Methods
-    } // Class
+		///<summary>
+		/// Retrieves the MaxSpeed field
+		/// Units: m/s</summary>
+		/// <returns>Returns nullable float representing the MaxSpeed field</returns>
+		public float? MaxSpeed
+		{
+			get
+			{
+				Object val = GetFieldValue(25, 0, Fit.SubfieldIndexMainField);
+				if (val == null)
+				{
+					return null;
+				}
+
+				return (Convert.ToSingle(val));
+
+			}
+			set
+			{
+				SetFieldValue(25, 0, value, Fit.SubfieldIndexMainField);
+			}
+		}
+
+		///<summary>
+		/// Retrieves the AvgVertSpeed field
+		/// Units: m/s</summary>
+		/// <returns>Returns nullable float representing the AvgVertSpeed field</returns>
+		public float? AvgVertSpeed
+		{
+			get
+			{
+				Object val = GetFieldValue(26, 0, Fit.SubfieldIndexMainField);
+				if (val == null)
+				{
+					return null;
+				}
+
+				return (Convert.ToSingle(val));
+
+			}
+			set
+			{
+				SetFieldValue(26, 0, value, Fit.SubfieldIndexMainField);
+			}
+		}
+
+		///<summary>
+		/// Retrieves the EndTime field</summary>
+		/// <returns>Returns DateTime representing the EndTime field</returns>
+		public DateTime EndTime
+		{
+			get
+			{
+				Object val = GetFieldValue(27, 0, Fit.SubfieldIndexMainField);
+				if (val == null)
+				{
+					return null;
+				}
+
+				return TimestampToDateTime(Convert.ToUInt32(val));
+
+			}
+			set
+			{
+				SetFieldValue(27, 0, value.GetTimeStamp(), Fit.SubfieldIndexMainField);
+			}
+		}
+
+		///<summary>
+		/// Retrieves the TotalCalories field
+		/// Units: kcal</summary>
+		/// <returns>Returns nullable uint representing the TotalCalories field</returns>
+		public uint? TotalCalories
+		{
+			get
+			{
+				Object val = GetFieldValue(28, 0, Fit.SubfieldIndexMainField);
+				if (val == null)
+				{
+					return null;
+				}
+
+				return (Convert.ToUInt32(val));
+
+			}
+			set
+			{
+				SetFieldValue(28, 0, value, Fit.SubfieldIndexMainField);
+			}
+		}
+
+		///<summary>
+		/// Retrieves the StartElevation field
+		/// Units: m</summary>
+		/// <returns>Returns nullable float representing the StartElevation field</returns>
+		public float? StartElevation
+		{
+			get
+			{
+				Object val = GetFieldValue(74, 0, Fit.SubfieldIndexMainField);
+				if (val == null)
+				{
+					return null;
+				}
+
+				return (Convert.ToSingle(val));
+
+			}
+			set
+			{
+				SetFieldValue(74, 0, value, Fit.SubfieldIndexMainField);
+			}
+		}
+
+		///<summary>
+		/// Retrieves the TotalMovingTime field
+		/// Units: s</summary>
+		/// <returns>Returns nullable float representing the TotalMovingTime field</returns>
+		public float? TotalMovingTime
+		{
+			get
+			{
+				Object val = GetFieldValue(110, 0, Fit.SubfieldIndexMainField);
+				if (val == null)
+				{
+					return null;
+				}
+
+				return (Convert.ToSingle(val));
+
+			}
+			set
+			{
+				SetFieldValue(110, 0, value, Fit.SubfieldIndexMainField);
+			}
+		}
+
+		#endregion // Methods
+	} // Class
 } // namespace

--- a/Dynastream/Fit/Profile/Mesgs/SplitSummaryMesg.cs
+++ b/Dynastream/Fit/Profile/Mesgs/SplitSummaryMesg.cs
@@ -21,386 +21,361 @@ using System.Linq;
 
 namespace Dynastream.Fit
 {
-    /// <summary>
-    /// Implements the SplitSummary profile message.
-    /// </summary>
-    public class SplitSummaryMesg : Mesg
-    {
-        #region Fields
-        #endregion
+	/// <summary>
+	/// Implements the SplitSummary profile message.
+	/// </summary>
+	public class SplitSummaryMesg : Mesg
+	{
+		#region Fields
+		#endregion
 
-        /// <summary>
-        /// Field Numbers for <see cref="SplitSummaryMesg"/>
-        /// </summary>
-        public sealed class FieldDefNum
-        {
-            public const byte MessageIndex = 254;
-            public const byte SplitType = 0;
-            public const byte NumSplits = 3;
-            public const byte TotalTimerTime = 4;
-            public const byte TotalDistance = 5;
-            public const byte AvgSpeed = 6;
-            public const byte MaxSpeed = 7;
-            public const byte TotalAscent = 8;
-            public const byte TotalDescent = 9;
-            public const byte AvgHeartRate = 10;
-            public const byte MaxHeartRate = 11;
-            public const byte AvgVertSpeed = 12;
-            public const byte TotalCalories = 13;
-            public const byte TotalMovingTime = 77;
-            public const byte Invalid = Fit.FieldNumInvalid;
-        }
+		/// <summary>
+		/// Field Numbers for <see cref="SplitSummaryMesg"/>
+		/// </summary>
+		public sealed class FieldDefNum
+		{
+			public const byte MessageIndex = 254;
+			public const byte SplitType = 0;
+			public const byte NumSplits = 3;
+			public const byte TotalTimerTime = 4;
+			public const byte TotalDistance = 5;
+			public const byte AvgSpeed = 6;
+			public const byte MaxSpeed = 7;
+			public const byte TotalAscent = 8;
+			public const byte TotalDescent = 9;
+			public const byte AvgHeartRate = 10;
+			public const byte MaxHeartRate = 11;
+			public const byte AvgVertSpeed = 12;
+			public const byte TotalCalories = 13;
+			public const byte TotalMovingTime = 77;
+			public const byte Invalid = Fit.FieldNumInvalid;
+		}
 
-        #region Constructors
-        public SplitSummaryMesg() : base(Profile.GetMesg(MesgNum.SplitSummary))
-        {
-        }
+		#region Constructors
+		public SplitSummaryMesg() : base(Profile.GetMesg(MesgNum.SplitSummary))
+		{
+		}
 
-        public SplitSummaryMesg(Mesg mesg) : base(mesg)
-        {
-        }
-        #endregion // Constructors
+		public SplitSummaryMesg(Mesg mesg) : base(mesg)
+		{
+		}
+		#endregion // Constructors
 
-        #region Methods
-        ///<summary>
-        /// Retrieves the MessageIndex field</summary>
-        /// <returns>Returns nullable ushort representing the MessageIndex field</returns>
-        public ushort? GetMessageIndex()
-        {
-            Object val = GetFieldValue(254, 0, Fit.SubfieldIndexMainField);
-            if(val == null)
-            {
-                return null;
-            }
+		#region Methods
+		///<summary>
+		/// Retrieves the MessageIndex field</summary>
+		/// <returns>Returns nullable ushort representing the MessageIndex field</returns>
+		public ushort? MessageIndex
+		{
+			get
+			{
+				Object val = GetFieldValue(254, 0, Fit.SubfieldIndexMainField);
+				if (val == null)
+				{
+					return null;
+				}
 
-            return (Convert.ToUInt16(val));
-            
-        }
+				return (Convert.ToUInt16(val));
 
-        /// <summary>
-        /// Set MessageIndex field</summary>
-        /// <param name="messageIndex_">Nullable field value to be set</param>
-        public void SetMessageIndex(ushort? messageIndex_)
-        {
-            SetFieldValue(254, 0, messageIndex_, Fit.SubfieldIndexMainField);
-        }
-        
-        ///<summary>
-        /// Retrieves the SplitType field</summary>
-        /// <returns>Returns nullable SplitType enum representing the SplitType field</returns>
-        public SplitType? GetSplitType()
-        {
-            object obj = GetFieldValue(0, 0, Fit.SubfieldIndexMainField);
-            SplitType? value = obj == null ? (SplitType?)null : (SplitType)obj;
-            return value;
-        }
+			}
+			set
+			{
+				SetFieldValue(254, 0, value, Fit.SubfieldIndexMainField);
+			}
+		}
 
-        /// <summary>
-        /// Set SplitType field</summary>
-        /// <param name="splitType_">Nullable field value to be set</param>
-        public void SetSplitType(SplitType? splitType_)
-        {
-            SetFieldValue(0, 0, splitType_, Fit.SubfieldIndexMainField);
-        }
-        
-        ///<summary>
-        /// Retrieves the NumSplits field</summary>
-        /// <returns>Returns nullable ushort representing the NumSplits field</returns>
-        public ushort? GetNumSplits()
-        {
-            Object val = GetFieldValue(3, 0, Fit.SubfieldIndexMainField);
-            if(val == null)
-            {
-                return null;
-            }
+		///<summary>
+		/// Retrieves the SplitType field</summary>
+		/// <returns>Returns nullable SplitType enum representing the SplitType field</returns>
+		public SplitType? SplitType
+		{
+			get
+			{
+				object obj = GetFieldValue(0, 0, Fit.SubfieldIndexMainField);
+				SplitType? value = obj == null ? (SplitType?)null : (SplitType)obj;
+				return value;
+			}
+			set
+			{
+				SetFieldValue(0, 0, value, Fit.SubfieldIndexMainField);
+			}
+		}
 
-            return (Convert.ToUInt16(val));
-            
-        }
+		///<summary>
+		/// Retrieves the NumSplits field</summary>
+		/// <returns>Returns nullable ushort representing the NumSplits field</returns>
+		public ushort? NumSplits
+		{
+			get
+			{
+				Object val = GetFieldValue(3, 0, Fit.SubfieldIndexMainField);
+				if (val == null)
+				{
+					return null;
+				}
 
-        /// <summary>
-        /// Set NumSplits field</summary>
-        /// <param name="numSplits_">Nullable field value to be set</param>
-        public void SetNumSplits(ushort? numSplits_)
-        {
-            SetFieldValue(3, 0, numSplits_, Fit.SubfieldIndexMainField);
-        }
-        
-        ///<summary>
-        /// Retrieves the TotalTimerTime field
-        /// Units: s</summary>
-        /// <returns>Returns nullable float representing the TotalTimerTime field</returns>
-        public float? GetTotalTimerTime()
-        {
-            Object val = GetFieldValue(4, 0, Fit.SubfieldIndexMainField);
-            if(val == null)
-            {
-                return null;
-            }
+				return (Convert.ToUInt16(val));
 
-            return (Convert.ToSingle(val));
-            
-        }
+			}
+			set
+			{
+				SetFieldValue(3, 0, value, Fit.SubfieldIndexMainField);
+			}
+		}
 
-        /// <summary>
-        /// Set TotalTimerTime field
-        /// Units: s</summary>
-        /// <param name="totalTimerTime_">Nullable field value to be set</param>
-        public void SetTotalTimerTime(float? totalTimerTime_)
-        {
-            SetFieldValue(4, 0, totalTimerTime_, Fit.SubfieldIndexMainField);
-        }
-        
-        ///<summary>
-        /// Retrieves the TotalDistance field
-        /// Units: m</summary>
-        /// <returns>Returns nullable float representing the TotalDistance field</returns>
-        public float? GetTotalDistance()
-        {
-            Object val = GetFieldValue(5, 0, Fit.SubfieldIndexMainField);
-            if(val == null)
-            {
-                return null;
-            }
+		///<summary>
+		/// Retrieves the TotalTimerTime field
+		/// Units: s</summary>
+		/// <returns>Returns nullable float representing the TotalTimerTime field</returns>
+		public float? TotalTimerTime
+		{
+			get
+			{
+				Object val = GetFieldValue(4, 0, Fit.SubfieldIndexMainField);
+				if (val == null)
+				{
+					return null;
+				}
 
-            return (Convert.ToSingle(val));
-            
-        }
+				return (Convert.ToSingle(val));
 
-        /// <summary>
-        /// Set TotalDistance field
-        /// Units: m</summary>
-        /// <param name="totalDistance_">Nullable field value to be set</param>
-        public void SetTotalDistance(float? totalDistance_)
-        {
-            SetFieldValue(5, 0, totalDistance_, Fit.SubfieldIndexMainField);
-        }
-        
-        ///<summary>
-        /// Retrieves the AvgSpeed field
-        /// Units: m/s</summary>
-        /// <returns>Returns nullable float representing the AvgSpeed field</returns>
-        public float? GetAvgSpeed()
-        {
-            Object val = GetFieldValue(6, 0, Fit.SubfieldIndexMainField);
-            if(val == null)
-            {
-                return null;
-            }
+			}
+			set
+			{
+				SetFieldValue(4, 0, value, Fit.SubfieldIndexMainField);
+			}
+		}
 
-            return (Convert.ToSingle(val));
-            
-        }
+		///<summary>
+		/// Retrieves the TotalDistance field
+		/// Units: m</summary>
+		/// <returns>Returns nullable float representing the TotalDistance field</returns>
+		public float? TotalDistance
+		{
+			get
+			{
+				Object val = GetFieldValue(5, 0, Fit.SubfieldIndexMainField);
+				if (val == null)
+				{
+					return null;
+				}
 
-        /// <summary>
-        /// Set AvgSpeed field
-        /// Units: m/s</summary>
-        /// <param name="avgSpeed_">Nullable field value to be set</param>
-        public void SetAvgSpeed(float? avgSpeed_)
-        {
-            SetFieldValue(6, 0, avgSpeed_, Fit.SubfieldIndexMainField);
-        }
-        
-        ///<summary>
-        /// Retrieves the MaxSpeed field
-        /// Units: m/s</summary>
-        /// <returns>Returns nullable float representing the MaxSpeed field</returns>
-        public float? GetMaxSpeed()
-        {
-            Object val = GetFieldValue(7, 0, Fit.SubfieldIndexMainField);
-            if(val == null)
-            {
-                return null;
-            }
+				return (Convert.ToSingle(val));
 
-            return (Convert.ToSingle(val));
-            
-        }
+			}
+			set
+			{
+				SetFieldValue(5, 0, value, Fit.SubfieldIndexMainField);
+			}
+		}
 
-        /// <summary>
-        /// Set MaxSpeed field
-        /// Units: m/s</summary>
-        /// <param name="maxSpeed_">Nullable field value to be set</param>
-        public void SetMaxSpeed(float? maxSpeed_)
-        {
-            SetFieldValue(7, 0, maxSpeed_, Fit.SubfieldIndexMainField);
-        }
-        
-        ///<summary>
-        /// Retrieves the TotalAscent field
-        /// Units: m</summary>
-        /// <returns>Returns nullable ushort representing the TotalAscent field</returns>
-        public ushort? GetTotalAscent()
-        {
-            Object val = GetFieldValue(8, 0, Fit.SubfieldIndexMainField);
-            if(val == null)
-            {
-                return null;
-            }
+		///<summary>
+		/// Retrieves the AvgSpeed field
+		/// Units: m/s</summary>
+		/// <returns>Returns nullable float representing the AvgSpeed field</returns>
+		public float? AvgSpeed
+		{
+			get
+			{
+				Object val = GetFieldValue(6, 0, Fit.SubfieldIndexMainField);
+				if (val == null)
+				{
+					return null;
+				}
 
-            return (Convert.ToUInt16(val));
-            
-        }
+				return (Convert.ToSingle(val));
 
-        /// <summary>
-        /// Set TotalAscent field
-        /// Units: m</summary>
-        /// <param name="totalAscent_">Nullable field value to be set</param>
-        public void SetTotalAscent(ushort? totalAscent_)
-        {
-            SetFieldValue(8, 0, totalAscent_, Fit.SubfieldIndexMainField);
-        }
-        
-        ///<summary>
-        /// Retrieves the TotalDescent field
-        /// Units: m</summary>
-        /// <returns>Returns nullable ushort representing the TotalDescent field</returns>
-        public ushort? GetTotalDescent()
-        {
-            Object val = GetFieldValue(9, 0, Fit.SubfieldIndexMainField);
-            if(val == null)
-            {
-                return null;
-            }
+			}
+			set
+			{
+				SetFieldValue(6, 0, value, Fit.SubfieldIndexMainField);
+			}
+		}
 
-            return (Convert.ToUInt16(val));
-            
-        }
+		///<summary>
+		/// Retrieves the MaxSpeed field
+		/// Units: m/s</summary>
+		/// <returns>Returns nullable float representing the MaxSpeed field</returns>
+		public float? MaxSpeed
+		{
+			get
+			{
+				Object val = GetFieldValue(7, 0, Fit.SubfieldIndexMainField);
+				if (val == null)
+				{
+					return null;
+				}
 
-        /// <summary>
-        /// Set TotalDescent field
-        /// Units: m</summary>
-        /// <param name="totalDescent_">Nullable field value to be set</param>
-        public void SetTotalDescent(ushort? totalDescent_)
-        {
-            SetFieldValue(9, 0, totalDescent_, Fit.SubfieldIndexMainField);
-        }
-        
-        ///<summary>
-        /// Retrieves the AvgHeartRate field
-        /// Units: bpm</summary>
-        /// <returns>Returns nullable byte representing the AvgHeartRate field</returns>
-        public byte? GetAvgHeartRate()
-        {
-            Object val = GetFieldValue(10, 0, Fit.SubfieldIndexMainField);
-            if(val == null)
-            {
-                return null;
-            }
+				return (Convert.ToSingle(val));
 
-            return (Convert.ToByte(val));
-            
-        }
+			}
+			set
+			{
+				SetFieldValue(7, 0, value, Fit.SubfieldIndexMainField);
+			}
+		}
 
-        /// <summary>
-        /// Set AvgHeartRate field
-        /// Units: bpm</summary>
-        /// <param name="avgHeartRate_">Nullable field value to be set</param>
-        public void SetAvgHeartRate(byte? avgHeartRate_)
-        {
-            SetFieldValue(10, 0, avgHeartRate_, Fit.SubfieldIndexMainField);
-        }
-        
-        ///<summary>
-        /// Retrieves the MaxHeartRate field
-        /// Units: bpm</summary>
-        /// <returns>Returns nullable byte representing the MaxHeartRate field</returns>
-        public byte? GetMaxHeartRate()
-        {
-            Object val = GetFieldValue(11, 0, Fit.SubfieldIndexMainField);
-            if(val == null)
-            {
-                return null;
-            }
+		///<summary>
+		/// Retrieves the TotalAscent field
+		/// Units: m</summary>
+		/// <returns>Returns nullable ushort representing the TotalAscent field</returns>
+		public ushort? TotalAscent
+		{
+			get
+			{
+				Object val = GetFieldValue(8, 0, Fit.SubfieldIndexMainField);
+				if (val == null)
+				{
+					return null;
+				}
 
-            return (Convert.ToByte(val));
-            
-        }
+				return (Convert.ToUInt16(val));
 
-        /// <summary>
-        /// Set MaxHeartRate field
-        /// Units: bpm</summary>
-        /// <param name="maxHeartRate_">Nullable field value to be set</param>
-        public void SetMaxHeartRate(byte? maxHeartRate_)
-        {
-            SetFieldValue(11, 0, maxHeartRate_, Fit.SubfieldIndexMainField);
-        }
-        
-        ///<summary>
-        /// Retrieves the AvgVertSpeed field
-        /// Units: m/s</summary>
-        /// <returns>Returns nullable float representing the AvgVertSpeed field</returns>
-        public float? GetAvgVertSpeed()
-        {
-            Object val = GetFieldValue(12, 0, Fit.SubfieldIndexMainField);
-            if(val == null)
-            {
-                return null;
-            }
+			}
+			set
+			{
+				SetFieldValue(8, 0, value, Fit.SubfieldIndexMainField);
+			}
+		}
 
-            return (Convert.ToSingle(val));
-            
-        }
+		///<summary>
+		/// Retrieves the TotalDescent field
+		/// Units: m</summary>
+		/// <returns>Returns nullable ushort representing the TotalDescent field</returns>
+		public ushort? TotalDescent
+		{
+			get
+			{
+				Object val = GetFieldValue(9, 0, Fit.SubfieldIndexMainField);
+				if (val == null)
+				{
+					return null;
+				}
 
-        /// <summary>
-        /// Set AvgVertSpeed field
-        /// Units: m/s</summary>
-        /// <param name="avgVertSpeed_">Nullable field value to be set</param>
-        public void SetAvgVertSpeed(float? avgVertSpeed_)
-        {
-            SetFieldValue(12, 0, avgVertSpeed_, Fit.SubfieldIndexMainField);
-        }
-        
-        ///<summary>
-        /// Retrieves the TotalCalories field
-        /// Units: kcal</summary>
-        /// <returns>Returns nullable uint representing the TotalCalories field</returns>
-        public uint? GetTotalCalories()
-        {
-            Object val = GetFieldValue(13, 0, Fit.SubfieldIndexMainField);
-            if(val == null)
-            {
-                return null;
-            }
+				return (Convert.ToUInt16(val));
 
-            return (Convert.ToUInt32(val));
-            
-        }
+			}
+			set
+			{
+				SetFieldValue(9, 0, value, Fit.SubfieldIndexMainField);
+			}
+		}
 
-        /// <summary>
-        /// Set TotalCalories field
-        /// Units: kcal</summary>
-        /// <param name="totalCalories_">Nullable field value to be set</param>
-        public void SetTotalCalories(uint? totalCalories_)
-        {
-            SetFieldValue(13, 0, totalCalories_, Fit.SubfieldIndexMainField);
-        }
-        
-        ///<summary>
-        /// Retrieves the TotalMovingTime field
-        /// Units: s</summary>
-        /// <returns>Returns nullable float representing the TotalMovingTime field</returns>
-        public float? GetTotalMovingTime()
-        {
-            Object val = GetFieldValue(77, 0, Fit.SubfieldIndexMainField);
-            if(val == null)
-            {
-                return null;
-            }
+		///<summary>
+		/// Retrieves the AvgHeartRate field
+		/// Units: bpm</summary>
+		/// <returns>Returns nullable byte representing the AvgHeartRate field</returns>
+		public byte? AvgHeartRate
+		{
+			get
+			{
+				Object val = GetFieldValue(10, 0, Fit.SubfieldIndexMainField);
+				if (val == null)
+				{
+					return null;
+				}
 
-            return (Convert.ToSingle(val));
-            
-        }
+				return (Convert.ToByte(val));
 
-        /// <summary>
-        /// Set TotalMovingTime field
-        /// Units: s</summary>
-        /// <param name="totalMovingTime_">Nullable field value to be set</param>
-        public void SetTotalMovingTime(float? totalMovingTime_)
-        {
-            SetFieldValue(77, 0, totalMovingTime_, Fit.SubfieldIndexMainField);
-        }
-        
-        #endregion // Methods
-    } // Class
+			}
+			set
+			{
+				SetFieldValue(10, 0, value, Fit.SubfieldIndexMainField);
+			}
+		}
+
+		///<summary>
+		/// Retrieves the MaxHeartRate field
+		/// Units: bpm</summary>
+		/// <returns>Returns nullable byte representing the MaxHeartRate field</returns>
+		public byte? MaxHeartRate
+		{
+			get
+			{
+				Object val = GetFieldValue(11, 0, Fit.SubfieldIndexMainField);
+				if (val == null)
+				{
+					return null;
+				}
+
+				return (Convert.ToByte(val));
+
+			}
+			set
+			{
+				SetFieldValue(11, 0, value, Fit.SubfieldIndexMainField);
+			}
+		}
+
+		///<summary>
+		/// Retrieves the AvgVertSpeed field
+		/// Units: m/s</summary>
+		/// <returns>Returns nullable float representing the AvgVertSpeed field</returns>
+		public float? AvgVertSpeed
+		{
+			get
+			{
+				Object val = GetFieldValue(12, 0, Fit.SubfieldIndexMainField);
+				if (val == null)
+				{
+					return null;
+				}
+
+				return (Convert.ToSingle(val));
+
+			}
+			set
+			{
+				SetFieldValue(12, 0, value, Fit.SubfieldIndexMainField);
+			}
+		}
+
+		///<summary>
+		/// Retrieves the TotalCalories field
+		/// Units: kcal</summary>
+		/// <returns>Returns nullable uint representing the TotalCalories field</returns>
+		public uint? TotalCalories
+		{
+			get
+			{
+				Object val = GetFieldValue(13, 0, Fit.SubfieldIndexMainField);
+				if (val == null)
+				{
+					return null;
+				}
+
+				return (Convert.ToUInt32(val));
+
+			}
+			set
+			{
+				SetFieldValue(13, 0, value, Fit.SubfieldIndexMainField);
+			}
+		}
+
+		///<summary>
+		/// Retrieves the TotalMovingTime field
+		/// Units: s</summary>
+		/// <returns>Returns nullable float representing the TotalMovingTime field</returns>
+		public float? TotalMovingTime
+		{
+			get
+			{
+				Object val = GetFieldValue(77, 0, Fit.SubfieldIndexMainField);
+				if (val == null)
+				{
+					return null;
+				}
+
+				return (Convert.ToSingle(val));
+
+			}
+			set
+			{
+				SetFieldValue(77, 0, value, Fit.SubfieldIndexMainField);
+			}
+		}
+
+		#endregion // Methods
+	} // Class
 } // namespace

--- a/Dynastream/Fit/Profile/Mesgs/Spo2DataMesg.cs
+++ b/Dynastream/Fit/Profile/Mesgs/Spo2DataMesg.cs
@@ -21,130 +21,123 @@ using System.Linq;
 
 namespace Dynastream.Fit
 {
-    /// <summary>
-    /// Implements the Spo2Data profile message.
-    /// </summary>
-    public class Spo2DataMesg : Mesg
-    {
-        #region Fields
-        #endregion
+	/// <summary>
+	/// Implements the Spo2Data profile message.
+	/// </summary>
+	public class Spo2DataMesg : Mesg
+	{
+		#region Fields
+		#endregion
 
-        /// <summary>
-        /// Field Numbers for <see cref="Spo2DataMesg"/>
-        /// </summary>
-        public sealed class FieldDefNum
-        {
-            public const byte Timestamp = 253;
-            public const byte ReadingSpo2 = 0;
-            public const byte ReadingConfidence = 1;
-            public const byte Mode = 2;
-            public const byte Invalid = Fit.FieldNumInvalid;
-        }
+		/// <summary>
+		/// Field Numbers for <see cref="Spo2DataMesg"/>
+		/// </summary>
+		public sealed class FieldDefNum
+		{
+			public const byte Timestamp = 253;
+			public const byte ReadingSpo2 = 0;
+			public const byte ReadingConfidence = 1;
+			public const byte Mode = 2;
+			public const byte Invalid = Fit.FieldNumInvalid;
+		}
 
-        #region Constructors
-        public Spo2DataMesg() : base(Profile.GetMesg(MesgNum.Spo2Data))
-        {
-        }
+		#region Constructors
+		public Spo2DataMesg() : base(Profile.GetMesg(MesgNum.Spo2Data))
+		{
+		}
 
-        public Spo2DataMesg(Mesg mesg) : base(mesg)
-        {
-        }
-        #endregion // Constructors
+		public Spo2DataMesg(Mesg mesg) : base(mesg)
+		{
+		}
+		#endregion // Constructors
 
-        #region Methods
-        ///<summary>
-        /// Retrieves the Timestamp field
-        /// Units: s</summary>
-        /// <returns>Returns DateTime representing the Timestamp field</returns>
-        public DateTime GetTimestamp()
-        {
-            Object val = GetFieldValue(253, 0, Fit.SubfieldIndexMainField);
-            if(val == null)
-            {
-                return null;
-            }
+		#region Methods
+		///<summary>
+		/// Retrieves the Timestamp field
+		/// Units: s</summary>
+		/// <returns>Returns DateTime representing the Timestamp field</returns>
+		public DateTime Timestamp
+		{
+			get
+			{
+				Object val = GetFieldValue(253, 0, Fit.SubfieldIndexMainField);
+				if (val == null)
+				{
+					return null;
+				}
 
-            return TimestampToDateTime(Convert.ToUInt32(val));
-            
-        }
+				return TimestampToDateTime(Convert.ToUInt32(val));
 
-        /// <summary>
-        /// Set Timestamp field
-        /// Units: s</summary>
-        /// <param name="timestamp_">Nullable field value to be set</param>
-        public void SetTimestamp(DateTime timestamp_)
-        {
-            SetFieldValue(253, 0, timestamp_.GetTimeStamp(), Fit.SubfieldIndexMainField);
-        }
-        
-        ///<summary>
-        /// Retrieves the ReadingSpo2 field
-        /// Units: percent</summary>
-        /// <returns>Returns nullable byte representing the ReadingSpo2 field</returns>
-        public byte? GetReadingSpo2()
-        {
-            Object val = GetFieldValue(0, 0, Fit.SubfieldIndexMainField);
-            if(val == null)
-            {
-                return null;
-            }
+			}
+			set
+			{
+				SetFieldValue(253, 0, value.GetTimeStamp(), Fit.SubfieldIndexMainField);
+			}
+		}
 
-            return (Convert.ToByte(val));
-            
-        }
+		///<summary>
+		/// Retrieves the ReadingSpo2 field
+		/// Units: percent</summary>
+		/// <returns>Returns nullable byte representing the ReadingSpo2 field</returns>
+		public byte? ReadingSpo2
+		{
+			get
+			{
+				Object val = GetFieldValue(0, 0, Fit.SubfieldIndexMainField);
+				if (val == null)
+				{
+					return null;
+				}
 
-        /// <summary>
-        /// Set ReadingSpo2 field
-        /// Units: percent</summary>
-        /// <param name="readingSpo2_">Nullable field value to be set</param>
-        public void SetReadingSpo2(byte? readingSpo2_)
-        {
-            SetFieldValue(0, 0, readingSpo2_, Fit.SubfieldIndexMainField);
-        }
-        
-        ///<summary>
-        /// Retrieves the ReadingConfidence field</summary>
-        /// <returns>Returns nullable byte representing the ReadingConfidence field</returns>
-        public byte? GetReadingConfidence()
-        {
-            Object val = GetFieldValue(1, 0, Fit.SubfieldIndexMainField);
-            if(val == null)
-            {
-                return null;
-            }
+				return (Convert.ToByte(val));
 
-            return (Convert.ToByte(val));
-            
-        }
+			}
+			set
+			{
+				SetFieldValue(0, 0, value, Fit.SubfieldIndexMainField);
+			}
+		}
 
-        /// <summary>
-        /// Set ReadingConfidence field</summary>
-        /// <param name="readingConfidence_">Nullable field value to be set</param>
-        public void SetReadingConfidence(byte? readingConfidence_)
-        {
-            SetFieldValue(1, 0, readingConfidence_, Fit.SubfieldIndexMainField);
-        }
-        
-        ///<summary>
-        /// Retrieves the Mode field
-        /// Comment: Mode when data was captured</summary>
-        /// <returns>Returns nullable Spo2MeasurementType enum representing the Mode field</returns>
-        public Spo2MeasurementType? GetMode()
-        {
-            object obj = GetFieldValue(2, 0, Fit.SubfieldIndexMainField);
-            Spo2MeasurementType? value = obj == null ? (Spo2MeasurementType?)null : (Spo2MeasurementType)obj;
-            return value;
-        }
+		///<summary>
+		/// Retrieves the ReadingConfidence field</summary>
+		/// <returns>Returns nullable byte representing the ReadingConfidence field</returns>
+		public byte? ReadingConfidence
+		{
+			get
+			{
+				Object val = GetFieldValue(1, 0, Fit.SubfieldIndexMainField);
+				if (val == null)
+				{
+					return null;
+				}
 
-        /// <summary>
-        /// Set Mode field
-        /// Comment: Mode when data was captured</summary>
-        /// <param name="mode_">Nullable field value to be set</param>
-        public void SetMode(Spo2MeasurementType? mode_)
-        {
-            SetFieldValue(2, 0, mode_, Fit.SubfieldIndexMainField);
-        }
-        
-        #endregion // Methods
-    } // Class
+				return (Convert.ToByte(val));
+
+			}
+			set
+			{
+				SetFieldValue(1, 0, value, Fit.SubfieldIndexMainField);
+			}
+		}
+
+		///<summary>
+		/// Retrieves the Mode field
+		/// Comment: Mode when data was captured</summary>
+		/// <returns>Returns nullable Spo2MeasurementType enum representing the Mode field</returns>
+		public Spo2MeasurementType? Mode
+		{
+			get
+			{
+				object obj = GetFieldValue(2, 0, Fit.SubfieldIndexMainField);
+				Spo2MeasurementType? value = obj == null ? (Spo2MeasurementType?)null : (Spo2MeasurementType)obj;
+				return value;
+			}
+			set
+			{
+				SetFieldValue(2, 0, value, Fit.SubfieldIndexMainField);
+			}
+		}
+
+		#endregion // Methods
+	} // Class
 } // namespace

--- a/Dynastream/Fit/Profile/Mesgs/SportMesg.cs
+++ b/Dynastream/Fit/Profile/Mesgs/SportMesg.cs
@@ -21,110 +21,106 @@ using System.Linq;
 
 namespace Dynastream.Fit
 {
-    /// <summary>
-    /// Implements the Sport profile message.
-    /// </summary>
-    public class SportMesg : Mesg
-    {
-        #region Fields
-        #endregion
+	/// <summary>
+	/// Implements the Sport profile message.
+	/// </summary>
+	public class SportMesg : Mesg
+	{
+		#region Fields
+		#endregion
 
-        /// <summary>
-        /// Field Numbers for <see cref="SportMesg"/>
-        /// </summary>
-        public sealed class FieldDefNum
-        {
-            public const byte Sport = 0;
-            public const byte SubSport = 1;
-            public const byte Name = 3;
-            public const byte Invalid = Fit.FieldNumInvalid;
-        }
+		/// <summary>
+		/// Field Numbers for <see cref="SportMesg"/>
+		/// </summary>
+		public sealed class FieldDefNum
+		{
+			public const byte Sport = 0;
+			public const byte SubSport = 1;
+			public const byte Name = 3;
+			public const byte Invalid = Fit.FieldNumInvalid;
+		}
 
-        #region Constructors
-        public SportMesg() : base(Profile.GetMesg(MesgNum.Sport))
-        {
-        }
+		#region Constructors
+		public SportMesg() : base(Profile.GetMesg(MesgNum.Sport))
+		{
+		}
 
-        public SportMesg(Mesg mesg) : base(mesg)
-        {
-        }
-        #endregion // Constructors
+		public SportMesg(Mesg mesg) : base(mesg)
+		{
+		}
+		#endregion // Constructors
 
-        #region Methods
-        ///<summary>
-        /// Retrieves the Sport field</summary>
-        /// <returns>Returns nullable Sport enum representing the Sport field</returns>
-        public Sport? GetSport()
-        {
-            object obj = GetFieldValue(0, 0, Fit.SubfieldIndexMainField);
-            Sport? value = obj == null ? (Sport?)null : (Sport)obj;
-            return value;
-        }
+		#region Methods
+		///<summary>
+		/// Retrieves the Sport field</summary>
+		/// <returns>Returns nullable Sport enum representing the Sport field</returns>
+		public Sport? Sport
+		{
+			get
+			{
+				object obj = GetFieldValue(0, 0, Fit.SubfieldIndexMainField);
+				Sport? value = obj == null ? (Sport?)null : (Sport)obj;
+				return value;
+			}
+			set
+			{
+				SetFieldValue(0, 0, value, Fit.SubfieldIndexMainField);
+			}
+		}
 
-        /// <summary>
-        /// Set Sport field</summary>
-        /// <param name="sport_">Nullable field value to be set</param>
-        public void SetSport(Sport? sport_)
-        {
-            SetFieldValue(0, 0, sport_, Fit.SubfieldIndexMainField);
-        }
-        
-        ///<summary>
-        /// Retrieves the SubSport field</summary>
-        /// <returns>Returns nullable SubSport enum representing the SubSport field</returns>
-        public SubSport? GetSubSport()
-        {
-            object obj = GetFieldValue(1, 0, Fit.SubfieldIndexMainField);
-            SubSport? value = obj == null ? (SubSport?)null : (SubSport)obj;
-            return value;
-        }
+		///<summary>
+		/// Retrieves the SubSport field</summary>
+		/// <returns>Returns nullable SubSport enum representing the SubSport field</returns>
+		public SubSport? SubSport
+		{
+			get
+			{
+				object obj = GetFieldValue(1, 0, Fit.SubfieldIndexMainField);
+				SubSport? value = obj == null ? (SubSport?)null : (SubSport)obj;
+				return value;
+			}
+			set
+			{
+				SetFieldValue(1, 0, value, Fit.SubfieldIndexMainField);
+			}
+		}
 
-        /// <summary>
-        /// Set SubSport field</summary>
-        /// <param name="subSport_">Nullable field value to be set</param>
-        public void SetSubSport(SubSport? subSport_)
-        {
-            SetFieldValue(1, 0, subSport_, Fit.SubfieldIndexMainField);
-        }
-        
-        ///<summary>
-        /// Retrieves the Name field</summary>
-        /// <returns>Returns byte[] representing the Name field</returns>
-        public byte[] GetName()
-        {
-            byte[] data = (byte[])GetFieldValue(3, 0, Fit.SubfieldIndexMainField);
-            return data.Take(data.Length - 1).ToArray();
-        }
+		///<summary>
+		/// Retrieves the Name field</summary>
+		/// <returns>Returns byte[] representing the Name field</returns>
+		public byte[] Name
+		{
+			get
+			{
+				byte[] data = (byte[])GetFieldValue(3, 0, Fit.SubfieldIndexMainField);
+				return data.Take(data.Length - 1).ToArray();
+			}
+			set
+			{
+				SetFieldValue(3, 0, value, Fit.SubfieldIndexMainField);
+			}
+		}
 
-        ///<summary>
-        /// Retrieves the Name field</summary>
-        /// <returns>Returns String representing the Name field</returns>
-        public String GetNameAsString()
-        {
-            byte[] data = (byte[])GetFieldValue(3, 0, Fit.SubfieldIndexMainField);
-            return data != null ? Encoding.UTF8.GetString(data, 0, data.Length - 1) : null;
-        }
+		///<summary>
+		/// Retrieves the Name field</summary>
+		/// <returns>Returns String representing the Name field</returns>
+		public String GetNameAsString()
+		{
+			byte[] data = (byte[])GetFieldValue(3, 0, Fit.SubfieldIndexMainField);
+			return data != null ? Encoding.UTF8.GetString(data, 0, data.Length - 1) : null;
+		}
 
-        ///<summary>
-        /// Set Name field</summary>
-        /// <param name="name_"> field value to be set</param>
-        public void SetName(String name_)
-        {
-            byte[] data = Encoding.UTF8.GetBytes(name_);
-            byte[] zdata = new byte[data.Length + 1];
-            data.CopyTo(zdata, 0);
-            SetFieldValue(3, 0, zdata, Fit.SubfieldIndexMainField);
-        }
+		///<summary>
+		/// Set Name field</summary>
+		/// <param name="name_"> field value to be set</param>
+		public void SetName(String name_)
+		{
+			byte[] data = Encoding.UTF8.GetBytes(name_);
+			byte[] zdata = new byte[data.Length + 1];
+			data.CopyTo(zdata, 0);
+			SetFieldValue(3, 0, zdata, Fit.SubfieldIndexMainField);
+		}
 
-        
-        /// <summary>
-        /// Set Name field</summary>
-        /// <param name="name_">field value to be set</param>
-        public void SetName(byte[] name_)
-        {
-            SetFieldValue(3, 0, name_, Fit.SubfieldIndexMainField);
-        }
-        
-        #endregion // Methods
-    } // Class
+		#endregion // Methods
+	} // Class
 } // namespace

--- a/Dynastream/Fit/Profile/Mesgs/StressLevelMesg.cs
+++ b/Dynastream/Fit/Profile/Mesgs/StressLevelMesg.cs
@@ -21,85 +21,81 @@ using System.Linq;
 
 namespace Dynastream.Fit
 {
-    /// <summary>
-    /// Implements the StressLevel profile message.
-    /// </summary>
-    public class StressLevelMesg : Mesg
-    {
-        #region Fields
-        #endregion
+	/// <summary>
+	/// Implements the StressLevel profile message.
+	/// </summary>
+	public class StressLevelMesg : Mesg
+	{
+		#region Fields
+		#endregion
 
-        /// <summary>
-        /// Field Numbers for <see cref="StressLevelMesg"/>
-        /// </summary>
-        public sealed class FieldDefNum
-        {
-            public const byte StressLevelValue = 0;
-            public const byte StressLevelTime = 1;
-            public const byte Invalid = Fit.FieldNumInvalid;
-        }
+		/// <summary>
+		/// Field Numbers for <see cref="StressLevelMesg"/>
+		/// </summary>
+		public sealed class FieldDefNum
+		{
+			public const byte StressLevelValue = 0;
+			public const byte StressLevelTime = 1;
+			public const byte Invalid = Fit.FieldNumInvalid;
+		}
 
-        #region Constructors
-        public StressLevelMesg() : base(Profile.GetMesg(MesgNum.StressLevel))
-        {
-        }
+		#region Constructors
+		public StressLevelMesg() : base(Profile.GetMesg(MesgNum.StressLevel))
+		{
+		}
 
-        public StressLevelMesg(Mesg mesg) : base(mesg)
-        {
-        }
-        #endregion // Constructors
+		public StressLevelMesg(Mesg mesg) : base(mesg)
+		{
+		}
+		#endregion // Constructors
 
-        #region Methods
-        ///<summary>
-        /// Retrieves the StressLevelValue field</summary>
-        /// <returns>Returns nullable short representing the StressLevelValue field</returns>
-        public short? GetStressLevelValue()
-        {
-            Object val = GetFieldValue(0, 0, Fit.SubfieldIndexMainField);
-            if(val == null)
-            {
-                return null;
-            }
+		#region Methods
+		///<summary>
+		/// Retrieves the StressLevelValue field</summary>
+		/// <returns>Returns nullable short representing the StressLevelValue field</returns>
+		public short? StressLevelValue
+		{
+			get
+			{
+				Object val = GetFieldValue(0, 0, Fit.SubfieldIndexMainField);
+				if (val == null)
+				{
+					return null;
+				}
 
-            return (Convert.ToInt16(val));
-            
-        }
+				return (Convert.ToInt16(val));
 
-        /// <summary>
-        /// Set StressLevelValue field</summary>
-        /// <param name="stressLevelValue_">Nullable field value to be set</param>
-        public void SetStressLevelValue(short? stressLevelValue_)
-        {
-            SetFieldValue(0, 0, stressLevelValue_, Fit.SubfieldIndexMainField);
-        }
-        
-        ///<summary>
-        /// Retrieves the StressLevelTime field
-        /// Units: s
-        /// Comment: Time stress score was calculated</summary>
-        /// <returns>Returns DateTime representing the StressLevelTime field</returns>
-        public DateTime GetStressLevelTime()
-        {
-            Object val = GetFieldValue(1, 0, Fit.SubfieldIndexMainField);
-            if(val == null)
-            {
-                return null;
-            }
+			}
+			set
+			{
+				SetFieldValue(0, 0, value, Fit.SubfieldIndexMainField);
+			}
+		}
 
-            return TimestampToDateTime(Convert.ToUInt32(val));
-            
-        }
+		///<summary>
+		/// Retrieves the StressLevelTime field
+		/// Units: s
+		/// Comment: Time stress score was calculated</summary>
+		/// <returns>Returns DateTime representing the StressLevelTime field</returns>
+		public DateTime StressLevelTime
+		{
+			get
+			{
+				Object val = GetFieldValue(1, 0, Fit.SubfieldIndexMainField);
+				if (val == null)
+				{
+					return null;
+				}
 
-        /// <summary>
-        /// Set StressLevelTime field
-        /// Units: s
-        /// Comment: Time stress score was calculated</summary>
-        /// <param name="stressLevelTime_">Nullable field value to be set</param>
-        public void SetStressLevelTime(DateTime stressLevelTime_)
-        {
-            SetFieldValue(1, 0, stressLevelTime_.GetTimeStamp(), Fit.SubfieldIndexMainField);
-        }
-        
-        #endregion // Methods
-    } // Class
+				return TimestampToDateTime(Convert.ToUInt32(val));
+
+			}
+			set
+			{
+				SetFieldValue(1, 0, value.GetTimeStamp(), Fit.SubfieldIndexMainField);
+			}
+		}
+
+		#endregion // Methods
+	} // Class
 } // namespace

--- a/Dynastream/Fit/Profile/Mesgs/TankSummaryMesg.cs
+++ b/Dynastream/Fit/Profile/Mesgs/TankSummaryMesg.cs
@@ -21,161 +21,152 @@ using System.Linq;
 
 namespace Dynastream.Fit
 {
-    /// <summary>
-    /// Implements the TankSummary profile message.
-    /// </summary>
-    public class TankSummaryMesg : Mesg
-    {
-        #region Fields
-        #endregion
+	/// <summary>
+	/// Implements the TankSummary profile message.
+	/// </summary>
+	public class TankSummaryMesg : Mesg
+	{
+		#region Fields
+		#endregion
 
-        /// <summary>
-        /// Field Numbers for <see cref="TankSummaryMesg"/>
-        /// </summary>
-        public sealed class FieldDefNum
-        {
-            public const byte Timestamp = 253;
-            public const byte Sensor = 0;
-            public const byte StartPressure = 1;
-            public const byte EndPressure = 2;
-            public const byte VolumeUsed = 3;
-            public const byte Invalid = Fit.FieldNumInvalid;
-        }
+		/// <summary>
+		/// Field Numbers for <see cref="TankSummaryMesg"/>
+		/// </summary>
+		public sealed class FieldDefNum
+		{
+			public const byte Timestamp = 253;
+			public const byte Sensor = 0;
+			public const byte StartPressure = 1;
+			public const byte EndPressure = 2;
+			public const byte VolumeUsed = 3;
+			public const byte Invalid = Fit.FieldNumInvalid;
+		}
 
-        #region Constructors
-        public TankSummaryMesg() : base(Profile.GetMesg(MesgNum.TankSummary))
-        {
-        }
+		#region Constructors
+		public TankSummaryMesg() : base(Profile.GetMesg(MesgNum.TankSummary))
+		{
+		}
 
-        public TankSummaryMesg(Mesg mesg) : base(mesg)
-        {
-        }
-        #endregion // Constructors
+		public TankSummaryMesg(Mesg mesg) : base(mesg)
+		{
+		}
+		#endregion // Constructors
 
-        #region Methods
-        ///<summary>
-        /// Retrieves the Timestamp field
-        /// Units: s</summary>
-        /// <returns>Returns DateTime representing the Timestamp field</returns>
-        public DateTime GetTimestamp()
-        {
-            Object val = GetFieldValue(253, 0, Fit.SubfieldIndexMainField);
-            if(val == null)
-            {
-                return null;
-            }
+		#region Methods
+		///<summary>
+		/// Retrieves the Timestamp field
+		/// Units: s</summary>
+		/// <returns>Returns DateTime representing the Timestamp field</returns>
+		public DateTime Timestamp
+		{
+			get
+			{
+				Object val = GetFieldValue(253, 0, Fit.SubfieldIndexMainField);
+				if (val == null)
+				{
+					return null;
+				}
 
-            return TimestampToDateTime(Convert.ToUInt32(val));
-            
-        }
+				return TimestampToDateTime(Convert.ToUInt32(val));
 
-        /// <summary>
-        /// Set Timestamp field
-        /// Units: s</summary>
-        /// <param name="timestamp_">Nullable field value to be set</param>
-        public void SetTimestamp(DateTime timestamp_)
-        {
-            SetFieldValue(253, 0, timestamp_.GetTimeStamp(), Fit.SubfieldIndexMainField);
-        }
-        
-        ///<summary>
-        /// Retrieves the Sensor field</summary>
-        /// <returns>Returns nullable uint representing the Sensor field</returns>
-        public uint? GetSensor()
-        {
-            Object val = GetFieldValue(0, 0, Fit.SubfieldIndexMainField);
-            if(val == null)
-            {
-                return null;
-            }
+			}
+			set
+			{
+				SetFieldValue(253, 0, value.GetTimeStamp(), Fit.SubfieldIndexMainField);
+			}
+		}
 
-            return (Convert.ToUInt32(val));
-            
-        }
+		///<summary>
+		/// Retrieves the Sensor field</summary>
+		/// <returns>Returns nullable uint representing the Sensor field</returns>
+		public uint? Sensor
+		{
+			get
+			{
+				Object val = GetFieldValue(0, 0, Fit.SubfieldIndexMainField);
+				if (val == null)
+				{
+					return null;
+				}
 
-        /// <summary>
-        /// Set Sensor field</summary>
-        /// <param name="sensor_">Nullable field value to be set</param>
-        public void SetSensor(uint? sensor_)
-        {
-            SetFieldValue(0, 0, sensor_, Fit.SubfieldIndexMainField);
-        }
-        
-        ///<summary>
-        /// Retrieves the StartPressure field
-        /// Units: bar</summary>
-        /// <returns>Returns nullable float representing the StartPressure field</returns>
-        public float? GetStartPressure()
-        {
-            Object val = GetFieldValue(1, 0, Fit.SubfieldIndexMainField);
-            if(val == null)
-            {
-                return null;
-            }
+				return (Convert.ToUInt32(val));
 
-            return (Convert.ToSingle(val));
-            
-        }
+			}
+			set
+			{
+				SetFieldValue(0, 0, value, Fit.SubfieldIndexMainField);
+			}
+		}
 
-        /// <summary>
-        /// Set StartPressure field
-        /// Units: bar</summary>
-        /// <param name="startPressure_">Nullable field value to be set</param>
-        public void SetStartPressure(float? startPressure_)
-        {
-            SetFieldValue(1, 0, startPressure_, Fit.SubfieldIndexMainField);
-        }
-        
-        ///<summary>
-        /// Retrieves the EndPressure field
-        /// Units: bar</summary>
-        /// <returns>Returns nullable float representing the EndPressure field</returns>
-        public float? GetEndPressure()
-        {
-            Object val = GetFieldValue(2, 0, Fit.SubfieldIndexMainField);
-            if(val == null)
-            {
-                return null;
-            }
+		///<summary>
+		/// Retrieves the StartPressure field
+		/// Units: bar</summary>
+		/// <returns>Returns nullable float representing the StartPressure field</returns>
+		public float? StartPressure
+		{
+			get
+			{
+				Object val = GetFieldValue(1, 0, Fit.SubfieldIndexMainField);
+				if (val == null)
+				{
+					return null;
+				}
 
-            return (Convert.ToSingle(val));
-            
-        }
+				return (Convert.ToSingle(val));
 
-        /// <summary>
-        /// Set EndPressure field
-        /// Units: bar</summary>
-        /// <param name="endPressure_">Nullable field value to be set</param>
-        public void SetEndPressure(float? endPressure_)
-        {
-            SetFieldValue(2, 0, endPressure_, Fit.SubfieldIndexMainField);
-        }
-        
-        ///<summary>
-        /// Retrieves the VolumeUsed field
-        /// Units: L</summary>
-        /// <returns>Returns nullable float representing the VolumeUsed field</returns>
-        public float? GetVolumeUsed()
-        {
-            Object val = GetFieldValue(3, 0, Fit.SubfieldIndexMainField);
-            if(val == null)
-            {
-                return null;
-            }
+			}
+			set
+			{
+				SetFieldValue(1, 0, value, Fit.SubfieldIndexMainField);
+			}
+		}
 
-            return (Convert.ToSingle(val));
-            
-        }
+		///<summary>
+		/// Retrieves the EndPressure field
+		/// Units: bar</summary>
+		/// <returns>Returns nullable float representing the EndPressure field</returns>
+		public float? EndPressure
+		{
+			get
+			{
+				Object val = GetFieldValue(2, 0, Fit.SubfieldIndexMainField);
+				if (val == null)
+				{
+					return null;
+				}
 
-        /// <summary>
-        /// Set VolumeUsed field
-        /// Units: L</summary>
-        /// <param name="volumeUsed_">Nullable field value to be set</param>
-        public void SetVolumeUsed(float? volumeUsed_)
-        {
-            SetFieldValue(3, 0, volumeUsed_, Fit.SubfieldIndexMainField);
-        }
-        
-        #endregion // Methods
-    } // Class
+				return (Convert.ToSingle(val));
+
+			}
+			set
+			{
+				SetFieldValue(2, 0, value, Fit.SubfieldIndexMainField);
+			}
+		}
+
+		///<summary>
+		/// Retrieves the VolumeUsed field
+		/// Units: L</summary>
+		/// <returns>Returns nullable float representing the VolumeUsed field</returns>
+		public float? VolumeUsed
+		{
+			get
+			{
+				Object val = GetFieldValue(3, 0, Fit.SubfieldIndexMainField);
+				if (val == null)
+				{
+					return null;
+				}
+
+				return (Convert.ToSingle(val));
+
+			}
+			set
+			{
+				SetFieldValue(3, 0, value, Fit.SubfieldIndexMainField);
+			}
+		}
+
+		#endregion // Methods
+	} // Class
 } // namespace

--- a/Dynastream/Fit/Profile/Mesgs/TankUpdateMesg.cs
+++ b/Dynastream/Fit/Profile/Mesgs/TankUpdateMesg.cs
@@ -21,109 +21,104 @@ using System.Linq;
 
 namespace Dynastream.Fit
 {
-    /// <summary>
-    /// Implements the TankUpdate profile message.
-    /// </summary>
-    public class TankUpdateMesg : Mesg
-    {
-        #region Fields
-        #endregion
+	/// <summary>
+	/// Implements the TankUpdate profile message.
+	/// </summary>
+	public class TankUpdateMesg : Mesg
+	{
+		#region Fields
+		#endregion
 
-        /// <summary>
-        /// Field Numbers for <see cref="TankUpdateMesg"/>
-        /// </summary>
-        public sealed class FieldDefNum
-        {
-            public const byte Timestamp = 253;
-            public const byte Sensor = 0;
-            public const byte Pressure = 1;
-            public const byte Invalid = Fit.FieldNumInvalid;
-        }
+		/// <summary>
+		/// Field Numbers for <see cref="TankUpdateMesg"/>
+		/// </summary>
+		public sealed class FieldDefNum
+		{
+			public const byte Timestamp = 253;
+			public const byte Sensor = 0;
+			public const byte Pressure = 1;
+			public const byte Invalid = Fit.FieldNumInvalid;
+		}
 
-        #region Constructors
-        public TankUpdateMesg() : base(Profile.GetMesg(MesgNum.TankUpdate))
-        {
-        }
+		#region Constructors
+		public TankUpdateMesg() : base(Profile.GetMesg(MesgNum.TankUpdate))
+		{
+		}
 
-        public TankUpdateMesg(Mesg mesg) : base(mesg)
-        {
-        }
-        #endregion // Constructors
+		public TankUpdateMesg(Mesg mesg) : base(mesg)
+		{
+		}
+		#endregion // Constructors
 
-        #region Methods
-        ///<summary>
-        /// Retrieves the Timestamp field
-        /// Units: s</summary>
-        /// <returns>Returns DateTime representing the Timestamp field</returns>
-        public DateTime GetTimestamp()
-        {
-            Object val = GetFieldValue(253, 0, Fit.SubfieldIndexMainField);
-            if(val == null)
-            {
-                return null;
-            }
+		#region Methods
+		///<summary>
+		/// Retrieves the Timestamp field
+		/// Units: s</summary>
+		/// <returns>Returns DateTime representing the Timestamp field</returns>
+		public DateTime Timestamp
+		{
+			get
+			{
+				Object val = GetFieldValue(253, 0, Fit.SubfieldIndexMainField);
+				if (val == null)
+				{
+					return null;
+				}
 
-            return TimestampToDateTime(Convert.ToUInt32(val));
-            
-        }
+				return TimestampToDateTime(Convert.ToUInt32(val));
 
-        /// <summary>
-        /// Set Timestamp field
-        /// Units: s</summary>
-        /// <param name="timestamp_">Nullable field value to be set</param>
-        public void SetTimestamp(DateTime timestamp_)
-        {
-            SetFieldValue(253, 0, timestamp_.GetTimeStamp(), Fit.SubfieldIndexMainField);
-        }
-        
-        ///<summary>
-        /// Retrieves the Sensor field</summary>
-        /// <returns>Returns nullable uint representing the Sensor field</returns>
-        public uint? GetSensor()
-        {
-            Object val = GetFieldValue(0, 0, Fit.SubfieldIndexMainField);
-            if(val == null)
-            {
-                return null;
-            }
+			}
+			set
+			{
+				SetFieldValue(253, 0, value.GetTimeStamp(), Fit.SubfieldIndexMainField);
+			}
+		}
 
-            return (Convert.ToUInt32(val));
-            
-        }
+		///<summary>
+		/// Retrieves the Sensor field</summary>
+		/// <returns>Returns nullable uint representing the Sensor field</returns>
+		public uint? Sensor
+		{
+			get
+			{
+				Object val = GetFieldValue(0, 0, Fit.SubfieldIndexMainField);
+				if (val == null)
+				{
+					return null;
+				}
 
-        /// <summary>
-        /// Set Sensor field</summary>
-        /// <param name="sensor_">Nullable field value to be set</param>
-        public void SetSensor(uint? sensor_)
-        {
-            SetFieldValue(0, 0, sensor_, Fit.SubfieldIndexMainField);
-        }
-        
-        ///<summary>
-        /// Retrieves the Pressure field
-        /// Units: bar</summary>
-        /// <returns>Returns nullable float representing the Pressure field</returns>
-        public float? GetPressure()
-        {
-            Object val = GetFieldValue(1, 0, Fit.SubfieldIndexMainField);
-            if(val == null)
-            {
-                return null;
-            }
+				return (Convert.ToUInt32(val));
 
-            return (Convert.ToSingle(val));
-            
-        }
+			}
+			set
+			{
+				SetFieldValue(0, 0, value, Fit.SubfieldIndexMainField);
+			}
+		}
 
-        /// <summary>
-        /// Set Pressure field
-        /// Units: bar</summary>
-        /// <param name="pressure_">Nullable field value to be set</param>
-        public void SetPressure(float? pressure_)
-        {
-            SetFieldValue(1, 0, pressure_, Fit.SubfieldIndexMainField);
-        }
-        
-        #endregion // Methods
-    } // Class
+		///<summary>
+		/// Retrieves the Pressure field
+		/// Units: bar</summary>
+		/// <returns>Returns nullable float representing the Pressure field</returns>
+		public float? Pressure
+		{
+			get
+			{
+				Object val = GetFieldValue(1, 0, Fit.SubfieldIndexMainField);
+				if (val == null)
+				{
+					return null;
+				}
+
+				return (Convert.ToSingle(val));
+
+			}
+			set
+			{
+				SetFieldValue(1, 0, value, Fit.SubfieldIndexMainField);
+			}
+		}
+
+		#endregion // Methods
+	} // Class
 } // namespace

--- a/Dynastream/Fit/Profile/Mesgs/ThreeDSensorCalibrationMesg.cs
+++ b/Dynastream/Fit/Profile/Mesgs/ThreeDSensorCalibrationMesg.cs
@@ -21,302 +21,282 @@ using System.Linq;
 
 namespace Dynastream.Fit
 {
-    /// <summary>
-    /// Implements the ThreeDSensorCalibration profile message.
-    /// </summary>
-    public class ThreeDSensorCalibrationMesg : Mesg
-    {
-        #region Fields
-        static class CalibrationFactorSubfield
-        {
-            public static ushort AccelCalFactor = 0;
-            public static ushort GyroCalFactor = 1;
-            public static ushort Subfields = 2;
-            public static ushort Active = Fit.SubfieldIndexActiveSubfield;
-            public static ushort MainField = Fit.SubfieldIndexMainField;
-        }
-        #endregion
+	/// <summary>
+	/// Implements the ThreeDSensorCalibration profile message.
+	/// </summary>
+	public class ThreeDSensorCalibrationMesg : Mesg
+	{
+		#region Fields
+		static class CalibrationFactorSubfield
+		{
+			public static ushort AccelCalFactor = 0;
+			public static ushort GyroCalFactor = 1;
+			public static ushort Subfields = 2;
+			public static ushort Active = Fit.SubfieldIndexActiveSubfield;
+			public static ushort MainField = Fit.SubfieldIndexMainField;
+		}
+		#endregion
 
-        /// <summary>
-        /// Field Numbers for <see cref="ThreeDSensorCalibrationMesg"/>
-        /// </summary>
-        public sealed class FieldDefNum
-        {
-            public const byte Timestamp = 253;
-            public const byte SensorType = 0;
-            public const byte CalibrationFactor = 1;
-            public const byte CalibrationDivisor = 2;
-            public const byte LevelShift = 3;
-            public const byte OffsetCal = 4;
-            public const byte OrientationMatrix = 5;
-            public const byte Invalid = Fit.FieldNumInvalid;
-        }
+		/// <summary>
+		/// Field Numbers for <see cref="ThreeDSensorCalibrationMesg"/>
+		/// </summary>
+		public sealed class FieldDefNum
+		{
+			public const byte Timestamp = 253;
+			public const byte SensorType = 0;
+			public const byte CalibrationFactor = 1;
+			public const byte CalibrationDivisor = 2;
+			public const byte LevelShift = 3;
+			public const byte OffsetCal = 4;
+			public const byte OrientationMatrix = 5;
+			public const byte Invalid = Fit.FieldNumInvalid;
+		}
 
-        #region Constructors
-        public ThreeDSensorCalibrationMesg() : base(Profile.GetMesg(MesgNum.ThreeDSensorCalibration))
-        {
-        }
+		#region Constructors
+		public ThreeDSensorCalibrationMesg() : base(Profile.GetMesg(MesgNum.ThreeDSensorCalibration))
+		{
+		}
 
-        public ThreeDSensorCalibrationMesg(Mesg mesg) : base(mesg)
-        {
-        }
-        #endregion // Constructors
+		public ThreeDSensorCalibrationMesg(Mesg mesg) : base(mesg)
+		{
+		}
+		#endregion // Constructors
 
-        #region Methods
-        ///<summary>
-        /// Retrieves the Timestamp field
-        /// Units: s
-        /// Comment: Whole second part of the timestamp</summary>
-        /// <returns>Returns DateTime representing the Timestamp field</returns>
-        public DateTime GetTimestamp()
-        {
-            Object val = GetFieldValue(253, 0, Fit.SubfieldIndexMainField);
-            if(val == null)
-            {
-                return null;
-            }
+		#region Methods
+		///<summary>
+		/// Retrieves the Timestamp field
+		/// Units: s
+		/// Comment: Whole second part of the timestamp</summary>
+		/// <returns>Returns DateTime representing the Timestamp field</returns>
+		public DateTime Timestamp
+		{
+			get
+			{
+				Object val = GetFieldValue(253, 0, Fit.SubfieldIndexMainField);
+				if (val == null)
+				{
+					return null;
+				}
 
-            return TimestampToDateTime(Convert.ToUInt32(val));
-            
-        }
+				return TimestampToDateTime(Convert.ToUInt32(val));
 
-        /// <summary>
-        /// Set Timestamp field
-        /// Units: s
-        /// Comment: Whole second part of the timestamp</summary>
-        /// <param name="timestamp_">Nullable field value to be set</param>
-        public void SetTimestamp(DateTime timestamp_)
-        {
-            SetFieldValue(253, 0, timestamp_.GetTimeStamp(), Fit.SubfieldIndexMainField);
-        }
-        
-        ///<summary>
-        /// Retrieves the SensorType field
-        /// Comment: Indicates which sensor the calibration is for</summary>
-        /// <returns>Returns nullable SensorType enum representing the SensorType field</returns>
-        public SensorType? GetSensorType()
-        {
-            object obj = GetFieldValue(0, 0, Fit.SubfieldIndexMainField);
-            SensorType? value = obj == null ? (SensorType?)null : (SensorType)obj;
-            return value;
-        }
+			}
+			set
+			{
+				SetFieldValue(253, 0, value.GetTimeStamp(), Fit.SubfieldIndexMainField);
+			}
+		}
 
-        /// <summary>
-        /// Set SensorType field
-        /// Comment: Indicates which sensor the calibration is for</summary>
-        /// <param name="sensorType_">Nullable field value to be set</param>
-        public void SetSensorType(SensorType? sensorType_)
-        {
-            SetFieldValue(0, 0, sensorType_, Fit.SubfieldIndexMainField);
-        }
-        
-        ///<summary>
-        /// Retrieves the CalibrationFactor field
-        /// Comment: Calibration factor used to convert from raw ADC value to degrees, g, etc.</summary>
-        /// <returns>Returns nullable uint representing the CalibrationFactor field</returns>
-        public uint? GetCalibrationFactor()
-        {
-            Object val = GetFieldValue(1, 0, Fit.SubfieldIndexMainField);
-            if(val == null)
-            {
-                return null;
-            }
+		///<summary>
+		/// Retrieves the SensorType field
+		/// Comment: Indicates which sensor the calibration is for</summary>
+		/// <returns>Returns nullable SensorType enum representing the SensorType field</returns>
+		public SensorType? SensorType
+		{
+			get
+			{
+				object obj = GetFieldValue(0, 0, Fit.SubfieldIndexMainField);
+				SensorType? value = obj == null ? (SensorType?)null : (SensorType)obj;
+				return value;
+			}
+			set
+			{
+				SetFieldValue(0, 0, value, Fit.SubfieldIndexMainField);
+			}
+		}
 
-            return (Convert.ToUInt32(val));
-            
-        }
+		///<summary>
+		/// Retrieves the CalibrationFactor field
+		/// Comment: Calibration factor used to convert from raw ADC value to degrees, g, etc.</summary>
+		/// <returns>Returns nullable uint representing the CalibrationFactor field</returns>
+		public uint? CalibrationFactor
+		{
+			get
+			{
+				Object val = GetFieldValue(1, 0, Fit.SubfieldIndexMainField);
+				if (val == null)
+				{
+					return null;
+				}
 
-        /// <summary>
-        /// Set CalibrationFactor field
-        /// Comment: Calibration factor used to convert from raw ADC value to degrees, g, etc.</summary>
-        /// <param name="calibrationFactor_">Nullable field value to be set</param>
-        public void SetCalibrationFactor(uint? calibrationFactor_)
-        {
-            SetFieldValue(1, 0, calibrationFactor_, Fit.SubfieldIndexMainField);
-        }
-        
+				return (Convert.ToUInt32(val));
 
-        /// <summary>
-        /// Retrieves the AccelCalFactor subfield
-        /// Units: g
-        /// Comment: Accelerometer calibration factor</summary>
-        /// <returns>Nullable uint representing the AccelCalFactor subfield</returns>
-        public uint? GetAccelCalFactor()
-        {
-            Object val = GetFieldValue(1, 0, CalibrationFactorSubfield.AccelCalFactor);
-            if(val == null)
-            {
-                return null;
-            }
+			}
+			set
+			{
+				SetFieldValue(1, 0, value, Fit.SubfieldIndexMainField);
+			}
+		}
 
-            return (Convert.ToUInt32(val));
-            
-        }
 
-        /// <summary>
-        ///
-        /// Set AccelCalFactor subfield
-        /// Units: g
-        /// Comment: Accelerometer calibration factor</summary>
-        /// <param name="accelCalFactor">Subfield value to be set</param>
-        public void SetAccelCalFactor(uint? accelCalFactor)
-        {
-            SetFieldValue(1, 0, accelCalFactor, CalibrationFactorSubfield.AccelCalFactor);
-        }
+		/// <summary>
+		/// Retrieves the AccelCalFactor subfield
+		/// Units: g
+		/// Comment: Accelerometer calibration factor</summary>
+		/// <returns>Nullable uint representing the AccelCalFactor subfield</returns>
+		public uint? AccelCalFactor
+		{
+			get
+			{
+				Object val = GetFieldValue(1, 0, CalibrationFactorSubfield.AccelCalFactor);
+				if (val == null)
+				{
+					return null;
+				}
 
-        /// <summary>
-        /// Retrieves the GyroCalFactor subfield
-        /// Units: deg/s
-        /// Comment: Gyro calibration factor</summary>
-        /// <returns>Nullable uint representing the GyroCalFactor subfield</returns>
-        public uint? GetGyroCalFactor()
-        {
-            Object val = GetFieldValue(1, 0, CalibrationFactorSubfield.GyroCalFactor);
-            if(val == null)
-            {
-                return null;
-            }
+				return (Convert.ToUInt32(val));
 
-            return (Convert.ToUInt32(val));
-            
-        }
+			}
+			set
+			{
+				SetFieldValue(1, 0, value, CalibrationFactorSubfield.AccelCalFactor);
+			}
+		}
 
-        /// <summary>
-        ///
-        /// Set GyroCalFactor subfield
-        /// Units: deg/s
-        /// Comment: Gyro calibration factor</summary>
-        /// <param name="gyroCalFactor">Subfield value to be set</param>
-        public void SetGyroCalFactor(uint? gyroCalFactor)
-        {
-            SetFieldValue(1, 0, gyroCalFactor, CalibrationFactorSubfield.GyroCalFactor);
-        }
-        ///<summary>
-        /// Retrieves the CalibrationDivisor field
-        /// Units: counts
-        /// Comment: Calibration factor divisor</summary>
-        /// <returns>Returns nullable uint representing the CalibrationDivisor field</returns>
-        public uint? GetCalibrationDivisor()
-        {
-            Object val = GetFieldValue(2, 0, Fit.SubfieldIndexMainField);
-            if(val == null)
-            {
-                return null;
-            }
+		/// <summary>
+		/// Retrieves the GyroCalFactor subfield
+		/// Units: deg/s
+		/// Comment: Gyro calibration factor</summary>
+		/// <returns>Nullable uint representing the GyroCalFactor subfield</returns>
+		public uint? GyroCalFactor
+		{
+			get
+			{
+				Object val = GetFieldValue(1, 0, CalibrationFactorSubfield.GyroCalFactor);
+				if (val == null)
+				{
+					return null;
+				}
 
-            return (Convert.ToUInt32(val));
-            
-        }
+				return (Convert.ToUInt32(val));
 
-        /// <summary>
-        /// Set CalibrationDivisor field
-        /// Units: counts
-        /// Comment: Calibration factor divisor</summary>
-        /// <param name="calibrationDivisor_">Nullable field value to be set</param>
-        public void SetCalibrationDivisor(uint? calibrationDivisor_)
-        {
-            SetFieldValue(2, 0, calibrationDivisor_, Fit.SubfieldIndexMainField);
-        }
-        
-        ///<summary>
-        /// Retrieves the LevelShift field
-        /// Comment: Level shift value used to shift the ADC value back into range</summary>
-        /// <returns>Returns nullable uint representing the LevelShift field</returns>
-        public uint? GetLevelShift()
-        {
-            Object val = GetFieldValue(3, 0, Fit.SubfieldIndexMainField);
-            if(val == null)
-            {
-                return null;
-            }
+			}
+			set
+			{
+				SetFieldValue(1, 0, value, CalibrationFactorSubfield.GyroCalFactor);
+			}
+		}
+		///<summary>
+		/// Retrieves the CalibrationDivisor field
+		/// Units: counts
+		/// Comment: Calibration factor divisor</summary>
+		/// <returns>Returns nullable uint representing the CalibrationDivisor field</returns>
+		public uint? CalibrationDivisor
+		{
+			get
+			{
+				Object val = GetFieldValue(2, 0, Fit.SubfieldIndexMainField);
+				if (val == null)
+				{
+					return null;
+				}
 
-            return (Convert.ToUInt32(val));
-            
-        }
+				return (Convert.ToUInt32(val));
 
-        /// <summary>
-        /// Set LevelShift field
-        /// Comment: Level shift value used to shift the ADC value back into range</summary>
-        /// <param name="levelShift_">Nullable field value to be set</param>
-        public void SetLevelShift(uint? levelShift_)
-        {
-            SetFieldValue(3, 0, levelShift_, Fit.SubfieldIndexMainField);
-        }
-        
-        
-        /// <summary>
-        ///
-        /// </summary>
-        /// <returns>returns number of elements in field OffsetCal</returns>
-        public int GetNumOffsetCal()
-        {
-            return GetNumFieldValues(4, Fit.SubfieldIndexMainField);
-        }
+			}
+			set
+			{
+				SetFieldValue(2, 0, value, Fit.SubfieldIndexMainField);
+			}
+		}
 
-        ///<summary>
-        /// Retrieves the OffsetCal field
-        /// Comment: Internal calibration factors, one for each: xy, yx, zx</summary>
-        /// <param name="index">0 based index of OffsetCal element to retrieve</param>
-        /// <returns>Returns nullable int representing the OffsetCal field</returns>
-        public int? GetOffsetCal(int index)
-        {
-            Object val = GetFieldValue(4, index, Fit.SubfieldIndexMainField);
-            if(val == null)
-            {
-                return null;
-            }
+		///<summary>
+		/// Retrieves the LevelShift field
+		/// Comment: Level shift value used to shift the ADC value back into range</summary>
+		/// <returns>Returns nullable uint representing the LevelShift field</returns>
+		public uint? LevelShift
+		{
+			get
+			{
+				Object val = GetFieldValue(3, 0, Fit.SubfieldIndexMainField);
+				if (val == null)
+				{
+					return null;
+				}
 
-            return (Convert.ToInt32(val));
-            
-        }
+				return (Convert.ToUInt32(val));
 
-        /// <summary>
-        /// Set OffsetCal field
-        /// Comment: Internal calibration factors, one for each: xy, yx, zx</summary>
-        /// <param name="index">0 based index of offset_cal</param>
-        /// <param name="offsetCal_">Nullable field value to be set</param>
-        public void SetOffsetCal(int index, int? offsetCal_)
-        {
-            SetFieldValue(4, index, offsetCal_, Fit.SubfieldIndexMainField);
-        }
-        
-        
-        /// <summary>
-        ///
-        /// </summary>
-        /// <returns>returns number of elements in field OrientationMatrix</returns>
-        public int GetNumOrientationMatrix()
-        {
-            return GetNumFieldValues(5, Fit.SubfieldIndexMainField);
-        }
+			}
+			set
+			{
+				SetFieldValue(3, 0, value, Fit.SubfieldIndexMainField);
+			}
+		}
 
-        ///<summary>
-        /// Retrieves the OrientationMatrix field
-        /// Comment: 3 x 3 rotation matrix (row major)</summary>
-        /// <param name="index">0 based index of OrientationMatrix element to retrieve</param>
-        /// <returns>Returns nullable float representing the OrientationMatrix field</returns>
-        public float? GetOrientationMatrix(int index)
-        {
-            Object val = GetFieldValue(5, index, Fit.SubfieldIndexMainField);
-            if(val == null)
-            {
-                return null;
-            }
 
-            return (Convert.ToSingle(val));
-            
-        }
+		/// <summary>
+		///
+		/// </summary>
+		/// <returns>returns number of elements in field OffsetCal</returns>
+		public int GetNumOffsetCal()
+		{
+			return GetNumFieldValues(4, Fit.SubfieldIndexMainField);
+		}
 
-        /// <summary>
-        /// Set OrientationMatrix field
-        /// Comment: 3 x 3 rotation matrix (row major)</summary>
-        /// <param name="index">0 based index of orientation_matrix</param>
-        /// <param name="orientationMatrix_">Nullable field value to be set</param>
-        public void SetOrientationMatrix(int index, float? orientationMatrix_)
-        {
-            SetFieldValue(5, index, orientationMatrix_, Fit.SubfieldIndexMainField);
-        }
-        
-        #endregion // Methods
-    } // Class
+		///<summary>
+		/// Retrieves the OffsetCal field
+		/// Comment: Internal calibration factors, one for each: xy, yx, zx</summary>
+		/// <param name="index">0 based index of OffsetCal element to retrieve</param>
+		/// <returns>Returns nullable int representing the OffsetCal field</returns>
+		public int? GetOffsetCal(int index)
+		{
+			Object val = GetFieldValue(4, index, Fit.SubfieldIndexMainField);
+			if (val == null)
+			{
+				return null;
+			}
+
+			return (Convert.ToInt32(val));
+
+		}
+
+		/// <summary>
+		/// Set OffsetCal field
+		/// Comment: Internal calibration factors, one for each: xy, yx, zx</summary>
+		/// <param name="index">0 based index of offset_cal</param>
+		/// <param name="offsetCal_">Nullable field value to be set</param>
+		public void SetOffsetCal(int index, int? offsetCal_)
+		{
+			SetFieldValue(4, index, offsetCal_, Fit.SubfieldIndexMainField);
+		}
+
+
+		/// <summary>
+		///
+		/// </summary>
+		/// <returns>returns number of elements in field OrientationMatrix</returns>
+		public int GetNumOrientationMatrix()
+		{
+			return GetNumFieldValues(5, Fit.SubfieldIndexMainField);
+		}
+
+		///<summary>
+		/// Retrieves the OrientationMatrix field
+		/// Comment: 3 x 3 rotation matrix (row major)</summary>
+		/// <param name="index">0 based index of OrientationMatrix element to retrieve</param>
+		/// <returns>Returns nullable float representing the OrientationMatrix field</returns>
+		public float? GetOrientationMatrix(int index)
+		{
+			Object val = GetFieldValue(5, index, Fit.SubfieldIndexMainField);
+			if (val == null)
+			{
+				return null;
+			}
+
+			return (Convert.ToSingle(val));
+
+		}
+
+		/// <summary>
+		/// Set OrientationMatrix field
+		/// Comment: 3 x 3 rotation matrix (row major)</summary>
+		/// <param name="index">0 based index of orientation_matrix</param>
+		/// <param name="orientationMatrix_">Nullable field value to be set</param>
+		public void SetOrientationMatrix(int index, float? orientationMatrix_)
+		{
+			SetFieldValue(5, index, orientationMatrix_, Fit.SubfieldIndexMainField);
+		}
+
+		#endregion // Methods
+	} // Class
 } // namespace

--- a/Dynastream/Fit/Profile/Mesgs/TimeInZoneMesg.cs
+++ b/Dynastream/Fit/Profile/Mesgs/TimeInZoneMesg.cs
@@ -21,545 +21,535 @@ using System.Linq;
 
 namespace Dynastream.Fit
 {
-    /// <summary>
-    /// Implements the TimeInZone profile message.
-    /// </summary>
-    public class TimeInZoneMesg : Mesg
-    {
-        #region Fields
-        #endregion
+	/// <summary>
+	/// Implements the TimeInZone profile message.
+	/// </summary>
+	public class TimeInZoneMesg : Mesg
+	{
+		#region Fields
+		#endregion
 
-        /// <summary>
-        /// Field Numbers for <see cref="TimeInZoneMesg"/>
-        /// </summary>
-        public sealed class FieldDefNum
-        {
-            public const byte Timestamp = 253;
-            public const byte ReferenceMesg = 0;
-            public const byte ReferenceIndex = 1;
-            public const byte TimeInHrZone = 2;
-            public const byte TimeInSpeedZone = 3;
-            public const byte TimeInCadenceZone = 4;
-            public const byte TimeInPowerZone = 5;
-            public const byte HrZoneHighBoundary = 6;
-            public const byte SpeedZoneHighBoundary = 7;
-            public const byte CadenceZoneHighBondary = 8;
-            public const byte PowerZoneHighBoundary = 9;
-            public const byte HrCalcType = 10;
-            public const byte MaxHeartRate = 11;
-            public const byte RestingHeartRate = 12;
-            public const byte ThresholdHeartRate = 13;
-            public const byte PwrCalcType = 14;
-            public const byte FunctionalThresholdPower = 15;
-            public const byte Invalid = Fit.FieldNumInvalid;
-        }
+		/// <summary>
+		/// Field Numbers for <see cref="TimeInZoneMesg"/>
+		/// </summary>
+		public sealed class FieldDefNum
+		{
+			public const byte Timestamp = 253;
+			public const byte ReferenceMesg = 0;
+			public const byte ReferenceIndex = 1;
+			public const byte TimeInHrZone = 2;
+			public const byte TimeInSpeedZone = 3;
+			public const byte TimeInCadenceZone = 4;
+			public const byte TimeInPowerZone = 5;
+			public const byte HrZoneHighBoundary = 6;
+			public const byte SpeedZoneHighBoundary = 7;
+			public const byte CadenceZoneHighBondary = 8;
+			public const byte PowerZoneHighBoundary = 9;
+			public const byte HrCalcType = 10;
+			public const byte MaxHeartRate = 11;
+			public const byte RestingHeartRate = 12;
+			public const byte ThresholdHeartRate = 13;
+			public const byte PwrCalcType = 14;
+			public const byte FunctionalThresholdPower = 15;
+			public const byte Invalid = Fit.FieldNumInvalid;
+		}
 
-        #region Constructors
-        public TimeInZoneMesg() : base(Profile.GetMesg(MesgNum.TimeInZone))
-        {
-        }
+		#region Constructors
+		public TimeInZoneMesg() : base(Profile.GetMesg(MesgNum.TimeInZone))
+		{
+		}
 
-        public TimeInZoneMesg(Mesg mesg) : base(mesg)
-        {
-        }
-        #endregion // Constructors
+		public TimeInZoneMesg(Mesg mesg) : base(mesg)
+		{
+		}
+		#endregion // Constructors
 
-        #region Methods
-        ///<summary>
-        /// Retrieves the Timestamp field
-        /// Units: s</summary>
-        /// <returns>Returns DateTime representing the Timestamp field</returns>
-        public DateTime GetTimestamp()
-        {
-            Object val = GetFieldValue(253, 0, Fit.SubfieldIndexMainField);
-            if(val == null)
-            {
-                return null;
-            }
+		#region Methods
+		///<summary>
+		/// Retrieves the Timestamp field
+		/// Units: s</summary>
+		/// <returns>Returns DateTime representing the Timestamp field</returns>
+		public DateTime Timestamp
+		{
+			get
+			{
+				Object val = GetFieldValue(253, 0, Fit.SubfieldIndexMainField);
+				if (val == null)
+				{
+					return null;
+				}
 
-            return TimestampToDateTime(Convert.ToUInt32(val));
-            
-        }
+				return TimestampToDateTime(Convert.ToUInt32(val));
 
-        /// <summary>
-        /// Set Timestamp field
-        /// Units: s</summary>
-        /// <param name="timestamp_">Nullable field value to be set</param>
-        public void SetTimestamp(DateTime timestamp_)
-        {
-            SetFieldValue(253, 0, timestamp_.GetTimeStamp(), Fit.SubfieldIndexMainField);
-        }
-        
-        ///<summary>
-        /// Retrieves the ReferenceMesg field</summary>
-        /// <returns>Returns nullable ushort representing the ReferenceMesg field</returns>
-        public ushort? GetReferenceMesg()
-        {
-            Object val = GetFieldValue(0, 0, Fit.SubfieldIndexMainField);
-            if(val == null)
-            {
-                return null;
-            }
+			}
+			set
+			{
+				SetFieldValue(253, 0, value.GetTimeStamp(), Fit.SubfieldIndexMainField);
+			}
+		}
 
-            return (Convert.ToUInt16(val));
-            
-        }
+		///<summary>
+		/// Retrieves the ReferenceMesg field</summary>
+		/// <returns>Returns nullable ushort representing the ReferenceMesg field</returns>
+		public ushort? ReferenceMesg
+		{
+			get
+			{
+				Object val = GetFieldValue(0, 0, Fit.SubfieldIndexMainField);
+				if (val == null)
+				{
+					return null;
+				}
 
-        /// <summary>
-        /// Set ReferenceMesg field</summary>
-        /// <param name="referenceMesg_">Nullable field value to be set</param>
-        public void SetReferenceMesg(ushort? referenceMesg_)
-        {
-            SetFieldValue(0, 0, referenceMesg_, Fit.SubfieldIndexMainField);
-        }
-        
-        ///<summary>
-        /// Retrieves the ReferenceIndex field</summary>
-        /// <returns>Returns nullable ushort representing the ReferenceIndex field</returns>
-        public ushort? GetReferenceIndex()
-        {
-            Object val = GetFieldValue(1, 0, Fit.SubfieldIndexMainField);
-            if(val == null)
-            {
-                return null;
-            }
+				return (Convert.ToUInt16(val));
 
-            return (Convert.ToUInt16(val));
-            
-        }
+			}
+			set
+			{
+				SetFieldValue(0, 0, value, Fit.SubfieldIndexMainField);
+			}
+		}
 
-        /// <summary>
-        /// Set ReferenceIndex field</summary>
-        /// <param name="referenceIndex_">Nullable field value to be set</param>
-        public void SetReferenceIndex(ushort? referenceIndex_)
-        {
-            SetFieldValue(1, 0, referenceIndex_, Fit.SubfieldIndexMainField);
-        }
-        
-        
-        /// <summary>
-        ///
-        /// </summary>
-        /// <returns>returns number of elements in field TimeInHrZone</returns>
-        public int GetNumTimeInHrZone()
-        {
-            return GetNumFieldValues(2, Fit.SubfieldIndexMainField);
-        }
+		///<summary>
+		/// Retrieves the ReferenceIndex field</summary>
+		/// <returns>Returns nullable ushort representing the ReferenceIndex field</returns>
+		public ushort? ReferenceIndex
+		{
+			get
+			{
+				Object val = GetFieldValue(1, 0, Fit.SubfieldIndexMainField);
+				if (val == null)
+				{
+					return null;
+				}
 
-        ///<summary>
-        /// Retrieves the TimeInHrZone field
-        /// Units: s</summary>
-        /// <param name="index">0 based index of TimeInHrZone element to retrieve</param>
-        /// <returns>Returns nullable float representing the TimeInHrZone field</returns>
-        public float? GetTimeInHrZone(int index)
-        {
-            Object val = GetFieldValue(2, index, Fit.SubfieldIndexMainField);
-            if(val == null)
-            {
-                return null;
-            }
+				return (Convert.ToUInt16(val));
 
-            return (Convert.ToSingle(val));
-            
-        }
+			}
+			set
+			{
+				SetFieldValue(1, 0, value, Fit.SubfieldIndexMainField);
+			}
+		}
 
-        /// <summary>
-        /// Set TimeInHrZone field
-        /// Units: s</summary>
-        /// <param name="index">0 based index of time_in_hr_zone</param>
-        /// <param name="timeInHrZone_">Nullable field value to be set</param>
-        public void SetTimeInHrZone(int index, float? timeInHrZone_)
-        {
-            SetFieldValue(2, index, timeInHrZone_, Fit.SubfieldIndexMainField);
-        }
-        
-        
-        /// <summary>
-        ///
-        /// </summary>
-        /// <returns>returns number of elements in field TimeInSpeedZone</returns>
-        public int GetNumTimeInSpeedZone()
-        {
-            return GetNumFieldValues(3, Fit.SubfieldIndexMainField);
-        }
 
-        ///<summary>
-        /// Retrieves the TimeInSpeedZone field
-        /// Units: s</summary>
-        /// <param name="index">0 based index of TimeInSpeedZone element to retrieve</param>
-        /// <returns>Returns nullable float representing the TimeInSpeedZone field</returns>
-        public float? GetTimeInSpeedZone(int index)
-        {
-            Object val = GetFieldValue(3, index, Fit.SubfieldIndexMainField);
-            if(val == null)
-            {
-                return null;
-            }
+		/// <summary>
+		///
+		/// </summary>
+		/// <returns>returns number of elements in field TimeInHrZone</returns>
+		public int GetNumTimeInHrZone()
+		{
+			return GetNumFieldValues(2, Fit.SubfieldIndexMainField);
+		}
 
-            return (Convert.ToSingle(val));
-            
-        }
+		///<summary>
+		/// Retrieves the TimeInHrZone field
+		/// Units: s</summary>
+		/// <param name="index">0 based index of TimeInHrZone element to retrieve</param>
+		/// <returns>Returns nullable float representing the TimeInHrZone field</returns>
+		public float? GetTimeInHrZone(int index)
+		{
+			Object val = GetFieldValue(2, index, Fit.SubfieldIndexMainField);
+			if (val == null)
+			{
+				return null;
+			}
 
-        /// <summary>
-        /// Set TimeInSpeedZone field
-        /// Units: s</summary>
-        /// <param name="index">0 based index of time_in_speed_zone</param>
-        /// <param name="timeInSpeedZone_">Nullable field value to be set</param>
-        public void SetTimeInSpeedZone(int index, float? timeInSpeedZone_)
-        {
-            SetFieldValue(3, index, timeInSpeedZone_, Fit.SubfieldIndexMainField);
-        }
-        
-        
-        /// <summary>
-        ///
-        /// </summary>
-        /// <returns>returns number of elements in field TimeInCadenceZone</returns>
-        public int GetNumTimeInCadenceZone()
-        {
-            return GetNumFieldValues(4, Fit.SubfieldIndexMainField);
-        }
+			return (Convert.ToSingle(val));
 
-        ///<summary>
-        /// Retrieves the TimeInCadenceZone field
-        /// Units: s</summary>
-        /// <param name="index">0 based index of TimeInCadenceZone element to retrieve</param>
-        /// <returns>Returns nullable float representing the TimeInCadenceZone field</returns>
-        public float? GetTimeInCadenceZone(int index)
-        {
-            Object val = GetFieldValue(4, index, Fit.SubfieldIndexMainField);
-            if(val == null)
-            {
-                return null;
-            }
+		}
 
-            return (Convert.ToSingle(val));
-            
-        }
+		/// <summary>
+		/// Set TimeInHrZone field
+		/// Units: s</summary>
+		/// <param name="index">0 based index of time_in_hr_zone</param>
+		/// <param name="timeInHrZone_">Nullable field value to be set</param>
+		public void SetTimeInHrZone(int index, float? timeInHrZone_)
+		{
+			SetFieldValue(2, index, timeInHrZone_, Fit.SubfieldIndexMainField);
+		}
 
-        /// <summary>
-        /// Set TimeInCadenceZone field
-        /// Units: s</summary>
-        /// <param name="index">0 based index of time_in_cadence_zone</param>
-        /// <param name="timeInCadenceZone_">Nullable field value to be set</param>
-        public void SetTimeInCadenceZone(int index, float? timeInCadenceZone_)
-        {
-            SetFieldValue(4, index, timeInCadenceZone_, Fit.SubfieldIndexMainField);
-        }
-        
-        
-        /// <summary>
-        ///
-        /// </summary>
-        /// <returns>returns number of elements in field TimeInPowerZone</returns>
-        public int GetNumTimeInPowerZone()
-        {
-            return GetNumFieldValues(5, Fit.SubfieldIndexMainField);
-        }
 
-        ///<summary>
-        /// Retrieves the TimeInPowerZone field
-        /// Units: s</summary>
-        /// <param name="index">0 based index of TimeInPowerZone element to retrieve</param>
-        /// <returns>Returns nullable float representing the TimeInPowerZone field</returns>
-        public float? GetTimeInPowerZone(int index)
-        {
-            Object val = GetFieldValue(5, index, Fit.SubfieldIndexMainField);
-            if(val == null)
-            {
-                return null;
-            }
+		/// <summary>
+		///
+		/// </summary>
+		/// <returns>returns number of elements in field TimeInSpeedZone</returns>
+		public int GetNumTimeInSpeedZone()
+		{
+			return GetNumFieldValues(3, Fit.SubfieldIndexMainField);
+		}
 
-            return (Convert.ToSingle(val));
-            
-        }
+		///<summary>
+		/// Retrieves the TimeInSpeedZone field
+		/// Units: s</summary>
+		/// <param name="index">0 based index of TimeInSpeedZone element to retrieve</param>
+		/// <returns>Returns nullable float representing the TimeInSpeedZone field</returns>
+		public float? GetTimeInSpeedZone(int index)
+		{
+			Object val = GetFieldValue(3, index, Fit.SubfieldIndexMainField);
+			if (val == null)
+			{
+				return null;
+			}
 
-        /// <summary>
-        /// Set TimeInPowerZone field
-        /// Units: s</summary>
-        /// <param name="index">0 based index of time_in_power_zone</param>
-        /// <param name="timeInPowerZone_">Nullable field value to be set</param>
-        public void SetTimeInPowerZone(int index, float? timeInPowerZone_)
-        {
-            SetFieldValue(5, index, timeInPowerZone_, Fit.SubfieldIndexMainField);
-        }
-        
-        
-        /// <summary>
-        ///
-        /// </summary>
-        /// <returns>returns number of elements in field HrZoneHighBoundary</returns>
-        public int GetNumHrZoneHighBoundary()
-        {
-            return GetNumFieldValues(6, Fit.SubfieldIndexMainField);
-        }
+			return (Convert.ToSingle(val));
 
-        ///<summary>
-        /// Retrieves the HrZoneHighBoundary field
-        /// Units: bpm</summary>
-        /// <param name="index">0 based index of HrZoneHighBoundary element to retrieve</param>
-        /// <returns>Returns nullable byte representing the HrZoneHighBoundary field</returns>
-        public byte? GetHrZoneHighBoundary(int index)
-        {
-            Object val = GetFieldValue(6, index, Fit.SubfieldIndexMainField);
-            if(val == null)
-            {
-                return null;
-            }
+		}
 
-            return (Convert.ToByte(val));
-            
-        }
+		/// <summary>
+		/// Set TimeInSpeedZone field
+		/// Units: s</summary>
+		/// <param name="index">0 based index of time_in_speed_zone</param>
+		/// <param name="timeInSpeedZone_">Nullable field value to be set</param>
+		public void SetTimeInSpeedZone(int index, float? timeInSpeedZone_)
+		{
+			SetFieldValue(3, index, timeInSpeedZone_, Fit.SubfieldIndexMainField);
+		}
 
-        /// <summary>
-        /// Set HrZoneHighBoundary field
-        /// Units: bpm</summary>
-        /// <param name="index">0 based index of hr_zone_high_boundary</param>
-        /// <param name="hrZoneHighBoundary_">Nullable field value to be set</param>
-        public void SetHrZoneHighBoundary(int index, byte? hrZoneHighBoundary_)
-        {
-            SetFieldValue(6, index, hrZoneHighBoundary_, Fit.SubfieldIndexMainField);
-        }
-        
-        
-        /// <summary>
-        ///
-        /// </summary>
-        /// <returns>returns number of elements in field SpeedZoneHighBoundary</returns>
-        public int GetNumSpeedZoneHighBoundary()
-        {
-            return GetNumFieldValues(7, Fit.SubfieldIndexMainField);
-        }
 
-        ///<summary>
-        /// Retrieves the SpeedZoneHighBoundary field
-        /// Units: m/s</summary>
-        /// <param name="index">0 based index of SpeedZoneHighBoundary element to retrieve</param>
-        /// <returns>Returns nullable float representing the SpeedZoneHighBoundary field</returns>
-        public float? GetSpeedZoneHighBoundary(int index)
-        {
-            Object val = GetFieldValue(7, index, Fit.SubfieldIndexMainField);
-            if(val == null)
-            {
-                return null;
-            }
+		/// <summary>
+		///
+		/// </summary>
+		/// <returns>returns number of elements in field TimeInCadenceZone</returns>
+		public int GetNumTimeInCadenceZone()
+		{
+			return GetNumFieldValues(4, Fit.SubfieldIndexMainField);
+		}
 
-            return (Convert.ToSingle(val));
-            
-        }
+		///<summary>
+		/// Retrieves the TimeInCadenceZone field
+		/// Units: s</summary>
+		/// <param name="index">0 based index of TimeInCadenceZone element to retrieve</param>
+		/// <returns>Returns nullable float representing the TimeInCadenceZone field</returns>
+		public float? GetTimeInCadenceZone(int index)
+		{
+			Object val = GetFieldValue(4, index, Fit.SubfieldIndexMainField);
+			if (val == null)
+			{
+				return null;
+			}
 
-        /// <summary>
-        /// Set SpeedZoneHighBoundary field
-        /// Units: m/s</summary>
-        /// <param name="index">0 based index of speed_zone_high_boundary</param>
-        /// <param name="speedZoneHighBoundary_">Nullable field value to be set</param>
-        public void SetSpeedZoneHighBoundary(int index, float? speedZoneHighBoundary_)
-        {
-            SetFieldValue(7, index, speedZoneHighBoundary_, Fit.SubfieldIndexMainField);
-        }
-        
-        
-        /// <summary>
-        ///
-        /// </summary>
-        /// <returns>returns number of elements in field CadenceZoneHighBondary</returns>
-        public int GetNumCadenceZoneHighBondary()
-        {
-            return GetNumFieldValues(8, Fit.SubfieldIndexMainField);
-        }
+			return (Convert.ToSingle(val));
 
-        ///<summary>
-        /// Retrieves the CadenceZoneHighBondary field
-        /// Units: rpm</summary>
-        /// <param name="index">0 based index of CadenceZoneHighBondary element to retrieve</param>
-        /// <returns>Returns nullable byte representing the CadenceZoneHighBondary field</returns>
-        public byte? GetCadenceZoneHighBondary(int index)
-        {
-            Object val = GetFieldValue(8, index, Fit.SubfieldIndexMainField);
-            if(val == null)
-            {
-                return null;
-            }
+		}
 
-            return (Convert.ToByte(val));
-            
-        }
+		/// <summary>
+		/// Set TimeInCadenceZone field
+		/// Units: s</summary>
+		/// <param name="index">0 based index of time_in_cadence_zone</param>
+		/// <param name="timeInCadenceZone_">Nullable field value to be set</param>
+		public void SetTimeInCadenceZone(int index, float? timeInCadenceZone_)
+		{
+			SetFieldValue(4, index, timeInCadenceZone_, Fit.SubfieldIndexMainField);
+		}
 
-        /// <summary>
-        /// Set CadenceZoneHighBondary field
-        /// Units: rpm</summary>
-        /// <param name="index">0 based index of cadence_zone_high_bondary</param>
-        /// <param name="cadenceZoneHighBondary_">Nullable field value to be set</param>
-        public void SetCadenceZoneHighBondary(int index, byte? cadenceZoneHighBondary_)
-        {
-            SetFieldValue(8, index, cadenceZoneHighBondary_, Fit.SubfieldIndexMainField);
-        }
-        
-        
-        /// <summary>
-        ///
-        /// </summary>
-        /// <returns>returns number of elements in field PowerZoneHighBoundary</returns>
-        public int GetNumPowerZoneHighBoundary()
-        {
-            return GetNumFieldValues(9, Fit.SubfieldIndexMainField);
-        }
 
-        ///<summary>
-        /// Retrieves the PowerZoneHighBoundary field
-        /// Units: watts</summary>
-        /// <param name="index">0 based index of PowerZoneHighBoundary element to retrieve</param>
-        /// <returns>Returns nullable ushort representing the PowerZoneHighBoundary field</returns>
-        public ushort? GetPowerZoneHighBoundary(int index)
-        {
-            Object val = GetFieldValue(9, index, Fit.SubfieldIndexMainField);
-            if(val == null)
-            {
-                return null;
-            }
+		/// <summary>
+		///
+		/// </summary>
+		/// <returns>returns number of elements in field TimeInPowerZone</returns>
+		public int GetNumTimeInPowerZone()
+		{
+			return GetNumFieldValues(5, Fit.SubfieldIndexMainField);
+		}
 
-            return (Convert.ToUInt16(val));
-            
-        }
+		///<summary>
+		/// Retrieves the TimeInPowerZone field
+		/// Units: s</summary>
+		/// <param name="index">0 based index of TimeInPowerZone element to retrieve</param>
+		/// <returns>Returns nullable float representing the TimeInPowerZone field</returns>
+		public float? GetTimeInPowerZone(int index)
+		{
+			Object val = GetFieldValue(5, index, Fit.SubfieldIndexMainField);
+			if (val == null)
+			{
+				return null;
+			}
 
-        /// <summary>
-        /// Set PowerZoneHighBoundary field
-        /// Units: watts</summary>
-        /// <param name="index">0 based index of power_zone_high_boundary</param>
-        /// <param name="powerZoneHighBoundary_">Nullable field value to be set</param>
-        public void SetPowerZoneHighBoundary(int index, ushort? powerZoneHighBoundary_)
-        {
-            SetFieldValue(9, index, powerZoneHighBoundary_, Fit.SubfieldIndexMainField);
-        }
-        
-        ///<summary>
-        /// Retrieves the HrCalcType field</summary>
-        /// <returns>Returns nullable HrZoneCalc enum representing the HrCalcType field</returns>
-        public HrZoneCalc? GetHrCalcType()
-        {
-            object obj = GetFieldValue(10, 0, Fit.SubfieldIndexMainField);
-            HrZoneCalc? value = obj == null ? (HrZoneCalc?)null : (HrZoneCalc)obj;
-            return value;
-        }
+			return (Convert.ToSingle(val));
 
-        /// <summary>
-        /// Set HrCalcType field</summary>
-        /// <param name="hrCalcType_">Nullable field value to be set</param>
-        public void SetHrCalcType(HrZoneCalc? hrCalcType_)
-        {
-            SetFieldValue(10, 0, hrCalcType_, Fit.SubfieldIndexMainField);
-        }
-        
-        ///<summary>
-        /// Retrieves the MaxHeartRate field</summary>
-        /// <returns>Returns nullable byte representing the MaxHeartRate field</returns>
-        public byte? GetMaxHeartRate()
-        {
-            Object val = GetFieldValue(11, 0, Fit.SubfieldIndexMainField);
-            if(val == null)
-            {
-                return null;
-            }
+		}
 
-            return (Convert.ToByte(val));
-            
-        }
+		/// <summary>
+		/// Set TimeInPowerZone field
+		/// Units: s</summary>
+		/// <param name="index">0 based index of time_in_power_zone</param>
+		/// <param name="timeInPowerZone_">Nullable field value to be set</param>
+		public void SetTimeInPowerZone(int index, float? timeInPowerZone_)
+		{
+			SetFieldValue(5, index, timeInPowerZone_, Fit.SubfieldIndexMainField);
+		}
 
-        /// <summary>
-        /// Set MaxHeartRate field</summary>
-        /// <param name="maxHeartRate_">Nullable field value to be set</param>
-        public void SetMaxHeartRate(byte? maxHeartRate_)
-        {
-            SetFieldValue(11, 0, maxHeartRate_, Fit.SubfieldIndexMainField);
-        }
-        
-        ///<summary>
-        /// Retrieves the RestingHeartRate field</summary>
-        /// <returns>Returns nullable byte representing the RestingHeartRate field</returns>
-        public byte? GetRestingHeartRate()
-        {
-            Object val = GetFieldValue(12, 0, Fit.SubfieldIndexMainField);
-            if(val == null)
-            {
-                return null;
-            }
 
-            return (Convert.ToByte(val));
-            
-        }
+		/// <summary>
+		///
+		/// </summary>
+		/// <returns>returns number of elements in field HrZoneHighBoundary</returns>
+		public int GetNumHrZoneHighBoundary()
+		{
+			return GetNumFieldValues(6, Fit.SubfieldIndexMainField);
+		}
 
-        /// <summary>
-        /// Set RestingHeartRate field</summary>
-        /// <param name="restingHeartRate_">Nullable field value to be set</param>
-        public void SetRestingHeartRate(byte? restingHeartRate_)
-        {
-            SetFieldValue(12, 0, restingHeartRate_, Fit.SubfieldIndexMainField);
-        }
-        
-        ///<summary>
-        /// Retrieves the ThresholdHeartRate field</summary>
-        /// <returns>Returns nullable byte representing the ThresholdHeartRate field</returns>
-        public byte? GetThresholdHeartRate()
-        {
-            Object val = GetFieldValue(13, 0, Fit.SubfieldIndexMainField);
-            if(val == null)
-            {
-                return null;
-            }
+		///<summary>
+		/// Retrieves the HrZoneHighBoundary field
+		/// Units: bpm</summary>
+		/// <param name="index">0 based index of HrZoneHighBoundary element to retrieve</param>
+		/// <returns>Returns nullable byte representing the HrZoneHighBoundary field</returns>
+		public byte? GetHrZoneHighBoundary(int index)
+		{
+			Object val = GetFieldValue(6, index, Fit.SubfieldIndexMainField);
+			if (val == null)
+			{
+				return null;
+			}
 
-            return (Convert.ToByte(val));
-            
-        }
+			return (Convert.ToByte(val));
 
-        /// <summary>
-        /// Set ThresholdHeartRate field</summary>
-        /// <param name="thresholdHeartRate_">Nullable field value to be set</param>
-        public void SetThresholdHeartRate(byte? thresholdHeartRate_)
-        {
-            SetFieldValue(13, 0, thresholdHeartRate_, Fit.SubfieldIndexMainField);
-        }
-        
-        ///<summary>
-        /// Retrieves the PwrCalcType field</summary>
-        /// <returns>Returns nullable PwrZoneCalc enum representing the PwrCalcType field</returns>
-        public PwrZoneCalc? GetPwrCalcType()
-        {
-            object obj = GetFieldValue(14, 0, Fit.SubfieldIndexMainField);
-            PwrZoneCalc? value = obj == null ? (PwrZoneCalc?)null : (PwrZoneCalc)obj;
-            return value;
-        }
+		}
 
-        /// <summary>
-        /// Set PwrCalcType field</summary>
-        /// <param name="pwrCalcType_">Nullable field value to be set</param>
-        public void SetPwrCalcType(PwrZoneCalc? pwrCalcType_)
-        {
-            SetFieldValue(14, 0, pwrCalcType_, Fit.SubfieldIndexMainField);
-        }
-        
-        ///<summary>
-        /// Retrieves the FunctionalThresholdPower field</summary>
-        /// <returns>Returns nullable ushort representing the FunctionalThresholdPower field</returns>
-        public ushort? GetFunctionalThresholdPower()
-        {
-            Object val = GetFieldValue(15, 0, Fit.SubfieldIndexMainField);
-            if(val == null)
-            {
-                return null;
-            }
+		/// <summary>
+		/// Set HrZoneHighBoundary field
+		/// Units: bpm</summary>
+		/// <param name="index">0 based index of hr_zone_high_boundary</param>
+		/// <param name="hrZoneHighBoundary_">Nullable field value to be set</param>
+		public void SetHrZoneHighBoundary(int index, byte? hrZoneHighBoundary_)
+		{
+			SetFieldValue(6, index, hrZoneHighBoundary_, Fit.SubfieldIndexMainField);
+		}
 
-            return (Convert.ToUInt16(val));
-            
-        }
 
-        /// <summary>
-        /// Set FunctionalThresholdPower field</summary>
-        /// <param name="functionalThresholdPower_">Nullable field value to be set</param>
-        public void SetFunctionalThresholdPower(ushort? functionalThresholdPower_)
-        {
-            SetFieldValue(15, 0, functionalThresholdPower_, Fit.SubfieldIndexMainField);
-        }
-        
-        #endregion // Methods
-    } // Class
+		/// <summary>
+		///
+		/// </summary>
+		/// <returns>returns number of elements in field SpeedZoneHighBoundary</returns>
+		public int GetNumSpeedZoneHighBoundary()
+		{
+			return GetNumFieldValues(7, Fit.SubfieldIndexMainField);
+		}
+
+		///<summary>
+		/// Retrieves the SpeedZoneHighBoundary field
+		/// Units: m/s</summary>
+		/// <param name="index">0 based index of SpeedZoneHighBoundary element to retrieve</param>
+		/// <returns>Returns nullable float representing the SpeedZoneHighBoundary field</returns>
+		public float? GetSpeedZoneHighBoundary(int index)
+		{
+			Object val = GetFieldValue(7, index, Fit.SubfieldIndexMainField);
+			if (val == null)
+			{
+				return null;
+			}
+
+			return (Convert.ToSingle(val));
+
+		}
+
+		/// <summary>
+		/// Set SpeedZoneHighBoundary field
+		/// Units: m/s</summary>
+		/// <param name="index">0 based index of speed_zone_high_boundary</param>
+		/// <param name="speedZoneHighBoundary_">Nullable field value to be set</param>
+		public void SetSpeedZoneHighBoundary(int index, float? speedZoneHighBoundary_)
+		{
+			SetFieldValue(7, index, speedZoneHighBoundary_, Fit.SubfieldIndexMainField);
+		}
+
+
+		/// <summary>
+		///
+		/// </summary>
+		/// <returns>returns number of elements in field CadenceZoneHighBondary</returns>
+		public int GetNumCadenceZoneHighBondary()
+		{
+			return GetNumFieldValues(8, Fit.SubfieldIndexMainField);
+		}
+
+		///<summary>
+		/// Retrieves the CadenceZoneHighBondary field
+		/// Units: rpm</summary>
+		/// <param name="index">0 based index of CadenceZoneHighBondary element to retrieve</param>
+		/// <returns>Returns nullable byte representing the CadenceZoneHighBondary field</returns>
+		public byte? GetCadenceZoneHighBondary(int index)
+		{
+			Object val = GetFieldValue(8, index, Fit.SubfieldIndexMainField);
+			if (val == null)
+			{
+				return null;
+			}
+
+			return (Convert.ToByte(val));
+
+		}
+
+		/// <summary>
+		/// Set CadenceZoneHighBondary field
+		/// Units: rpm</summary>
+		/// <param name="index">0 based index of cadence_zone_high_bondary</param>
+		/// <param name="cadenceZoneHighBondary_">Nullable field value to be set</param>
+		public void SetCadenceZoneHighBondary(int index, byte? cadenceZoneHighBondary_)
+		{
+			SetFieldValue(8, index, cadenceZoneHighBondary_, Fit.SubfieldIndexMainField);
+		}
+
+
+		/// <summary>
+		///
+		/// </summary>
+		/// <returns>returns number of elements in field PowerZoneHighBoundary</returns>
+		public int GetNumPowerZoneHighBoundary()
+		{
+			return GetNumFieldValues(9, Fit.SubfieldIndexMainField);
+		}
+
+		///<summary>
+		/// Retrieves the PowerZoneHighBoundary field
+		/// Units: watts</summary>
+		/// <param name="index">0 based index of PowerZoneHighBoundary element to retrieve</param>
+		/// <returns>Returns nullable ushort representing the PowerZoneHighBoundary field</returns>
+		public ushort? GetPowerZoneHighBoundary(int index)
+		{
+			Object val = GetFieldValue(9, index, Fit.SubfieldIndexMainField);
+			if (val == null)
+			{
+				return null;
+			}
+
+			return (Convert.ToUInt16(val));
+
+		}
+
+		/// <summary>
+		/// Set PowerZoneHighBoundary field
+		/// Units: watts</summary>
+		/// <param name="index">0 based index of power_zone_high_boundary</param>
+		/// <param name="powerZoneHighBoundary_">Nullable field value to be set</param>
+		public void SetPowerZoneHighBoundary(int index, ushort? powerZoneHighBoundary_)
+		{
+			SetFieldValue(9, index, powerZoneHighBoundary_, Fit.SubfieldIndexMainField);
+		}
+
+		///<summary>
+		/// Retrieves the HrCalcType field</summary>
+		/// <returns>Returns nullable HrZoneCalc enum representing the HrCalcType field</returns>
+		public HrZoneCalc? HrCalcType
+		{
+			get
+			{
+				object obj = GetFieldValue(10, 0, Fit.SubfieldIndexMainField);
+				HrZoneCalc? value = obj == null ? (HrZoneCalc?)null : (HrZoneCalc)obj;
+				return value;
+			}
+			set
+			{
+				SetFieldValue(10, 0, value, Fit.SubfieldIndexMainField);
+			}
+		}
+
+		///<summary>
+		/// Retrieves the MaxHeartRate field</summary>
+		/// <returns>Returns nullable byte representing the MaxHeartRate field</returns>
+		public byte? MaxHeartRate
+		{
+			get
+			{
+				Object val = GetFieldValue(11, 0, Fit.SubfieldIndexMainField);
+				if (val == null)
+				{
+					return null;
+				}
+
+				return (Convert.ToByte(val));
+
+			}
+			set
+			{
+				SetFieldValue(11, 0, value, Fit.SubfieldIndexMainField);
+			}
+		}
+
+		///<summary>
+		/// Retrieves the RestingHeartRate field</summary>
+		/// <returns>Returns nullable byte representing the RestingHeartRate field</returns>
+		public byte? RestingHeartRate
+		{
+			get
+			{
+				Object val = GetFieldValue(12, 0, Fit.SubfieldIndexMainField);
+				if (val == null)
+				{
+					return null;
+				}
+
+				return (Convert.ToByte(val));
+
+			}
+			set
+			{
+				SetFieldValue(12, 0, value, Fit.SubfieldIndexMainField);
+			}
+		}
+
+		///<summary>
+		/// Retrieves the ThresholdHeartRate field</summary>
+		/// <returns>Returns nullable byte representing the ThresholdHeartRate field</returns>
+		public byte? ThresholdHeartRate
+		{
+			get
+			{
+				Object val = GetFieldValue(13, 0, Fit.SubfieldIndexMainField);
+				if (val == null)
+				{
+					return null;
+				}
+
+				return (Convert.ToByte(val));
+
+			}
+			set
+			{
+				SetFieldValue(13, 0, value, Fit.SubfieldIndexMainField);
+			}
+		}
+
+		///<summary>
+		/// Retrieves the PwrCalcType field</summary>
+		/// <returns>Returns nullable PwrZoneCalc enum representing the PwrCalcType field</returns>
+		public PwrZoneCalc? PwrCalcType
+		{
+			get
+			{
+				object obj = GetFieldValue(14, 0, Fit.SubfieldIndexMainField);
+				PwrZoneCalc? value = obj == null ? (PwrZoneCalc?)null : (PwrZoneCalc)obj;
+				return value;
+			}
+			set
+			{
+				SetFieldValue(14, 0, value, Fit.SubfieldIndexMainField);
+			}
+		}
+
+		///<summary>
+		/// Retrieves the FunctionalThresholdPower field</summary>
+		/// <returns>Returns nullable ushort representing the FunctionalThresholdPower field</returns>
+		public ushort? FunctionalThresholdPower
+		{
+			get
+			{
+				Object val = GetFieldValue(15, 0, Fit.SubfieldIndexMainField);
+				if (val == null)
+				{
+					return null;
+				}
+
+				return (Convert.ToUInt16(val));
+
+			}
+			set
+			{
+				SetFieldValue(15, 0, value, Fit.SubfieldIndexMainField);
+			}
+		}
+
+		#endregion // Methods
+	} // Class
 } // namespace

--- a/Dynastream/Fit/Profile/Mesgs/TimestampCorrelationMesg.cs
+++ b/Dynastream/Fit/Profile/Mesgs/TimestampCorrelationMesg.cs
@@ -21,229 +21,208 @@ using System.Linq;
 
 namespace Dynastream.Fit
 {
-    /// <summary>
-    /// Implements the TimestampCorrelation profile message.
-    /// </summary>
-    public class TimestampCorrelationMesg : Mesg
-    {
-        #region Fields
-        #endregion
+	/// <summary>
+	/// Implements the TimestampCorrelation profile message.
+	/// </summary>
+	public class TimestampCorrelationMesg : Mesg
+	{
+		#region Fields
+		#endregion
 
-        /// <summary>
-        /// Field Numbers for <see cref="TimestampCorrelationMesg"/>
-        /// </summary>
-        public sealed class FieldDefNum
-        {
-            public const byte Timestamp = 253;
-            public const byte FractionalTimestamp = 0;
-            public const byte SystemTimestamp = 1;
-            public const byte FractionalSystemTimestamp = 2;
-            public const byte LocalTimestamp = 3;
-            public const byte TimestampMs = 4;
-            public const byte SystemTimestampMs = 5;
-            public const byte Invalid = Fit.FieldNumInvalid;
-        }
+		/// <summary>
+		/// Field Numbers for <see cref="TimestampCorrelationMesg"/>
+		/// </summary>
+		public sealed class FieldDefNum
+		{
+			public const byte Timestamp = 253;
+			public const byte FractionalTimestamp = 0;
+			public const byte SystemTimestamp = 1;
+			public const byte FractionalSystemTimestamp = 2;
+			public const byte LocalTimestamp = 3;
+			public const byte TimestampMs = 4;
+			public const byte SystemTimestampMs = 5;
+			public const byte Invalid = Fit.FieldNumInvalid;
+		}
 
-        #region Constructors
-        public TimestampCorrelationMesg() : base(Profile.GetMesg(MesgNum.TimestampCorrelation))
-        {
-        }
+		#region Constructors
+		public TimestampCorrelationMesg() : base(Profile.GetMesg(MesgNum.TimestampCorrelation))
+		{
+		}
 
-        public TimestampCorrelationMesg(Mesg mesg) : base(mesg)
-        {
-        }
-        #endregion // Constructors
+		public TimestampCorrelationMesg(Mesg mesg) : base(mesg)
+		{
+		}
+		#endregion // Constructors
 
-        #region Methods
-        ///<summary>
-        /// Retrieves the Timestamp field
-        /// Units: s
-        /// Comment: Whole second part of UTC timestamp at the time the system timestamp was recorded.</summary>
-        /// <returns>Returns DateTime representing the Timestamp field</returns>
-        public DateTime GetTimestamp()
-        {
-            Object val = GetFieldValue(253, 0, Fit.SubfieldIndexMainField);
-            if(val == null)
-            {
-                return null;
-            }
+		#region Methods
+		///<summary>
+		/// Retrieves the Timestamp field
+		/// Units: s
+		/// Comment: Whole second part of UTC timestamp at the time the system timestamp was recorded.</summary>
+		/// <returns>Returns DateTime representing the Timestamp field</returns>
+		public DateTime Timestamp
+		{
+			get
+			{
+				Object val = GetFieldValue(253, 0, Fit.SubfieldIndexMainField);
+				if (val == null)
+				{
+					return null;
+				}
 
-            return TimestampToDateTime(Convert.ToUInt32(val));
-            
-        }
+				return TimestampToDateTime(Convert.ToUInt32(val));
 
-        /// <summary>
-        /// Set Timestamp field
-        /// Units: s
-        /// Comment: Whole second part of UTC timestamp at the time the system timestamp was recorded.</summary>
-        /// <param name="timestamp_">Nullable field value to be set</param>
-        public void SetTimestamp(DateTime timestamp_)
-        {
-            SetFieldValue(253, 0, timestamp_.GetTimeStamp(), Fit.SubfieldIndexMainField);
-        }
-        
-        ///<summary>
-        /// Retrieves the FractionalTimestamp field
-        /// Units: s
-        /// Comment: Fractional part of the UTC timestamp at the time the system timestamp was recorded.</summary>
-        /// <returns>Returns nullable float representing the FractionalTimestamp field</returns>
-        public float? GetFractionalTimestamp()
-        {
-            Object val = GetFieldValue(0, 0, Fit.SubfieldIndexMainField);
-            if(val == null)
-            {
-                return null;
-            }
+			}
+			set
+			{
+				SetFieldValue(253, 0, value.GetTimeStamp(), Fit.SubfieldIndexMainField);
+			}
+		}
 
-            return (Convert.ToSingle(val));
-            
-        }
+		///<summary>
+		/// Retrieves the FractionalTimestamp field
+		/// Units: s
+		/// Comment: Fractional part of the UTC timestamp at the time the system timestamp was recorded.</summary>
+		/// <returns>Returns nullable float representing the FractionalTimestamp field</returns>
+		public float? FractionalTimestamp
+		{
+			get
+			{
+				Object val = GetFieldValue(0, 0, Fit.SubfieldIndexMainField);
+				if (val == null)
+				{
+					return null;
+				}
 
-        /// <summary>
-        /// Set FractionalTimestamp field
-        /// Units: s
-        /// Comment: Fractional part of the UTC timestamp at the time the system timestamp was recorded.</summary>
-        /// <param name="fractionalTimestamp_">Nullable field value to be set</param>
-        public void SetFractionalTimestamp(float? fractionalTimestamp_)
-        {
-            SetFieldValue(0, 0, fractionalTimestamp_, Fit.SubfieldIndexMainField);
-        }
-        
-        ///<summary>
-        /// Retrieves the SystemTimestamp field
-        /// Units: s
-        /// Comment: Whole second part of the system timestamp</summary>
-        /// <returns>Returns DateTime representing the SystemTimestamp field</returns>
-        public DateTime GetSystemTimestamp()
-        {
-            Object val = GetFieldValue(1, 0, Fit.SubfieldIndexMainField);
-            if(val == null)
-            {
-                return null;
-            }
+				return (Convert.ToSingle(val));
 
-            return TimestampToDateTime(Convert.ToUInt32(val));
-            
-        }
+			}
+			set
+			{
+				SetFieldValue(0, 0, value, Fit.SubfieldIndexMainField);
+			}
+		}
 
-        /// <summary>
-        /// Set SystemTimestamp field
-        /// Units: s
-        /// Comment: Whole second part of the system timestamp</summary>
-        /// <param name="systemTimestamp_">Nullable field value to be set</param>
-        public void SetSystemTimestamp(DateTime systemTimestamp_)
-        {
-            SetFieldValue(1, 0, systemTimestamp_.GetTimeStamp(), Fit.SubfieldIndexMainField);
-        }
-        
-        ///<summary>
-        /// Retrieves the FractionalSystemTimestamp field
-        /// Units: s
-        /// Comment: Fractional part of the system timestamp</summary>
-        /// <returns>Returns nullable float representing the FractionalSystemTimestamp field</returns>
-        public float? GetFractionalSystemTimestamp()
-        {
-            Object val = GetFieldValue(2, 0, Fit.SubfieldIndexMainField);
-            if(val == null)
-            {
-                return null;
-            }
+		///<summary>
+		/// Retrieves the SystemTimestamp field
+		/// Units: s
+		/// Comment: Whole second part of the system timestamp</summary>
+		/// <returns>Returns DateTime representing the SystemTimestamp field</returns>
+		public DateTime SystemTimestamp
+		{
+			get
+			{
+				Object val = GetFieldValue(1, 0, Fit.SubfieldIndexMainField);
+				if (val == null)
+				{
+					return null;
+				}
 
-            return (Convert.ToSingle(val));
-            
-        }
+				return TimestampToDateTime(Convert.ToUInt32(val));
 
-        /// <summary>
-        /// Set FractionalSystemTimestamp field
-        /// Units: s
-        /// Comment: Fractional part of the system timestamp</summary>
-        /// <param name="fractionalSystemTimestamp_">Nullable field value to be set</param>
-        public void SetFractionalSystemTimestamp(float? fractionalSystemTimestamp_)
-        {
-            SetFieldValue(2, 0, fractionalSystemTimestamp_, Fit.SubfieldIndexMainField);
-        }
-        
-        ///<summary>
-        /// Retrieves the LocalTimestamp field
-        /// Units: s
-        /// Comment: timestamp epoch expressed in local time used to convert timestamps to local time</summary>
-        /// <returns>Returns nullable uint representing the LocalTimestamp field</returns>
-        public uint? GetLocalTimestamp()
-        {
-            Object val = GetFieldValue(3, 0, Fit.SubfieldIndexMainField);
-            if(val == null)
-            {
-                return null;
-            }
+			}
+			set
+			{
+				SetFieldValue(1, 0, value.GetTimeStamp(), Fit.SubfieldIndexMainField);
+			}
+		}
 
-            return (Convert.ToUInt32(val));
-            
-        }
+		///<summary>
+		/// Retrieves the FractionalSystemTimestamp field
+		/// Units: s
+		/// Comment: Fractional part of the system timestamp</summary>
+		/// <returns>Returns nullable float representing the FractionalSystemTimestamp field</returns>
+		public float? FractionalSystemTimestamp
+		{
+			get
+			{
+				Object val = GetFieldValue(2, 0, Fit.SubfieldIndexMainField);
+				if (val == null)
+				{
+					return null;
+				}
 
-        /// <summary>
-        /// Set LocalTimestamp field
-        /// Units: s
-        /// Comment: timestamp epoch expressed in local time used to convert timestamps to local time</summary>
-        /// <param name="localTimestamp_">Nullable field value to be set</param>
-        public void SetLocalTimestamp(uint? localTimestamp_)
-        {
-            SetFieldValue(3, 0, localTimestamp_, Fit.SubfieldIndexMainField);
-        }
-        
-        ///<summary>
-        /// Retrieves the TimestampMs field
-        /// Units: ms
-        /// Comment: Millisecond part of the UTC timestamp at the time the system timestamp was recorded.</summary>
-        /// <returns>Returns nullable ushort representing the TimestampMs field</returns>
-        public ushort? GetTimestampMs()
-        {
-            Object val = GetFieldValue(4, 0, Fit.SubfieldIndexMainField);
-            if(val == null)
-            {
-                return null;
-            }
+				return (Convert.ToSingle(val));
 
-            return (Convert.ToUInt16(val));
-            
-        }
+			}
+			set
+			{
+				SetFieldValue(2, 0, value, Fit.SubfieldIndexMainField);
+			}
+		}
 
-        /// <summary>
-        /// Set TimestampMs field
-        /// Units: ms
-        /// Comment: Millisecond part of the UTC timestamp at the time the system timestamp was recorded.</summary>
-        /// <param name="timestampMs_">Nullable field value to be set</param>
-        public void SetTimestampMs(ushort? timestampMs_)
-        {
-            SetFieldValue(4, 0, timestampMs_, Fit.SubfieldIndexMainField);
-        }
-        
-        ///<summary>
-        /// Retrieves the SystemTimestampMs field
-        /// Units: ms
-        /// Comment: Millisecond part of the system timestamp</summary>
-        /// <returns>Returns nullable ushort representing the SystemTimestampMs field</returns>
-        public ushort? GetSystemTimestampMs()
-        {
-            Object val = GetFieldValue(5, 0, Fit.SubfieldIndexMainField);
-            if(val == null)
-            {
-                return null;
-            }
+		///<summary>
+		/// Retrieves the LocalTimestamp field
+		/// Units: s
+		/// Comment: timestamp epoch expressed in local time used to convert timestamps to local time</summary>
+		/// <returns>Returns nullable uint representing the LocalTimestamp field</returns>
+		public uint? LocalTimestamp
+		{
+			get
+			{
+				Object val = GetFieldValue(3, 0, Fit.SubfieldIndexMainField);
+				if (val == null)
+				{
+					return null;
+				}
 
-            return (Convert.ToUInt16(val));
-            
-        }
+				return (Convert.ToUInt32(val));
 
-        /// <summary>
-        /// Set SystemTimestampMs field
-        /// Units: ms
-        /// Comment: Millisecond part of the system timestamp</summary>
-        /// <param name="systemTimestampMs_">Nullable field value to be set</param>
-        public void SetSystemTimestampMs(ushort? systemTimestampMs_)
-        {
-            SetFieldValue(5, 0, systemTimestampMs_, Fit.SubfieldIndexMainField);
-        }
-        
-        #endregion // Methods
-    } // Class
+			}
+			set
+			{
+				SetFieldValue(3, 0, value, Fit.SubfieldIndexMainField);
+			}
+		}
+
+		///<summary>
+		/// Retrieves the TimestampMs field
+		/// Units: ms
+		/// Comment: Millisecond part of the UTC timestamp at the time the system timestamp was recorded.</summary>
+		/// <returns>Returns nullable ushort representing the TimestampMs field</returns>
+		public ushort? TimestampMs
+		{
+			get
+			{
+				Object val = GetFieldValue(4, 0, Fit.SubfieldIndexMainField);
+				if (val == null)
+				{
+					return null;
+				}
+
+				return (Convert.ToUInt16(val));
+
+			}
+			set
+			{
+				SetFieldValue(4, 0, value, Fit.SubfieldIndexMainField);
+			}
+		}
+
+		///<summary>
+		/// Retrieves the SystemTimestampMs field
+		/// Units: ms
+		/// Comment: Millisecond part of the system timestamp</summary>
+		/// <returns>Returns nullable ushort representing the SystemTimestampMs field</returns>
+		public ushort? SystemTimestampMs
+		{
+			get
+			{
+				Object val = GetFieldValue(5, 0, Fit.SubfieldIndexMainField);
+				if (val == null)
+				{
+					return null;
+				}
+
+				return (Convert.ToUInt16(val));
+
+			}
+			set
+			{
+				SetFieldValue(5, 0, value, Fit.SubfieldIndexMainField);
+			}
+		}
+
+		#endregion // Methods
+	} // Class
 } // namespace

--- a/Dynastream/Fit/Profile/Mesgs/TotalsMesg.cs
+++ b/Dynastream/Fit/Profile/Mesgs/TotalsMesg.cs
@@ -21,284 +21,266 @@ using System.Linq;
 
 namespace Dynastream.Fit
 {
-    /// <summary>
-    /// Implements the Totals profile message.
-    /// </summary>
-    public class TotalsMesg : Mesg
-    {
-        #region Fields
-        #endregion
+	/// <summary>
+	/// Implements the Totals profile message.
+	/// </summary>
+	public class TotalsMesg : Mesg
+	{
+		#region Fields
+		#endregion
 
-        /// <summary>
-        /// Field Numbers for <see cref="TotalsMesg"/>
-        /// </summary>
-        public sealed class FieldDefNum
-        {
-            public const byte MessageIndex = 254;
-            public const byte Timestamp = 253;
-            public const byte TimerTime = 0;
-            public const byte Distance = 1;
-            public const byte Calories = 2;
-            public const byte Sport = 3;
-            public const byte ElapsedTime = 4;
-            public const byte Sessions = 5;
-            public const byte ActiveTime = 6;
-            public const byte SportIndex = 9;
-            public const byte Invalid = Fit.FieldNumInvalid;
-        }
+		/// <summary>
+		/// Field Numbers for <see cref="TotalsMesg"/>
+		/// </summary>
+		public sealed class FieldDefNum
+		{
+			public const byte MessageIndex = 254;
+			public const byte Timestamp = 253;
+			public const byte TimerTime = 0;
+			public const byte Distance = 1;
+			public const byte Calories = 2;
+			public const byte Sport = 3;
+			public const byte ElapsedTime = 4;
+			public const byte Sessions = 5;
+			public const byte ActiveTime = 6;
+			public const byte SportIndex = 9;
+			public const byte Invalid = Fit.FieldNumInvalid;
+		}
 
-        #region Constructors
-        public TotalsMesg() : base(Profile.GetMesg(MesgNum.Totals))
-        {
-        }
+		#region Constructors
+		public TotalsMesg() : base(Profile.GetMesg(MesgNum.Totals))
+		{
+		}
 
-        public TotalsMesg(Mesg mesg) : base(mesg)
-        {
-        }
-        #endregion // Constructors
+		public TotalsMesg(Mesg mesg) : base(mesg)
+		{
+		}
+		#endregion // Constructors
 
-        #region Methods
-        ///<summary>
-        /// Retrieves the MessageIndex field</summary>
-        /// <returns>Returns nullable ushort representing the MessageIndex field</returns>
-        public ushort? GetMessageIndex()
-        {
-            Object val = GetFieldValue(254, 0, Fit.SubfieldIndexMainField);
-            if(val == null)
-            {
-                return null;
-            }
+		#region Methods
+		///<summary>
+		/// Retrieves the MessageIndex field</summary>
+		/// <returns>Returns nullable ushort representing the MessageIndex field</returns>
+		public ushort? MessageIndex
+		{
+			get
+			{
+				Object val = GetFieldValue(254, 0, Fit.SubfieldIndexMainField);
+				if (val == null)
+				{
+					return null;
+				}
 
-            return (Convert.ToUInt16(val));
-            
-        }
+				return (Convert.ToUInt16(val));
 
-        /// <summary>
-        /// Set MessageIndex field</summary>
-        /// <param name="messageIndex_">Nullable field value to be set</param>
-        public void SetMessageIndex(ushort? messageIndex_)
-        {
-            SetFieldValue(254, 0, messageIndex_, Fit.SubfieldIndexMainField);
-        }
-        
-        ///<summary>
-        /// Retrieves the Timestamp field
-        /// Units: s</summary>
-        /// <returns>Returns DateTime representing the Timestamp field</returns>
-        public DateTime GetTimestamp()
-        {
-            Object val = GetFieldValue(253, 0, Fit.SubfieldIndexMainField);
-            if(val == null)
-            {
-                return null;
-            }
+			}
+			set
+			{
+				SetFieldValue(254, 0, value, Fit.SubfieldIndexMainField);
+			}
+		}
 
-            return TimestampToDateTime(Convert.ToUInt32(val));
-            
-        }
+		///<summary>
+		/// Retrieves the Timestamp field
+		/// Units: s</summary>
+		/// <returns>Returns DateTime representing the Timestamp field</returns>
+		public DateTime Timestamp
+		{
+			get
+			{
+				Object val = GetFieldValue(253, 0, Fit.SubfieldIndexMainField);
+				if (val == null)
+				{
+					return null;
+				}
 
-        /// <summary>
-        /// Set Timestamp field
-        /// Units: s</summary>
-        /// <param name="timestamp_">Nullable field value to be set</param>
-        public void SetTimestamp(DateTime timestamp_)
-        {
-            SetFieldValue(253, 0, timestamp_.GetTimeStamp(), Fit.SubfieldIndexMainField);
-        }
-        
-        ///<summary>
-        /// Retrieves the TimerTime field
-        /// Units: s
-        /// Comment: Excludes pauses</summary>
-        /// <returns>Returns nullable uint representing the TimerTime field</returns>
-        public uint? GetTimerTime()
-        {
-            Object val = GetFieldValue(0, 0, Fit.SubfieldIndexMainField);
-            if(val == null)
-            {
-                return null;
-            }
+				return TimestampToDateTime(Convert.ToUInt32(val));
 
-            return (Convert.ToUInt32(val));
-            
-        }
+			}
+			set
+			{
+				SetFieldValue(253, 0, value.GetTimeStamp(), Fit.SubfieldIndexMainField);
+			}
+		}
 
-        /// <summary>
-        /// Set TimerTime field
-        /// Units: s
-        /// Comment: Excludes pauses</summary>
-        /// <param name="timerTime_">Nullable field value to be set</param>
-        public void SetTimerTime(uint? timerTime_)
-        {
-            SetFieldValue(0, 0, timerTime_, Fit.SubfieldIndexMainField);
-        }
-        
-        ///<summary>
-        /// Retrieves the Distance field
-        /// Units: m</summary>
-        /// <returns>Returns nullable uint representing the Distance field</returns>
-        public uint? GetDistance()
-        {
-            Object val = GetFieldValue(1, 0, Fit.SubfieldIndexMainField);
-            if(val == null)
-            {
-                return null;
-            }
+		///<summary>
+		/// Retrieves the TimerTime field
+		/// Units: s
+		/// Comment: Excludes pauses</summary>
+		/// <returns>Returns nullable uint representing the TimerTime field</returns>
+		public uint? TimerTime
+		{
+			get
+			{
+				Object val = GetFieldValue(0, 0, Fit.SubfieldIndexMainField);
+				if (val == null)
+				{
+					return null;
+				}
 
-            return (Convert.ToUInt32(val));
-            
-        }
+				return (Convert.ToUInt32(val));
 
-        /// <summary>
-        /// Set Distance field
-        /// Units: m</summary>
-        /// <param name="distance_">Nullable field value to be set</param>
-        public void SetDistance(uint? distance_)
-        {
-            SetFieldValue(1, 0, distance_, Fit.SubfieldIndexMainField);
-        }
-        
-        ///<summary>
-        /// Retrieves the Calories field
-        /// Units: kcal</summary>
-        /// <returns>Returns nullable uint representing the Calories field</returns>
-        public uint? GetCalories()
-        {
-            Object val = GetFieldValue(2, 0, Fit.SubfieldIndexMainField);
-            if(val == null)
-            {
-                return null;
-            }
+			}
+			set
+			{
+				SetFieldValue(0, 0, value, Fit.SubfieldIndexMainField);
+			}
+		}
 
-            return (Convert.ToUInt32(val));
-            
-        }
+		///<summary>
+		/// Retrieves the Distance field
+		/// Units: m</summary>
+		/// <returns>Returns nullable uint representing the Distance field</returns>
+		public uint? Distance
+		{
+			get
+			{
+				Object val = GetFieldValue(1, 0, Fit.SubfieldIndexMainField);
+				if (val == null)
+				{
+					return null;
+				}
 
-        /// <summary>
-        /// Set Calories field
-        /// Units: kcal</summary>
-        /// <param name="calories_">Nullable field value to be set</param>
-        public void SetCalories(uint? calories_)
-        {
-            SetFieldValue(2, 0, calories_, Fit.SubfieldIndexMainField);
-        }
-        
-        ///<summary>
-        /// Retrieves the Sport field</summary>
-        /// <returns>Returns nullable Sport enum representing the Sport field</returns>
-        public Sport? GetSport()
-        {
-            object obj = GetFieldValue(3, 0, Fit.SubfieldIndexMainField);
-            Sport? value = obj == null ? (Sport?)null : (Sport)obj;
-            return value;
-        }
+				return (Convert.ToUInt32(val));
 
-        /// <summary>
-        /// Set Sport field</summary>
-        /// <param name="sport_">Nullable field value to be set</param>
-        public void SetSport(Sport? sport_)
-        {
-            SetFieldValue(3, 0, sport_, Fit.SubfieldIndexMainField);
-        }
-        
-        ///<summary>
-        /// Retrieves the ElapsedTime field
-        /// Units: s
-        /// Comment: Includes pauses</summary>
-        /// <returns>Returns nullable uint representing the ElapsedTime field</returns>
-        public uint? GetElapsedTime()
-        {
-            Object val = GetFieldValue(4, 0, Fit.SubfieldIndexMainField);
-            if(val == null)
-            {
-                return null;
-            }
+			}
+			set
+			{
+				SetFieldValue(1, 0, value, Fit.SubfieldIndexMainField);
+			}
+		}
 
-            return (Convert.ToUInt32(val));
-            
-        }
+		///<summary>
+		/// Retrieves the Calories field
+		/// Units: kcal</summary>
+		/// <returns>Returns nullable uint representing the Calories field</returns>
+		public uint? Calories
+		{
+			get
+			{
+				Object val = GetFieldValue(2, 0, Fit.SubfieldIndexMainField);
+				if (val == null)
+				{
+					return null;
+				}
 
-        /// <summary>
-        /// Set ElapsedTime field
-        /// Units: s
-        /// Comment: Includes pauses</summary>
-        /// <param name="elapsedTime_">Nullable field value to be set</param>
-        public void SetElapsedTime(uint? elapsedTime_)
-        {
-            SetFieldValue(4, 0, elapsedTime_, Fit.SubfieldIndexMainField);
-        }
-        
-        ///<summary>
-        /// Retrieves the Sessions field</summary>
-        /// <returns>Returns nullable ushort representing the Sessions field</returns>
-        public ushort? GetSessions()
-        {
-            Object val = GetFieldValue(5, 0, Fit.SubfieldIndexMainField);
-            if(val == null)
-            {
-                return null;
-            }
+				return (Convert.ToUInt32(val));
 
-            return (Convert.ToUInt16(val));
-            
-        }
+			}
+			set
+			{
+				SetFieldValue(2, 0, value, Fit.SubfieldIndexMainField);
+			}
+		}
 
-        /// <summary>
-        /// Set Sessions field</summary>
-        /// <param name="sessions_">Nullable field value to be set</param>
-        public void SetSessions(ushort? sessions_)
-        {
-            SetFieldValue(5, 0, sessions_, Fit.SubfieldIndexMainField);
-        }
-        
-        ///<summary>
-        /// Retrieves the ActiveTime field
-        /// Units: s</summary>
-        /// <returns>Returns nullable uint representing the ActiveTime field</returns>
-        public uint? GetActiveTime()
-        {
-            Object val = GetFieldValue(6, 0, Fit.SubfieldIndexMainField);
-            if(val == null)
-            {
-                return null;
-            }
+		///<summary>
+		/// Retrieves the Sport field</summary>
+		/// <returns>Returns nullable Sport enum representing the Sport field</returns>
+		public Sport? Sport
+		{
+			get
+			{
+				object obj = GetFieldValue(3, 0, Fit.SubfieldIndexMainField);
+				Sport? value = obj == null ? (Sport?)null : (Sport)obj;
+				return value;
+			}
+			set
+			{
+				SetFieldValue(3, 0, value, Fit.SubfieldIndexMainField);
+			}
+		}
 
-            return (Convert.ToUInt32(val));
-            
-        }
+		///<summary>
+		/// Retrieves the ElapsedTime field
+		/// Units: s
+		/// Comment: Includes pauses</summary>
+		/// <returns>Returns nullable uint representing the ElapsedTime field</returns>
+		public uint? ElapsedTime
+		{
+			get
+			{
+				Object val = GetFieldValue(4, 0, Fit.SubfieldIndexMainField);
+				if (val == null)
+				{
+					return null;
+				}
 
-        /// <summary>
-        /// Set ActiveTime field
-        /// Units: s</summary>
-        /// <param name="activeTime_">Nullable field value to be set</param>
-        public void SetActiveTime(uint? activeTime_)
-        {
-            SetFieldValue(6, 0, activeTime_, Fit.SubfieldIndexMainField);
-        }
-        
-        ///<summary>
-        /// Retrieves the SportIndex field</summary>
-        /// <returns>Returns nullable byte representing the SportIndex field</returns>
-        public byte? GetSportIndex()
-        {
-            Object val = GetFieldValue(9, 0, Fit.SubfieldIndexMainField);
-            if(val == null)
-            {
-                return null;
-            }
+				return (Convert.ToUInt32(val));
 
-            return (Convert.ToByte(val));
-            
-        }
+			}
+			set
+			{
+				SetFieldValue(4, 0, value, Fit.SubfieldIndexMainField);
+			}
+		}
 
-        /// <summary>
-        /// Set SportIndex field</summary>
-        /// <param name="sportIndex_">Nullable field value to be set</param>
-        public void SetSportIndex(byte? sportIndex_)
-        {
-            SetFieldValue(9, 0, sportIndex_, Fit.SubfieldIndexMainField);
-        }
-        
-        #endregion // Methods
-    } // Class
+		///<summary>
+		/// Retrieves the Sessions field</summary>
+		/// <returns>Returns nullable ushort representing the Sessions field</returns>
+		public ushort? Sessions
+		{
+			get
+			{
+				Object val = GetFieldValue(5, 0, Fit.SubfieldIndexMainField);
+				if (val == null)
+				{
+					return null;
+				}
+
+				return (Convert.ToUInt16(val));
+
+			}
+			set
+			{
+				SetFieldValue(5, 0, value, Fit.SubfieldIndexMainField);
+			}
+		}
+
+		///<summary>
+		/// Retrieves the ActiveTime field
+		/// Units: s</summary>
+		/// <returns>Returns nullable uint representing the ActiveTime field</returns>
+		public uint? ActiveTime
+		{
+			get
+			{
+				Object val = GetFieldValue(6, 0, Fit.SubfieldIndexMainField);
+				if (val == null)
+				{
+					return null;
+				}
+
+				return (Convert.ToUInt32(val));
+
+			}
+			set
+			{
+				SetFieldValue(6, 0, value, Fit.SubfieldIndexMainField);
+			}
+		}
+
+		///<summary>
+		/// Retrieves the SportIndex field</summary>
+		/// <returns>Returns nullable byte representing the SportIndex field</returns>
+		public byte? SportIndex
+		{
+			get
+			{
+				Object val = GetFieldValue(9, 0, Fit.SubfieldIndexMainField);
+				if (val == null)
+				{
+					return null;
+				}
+
+				return (Convert.ToByte(val));
+
+			}
+			set
+			{
+				SetFieldValue(9, 0, value, Fit.SubfieldIndexMainField);
+			}
+		}
+
+		#endregion // Methods
+	} // Class
 } // namespace

--- a/Dynastream/Fit/Profile/Mesgs/TrainingFileMesg.cs
+++ b/Dynastream/Fit/Profile/Mesgs/TrainingFileMesg.cs
@@ -21,228 +21,218 @@ using System.Linq;
 
 namespace Dynastream.Fit
 {
-    /// <summary>
-    /// Implements the TrainingFile profile message.
-    /// </summary>
-    public class TrainingFileMesg : Mesg
-    {
-        #region Fields
-        static class ProductSubfield
-        {
-            public static ushort FaveroProduct = 0;
-            public static ushort GarminProduct = 1;
-            public static ushort Subfields = 2;
-            public static ushort Active = Fit.SubfieldIndexActiveSubfield;
-            public static ushort MainField = Fit.SubfieldIndexMainField;
-        }
-        #endregion
+	/// <summary>
+	/// Implements the TrainingFile profile message.
+	/// </summary>
+	public class TrainingFileMesg : Mesg
+	{
+		#region Fields
+		static class ProductSubfield
+		{
+			public static ushort FaveroProduct = 0;
+			public static ushort GarminProduct = 1;
+			public static ushort Subfields = 2;
+			public static ushort Active = Fit.SubfieldIndexActiveSubfield;
+			public static ushort MainField = Fit.SubfieldIndexMainField;
+		}
+		#endregion
 
-        /// <summary>
-        /// Field Numbers for <see cref="TrainingFileMesg"/>
-        /// </summary>
-        public sealed class FieldDefNum
-        {
-            public const byte Timestamp = 253;
-            public const byte Type = 0;
-            public const byte Manufacturer = 1;
-            public const byte Product = 2;
-            public const byte SerialNumber = 3;
-            public const byte TimeCreated = 4;
-            public const byte Invalid = Fit.FieldNumInvalid;
-        }
+		/// <summary>
+		/// Field Numbers for <see cref="TrainingFileMesg"/>
+		/// </summary>
+		public sealed class FieldDefNum
+		{
+			public const byte Timestamp = 253;
+			public const byte Type = 0;
+			public const byte Manufacturer = 1;
+			public const byte Product = 2;
+			public const byte SerialNumber = 3;
+			public const byte TimeCreated = 4;
+			public const byte Invalid = Fit.FieldNumInvalid;
+		}
 
-        #region Constructors
-        public TrainingFileMesg() : base(Profile.GetMesg(MesgNum.TrainingFile))
-        {
-        }
+		#region Constructors
+		public TrainingFileMesg() : base(Profile.GetMesg(MesgNum.TrainingFile))
+		{
+		}
 
-        public TrainingFileMesg(Mesg mesg) : base(mesg)
-        {
-        }
-        #endregion // Constructors
+		public TrainingFileMesg(Mesg mesg) : base(mesg)
+		{
+		}
+		#endregion // Constructors
 
-        #region Methods
-        ///<summary>
-        /// Retrieves the Timestamp field</summary>
-        /// <returns>Returns DateTime representing the Timestamp field</returns>
-        public DateTime GetTimestamp()
-        {
-            Object val = GetFieldValue(253, 0, Fit.SubfieldIndexMainField);
-            if(val == null)
-            {
-                return null;
-            }
+		#region Methods
+		///<summary>
+		/// Retrieves the Timestamp field</summary>
+		/// <returns>Returns DateTime representing the Timestamp field</returns>
+		public DateTime Timestamp
+		{
+			get
+			{
+				Object val = GetFieldValue(253, 0, Fit.SubfieldIndexMainField);
+				if (val == null)
+				{
+					return null;
+				}
 
-            return TimestampToDateTime(Convert.ToUInt32(val));
-            
-        }
+				return TimestampToDateTime(Convert.ToUInt32(val));
 
-        /// <summary>
-        /// Set Timestamp field</summary>
-        /// <param name="timestamp_">Nullable field value to be set</param>
-        public void SetTimestamp(DateTime timestamp_)
-        {
-            SetFieldValue(253, 0, timestamp_.GetTimeStamp(), Fit.SubfieldIndexMainField);
-        }
-        
-        ///<summary>
-        /// Retrieves the Type field</summary>
-        /// <returns>Returns nullable File enum representing the Type field</returns>
-        new public File? GetType()
-        {
-            object obj = GetFieldValue(0, 0, Fit.SubfieldIndexMainField);
-            File? value = obj == null ? (File?)null : (File)obj;
-            return value;
-        }
+			}
+			set
+			{
+				SetFieldValue(253, 0, value.GetTimeStamp(), Fit.SubfieldIndexMainField);
+			}
+		}
 
-        /// <summary>
-        /// Set Type field</summary>
-        /// <param name="type_">Nullable field value to be set</param>
-        public void SetType(File? type_)
-        {
-            SetFieldValue(0, 0, type_, Fit.SubfieldIndexMainField);
-        }
-        
-        ///<summary>
-        /// Retrieves the Manufacturer field</summary>
-        /// <returns>Returns nullable ushort representing the Manufacturer field</returns>
-        public ushort? GetManufacturer()
-        {
-            Object val = GetFieldValue(1, 0, Fit.SubfieldIndexMainField);
-            if(val == null)
-            {
-                return null;
-            }
+		///<summary>
+		/// Retrieves the Type field</summary>
+		/// <returns>Returns nullable File enum representing the Type field</returns>
+		public File? Type
+		{
+			get
+			{
+				object obj = GetFieldValue(0, 0, Fit.SubfieldIndexMainField);
+				File? value = obj == null ? (File?)null : (File)obj;
+				return value;
+			}
+			set
+			{
+				SetFieldValue(0, 0, value, Fit.SubfieldIndexMainField);
+			}
+		}
 
-            return (Convert.ToUInt16(val));
-            
-        }
+		///<summary>
+		/// Retrieves the Manufacturer field</summary>
+		/// <returns>Returns nullable ushort representing the Manufacturer field</returns>
+		public ushort? Manufacturer
+		{
+			get
+			{
+				Object val = GetFieldValue(1, 0, Fit.SubfieldIndexMainField);
+				if (val == null)
+				{
+					return null;
+				}
 
-        /// <summary>
-        /// Set Manufacturer field</summary>
-        /// <param name="manufacturer_">Nullable field value to be set</param>
-        public void SetManufacturer(ushort? manufacturer_)
-        {
-            SetFieldValue(1, 0, manufacturer_, Fit.SubfieldIndexMainField);
-        }
-        
-        ///<summary>
-        /// Retrieves the Product field</summary>
-        /// <returns>Returns nullable ushort representing the Product field</returns>
-        public ushort? GetProduct()
-        {
-            Object val = GetFieldValue(2, 0, Fit.SubfieldIndexMainField);
-            if(val == null)
-            {
-                return null;
-            }
+				return (Convert.ToUInt16(val));
 
-            return (Convert.ToUInt16(val));
-            
-        }
+			}
+			set
+			{
+				SetFieldValue(1, 0, value, Fit.SubfieldIndexMainField);
+			}
+		}
 
-        /// <summary>
-        /// Set Product field</summary>
-        /// <param name="product_">Nullable field value to be set</param>
-        public void SetProduct(ushort? product_)
-        {
-            SetFieldValue(2, 0, product_, Fit.SubfieldIndexMainField);
-        }
-        
+		///<summary>
+		/// Retrieves the Product field</summary>
+		/// <returns>Returns nullable ushort representing the Product field</returns>
+		public ushort? Product
+		{
+			get
+			{
+				Object val = GetFieldValue(2, 0, Fit.SubfieldIndexMainField);
+				if (val == null)
+				{
+					return null;
+				}
 
-        /// <summary>
-        /// Retrieves the FaveroProduct subfield</summary>
-        /// <returns>Nullable ushort representing the FaveroProduct subfield</returns>
-        public ushort? GetFaveroProduct()
-        {
-            Object val = GetFieldValue(2, 0, ProductSubfield.FaveroProduct);
-            if(val == null)
-            {
-                return null;
-            }
+				return (Convert.ToUInt16(val));
 
-            return (Convert.ToUInt16(val));
-            
-        }
+			}
+			set
+			{
+				SetFieldValue(2, 0, value, Fit.SubfieldIndexMainField);
+			}
+		}
 
-        /// <summary>
-        ///
-        /// Set FaveroProduct subfield</summary>
-        /// <param name="faveroProduct">Subfield value to be set</param>
-        public void SetFaveroProduct(ushort? faveroProduct)
-        {
-            SetFieldValue(2, 0, faveroProduct, ProductSubfield.FaveroProduct);
-        }
 
-        /// <summary>
-        /// Retrieves the GarminProduct subfield</summary>
-        /// <returns>Nullable ushort representing the GarminProduct subfield</returns>
-        public ushort? GetGarminProduct()
-        {
-            Object val = GetFieldValue(2, 0, ProductSubfield.GarminProduct);
-            if(val == null)
-            {
-                return null;
-            }
+		/// <summary>
+		/// Retrieves the FaveroProduct subfield</summary>
+		/// <returns>Nullable ushort representing the FaveroProduct subfield</returns>
+		public ushort? FaveroProduct
+		{
+			get
+			{
+				Object val = GetFieldValue(2, 0, ProductSubfield.FaveroProduct);
+				if (val == null)
+				{
+					return null;
+				}
 
-            return (Convert.ToUInt16(val));
-            
-        }
+				return (Convert.ToUInt16(val));
 
-        /// <summary>
-        ///
-        /// Set GarminProduct subfield</summary>
-        /// <param name="garminProduct">Subfield value to be set</param>
-        public void SetGarminProduct(ushort? garminProduct)
-        {
-            SetFieldValue(2, 0, garminProduct, ProductSubfield.GarminProduct);
-        }
-        ///<summary>
-        /// Retrieves the SerialNumber field</summary>
-        /// <returns>Returns nullable uint representing the SerialNumber field</returns>
-        public uint? GetSerialNumber()
-        {
-            Object val = GetFieldValue(3, 0, Fit.SubfieldIndexMainField);
-            if(val == null)
-            {
-                return null;
-            }
+			}
+			set
+			{
+				SetFieldValue(2, 0, value, ProductSubfield.FaveroProduct);
+			}
+		}
 
-            return (Convert.ToUInt32(val));
-            
-        }
+		/// <summary>
+		/// Retrieves the GarminProduct subfield</summary>
+		/// <returns>Nullable ushort representing the GarminProduct subfield</returns>
+		public ushort? GarminProduct
+		{
+			get
+			{
+				Object val = GetFieldValue(2, 0, ProductSubfield.GarminProduct);
+				if (val == null)
+				{
+					return null;
+				}
 
-        /// <summary>
-        /// Set SerialNumber field</summary>
-        /// <param name="serialNumber_">Nullable field value to be set</param>
-        public void SetSerialNumber(uint? serialNumber_)
-        {
-            SetFieldValue(3, 0, serialNumber_, Fit.SubfieldIndexMainField);
-        }
-        
-        ///<summary>
-        /// Retrieves the TimeCreated field</summary>
-        /// <returns>Returns DateTime representing the TimeCreated field</returns>
-        public DateTime GetTimeCreated()
-        {
-            Object val = GetFieldValue(4, 0, Fit.SubfieldIndexMainField);
-            if(val == null)
-            {
-                return null;
-            }
+				return (Convert.ToUInt16(val));
 
-            return TimestampToDateTime(Convert.ToUInt32(val));
-            
-        }
+			}
+			set
+			{
+				SetFieldValue(2, 0, value, ProductSubfield.GarminProduct);
+			}
+		}
+		///<summary>
+		/// Retrieves the SerialNumber field</summary>
+		/// <returns>Returns nullable uint representing the SerialNumber field</returns>
+		public uint? SerialNumber
+		{
+			get
+			{
+				Object val = GetFieldValue(3, 0, Fit.SubfieldIndexMainField);
+				if (val == null)
+				{
+					return null;
+				}
 
-        /// <summary>
-        /// Set TimeCreated field</summary>
-        /// <param name="timeCreated_">Nullable field value to be set</param>
-        public void SetTimeCreated(DateTime timeCreated_)
-        {
-            SetFieldValue(4, 0, timeCreated_.GetTimeStamp(), Fit.SubfieldIndexMainField);
-        }
-        
-        #endregion // Methods
-    } // Class
+				return (Convert.ToUInt32(val));
+
+			}
+			set
+			{
+				SetFieldValue(3, 0, value, Fit.SubfieldIndexMainField);
+			}
+		}
+
+		///<summary>
+		/// Retrieves the TimeCreated field</summary>
+		/// <returns>Returns DateTime representing the TimeCreated field</returns>
+		public DateTime TimeCreated
+		{
+			get
+			{
+				Object val = GetFieldValue(4, 0, Fit.SubfieldIndexMainField);
+				if (val == null)
+				{
+					return null;
+				}
+
+				return TimestampToDateTime(Convert.ToUInt32(val));
+
+			}
+			set
+			{
+				SetFieldValue(4, 0, value.GetTimeStamp(), Fit.SubfieldIndexMainField);
+			}
+		}
+
+		#endregion // Methods
+	} // Class
 } // namespace

--- a/Dynastream/Fit/Profile/Mesgs/UserProfileMesg.cs
+++ b/Dynastream/Fit/Profile/Mesgs/UserProfileMesg.cs
@@ -21,721 +21,678 @@ using System.Linq;
 
 namespace Dynastream.Fit
 {
-    /// <summary>
-    /// Implements the UserProfile profile message.
-    /// </summary>
-    public class UserProfileMesg : Mesg
-    {
-        #region Fields
-        #endregion
+	/// <summary>
+	/// Implements the UserProfile profile message.
+	/// </summary>
+	public class UserProfileMesg : Mesg
+	{
+		#region Fields
+		#endregion
 
-        /// <summary>
-        /// Field Numbers for <see cref="UserProfileMesg"/>
-        /// </summary>
-        public sealed class FieldDefNum
-        {
-            public const byte MessageIndex = 254;
-            public const byte FriendlyName = 0;
-            public const byte Gender = 1;
-            public const byte Age = 2;
-            public const byte Height = 3;
-            public const byte Weight = 4;
-            public const byte Language = 5;
-            public const byte ElevSetting = 6;
-            public const byte WeightSetting = 7;
-            public const byte RestingHeartRate = 8;
-            public const byte DefaultMaxRunningHeartRate = 9;
-            public const byte DefaultMaxBikingHeartRate = 10;
-            public const byte DefaultMaxHeartRate = 11;
-            public const byte HrSetting = 12;
-            public const byte SpeedSetting = 13;
-            public const byte DistSetting = 14;
-            public const byte PowerSetting = 16;
-            public const byte ActivityClass = 17;
-            public const byte PositionSetting = 18;
-            public const byte TemperatureSetting = 21;
-            public const byte LocalId = 22;
-            public const byte GlobalId = 23;
-            public const byte WakeTime = 28;
-            public const byte SleepTime = 29;
-            public const byte HeightSetting = 30;
-            public const byte UserRunningStepLength = 31;
-            public const byte UserWalkingStepLength = 32;
-            public const byte DepthSetting = 47;
-            public const byte DiveCount = 49;
-            public const byte Invalid = Fit.FieldNumInvalid;
-        }
+		/// <summary>
+		/// Field Numbers for <see cref="UserProfileMesg"/>
+		/// </summary>
+		public sealed class FieldDefNum
+		{
+			public const byte MessageIndex = 254;
+			public const byte FriendlyName = 0;
+			public const byte Gender = 1;
+			public const byte Age = 2;
+			public const byte Height = 3;
+			public const byte Weight = 4;
+			public const byte Language = 5;
+			public const byte ElevSetting = 6;
+			public const byte WeightSetting = 7;
+			public const byte RestingHeartRate = 8;
+			public const byte DefaultMaxRunningHeartRate = 9;
+			public const byte DefaultMaxBikingHeartRate = 10;
+			public const byte DefaultMaxHeartRate = 11;
+			public const byte HrSetting = 12;
+			public const byte SpeedSetting = 13;
+			public const byte DistSetting = 14;
+			public const byte PowerSetting = 16;
+			public const byte ActivityClass = 17;
+			public const byte PositionSetting = 18;
+			public const byte TemperatureSetting = 21;
+			public const byte LocalId = 22;
+			public const byte GlobalId = 23;
+			public const byte WakeTime = 28;
+			public const byte SleepTime = 29;
+			public const byte HeightSetting = 30;
+			public const byte UserRunningStepLength = 31;
+			public const byte UserWalkingStepLength = 32;
+			public const byte DepthSetting = 47;
+			public const byte DiveCount = 49;
+			public const byte Invalid = Fit.FieldNumInvalid;
+		}
 
-        #region Constructors
-        public UserProfileMesg() : base(Profile.GetMesg(MesgNum.UserProfile))
-        {
-        }
+		#region Constructors
+		public UserProfileMesg() : base(Profile.GetMesg(MesgNum.UserProfile))
+		{
+		}
 
-        public UserProfileMesg(Mesg mesg) : base(mesg)
-        {
-        }
-        #endregion // Constructors
+		public UserProfileMesg(Mesg mesg) : base(mesg)
+		{
+		}
+		#endregion // Constructors
 
-        #region Methods
-        ///<summary>
-        /// Retrieves the MessageIndex field</summary>
-        /// <returns>Returns nullable ushort representing the MessageIndex field</returns>
-        public ushort? GetMessageIndex()
-        {
-            Object val = GetFieldValue(254, 0, Fit.SubfieldIndexMainField);
-            if(val == null)
-            {
-                return null;
-            }
+		#region Methods
+		///<summary>
+		/// Retrieves the MessageIndex field</summary>
+		/// <returns>Returns nullable ushort representing the MessageIndex field</returns>
+		public ushort? MessageIndex
+		{
+			get
+			{
+				Object val = GetFieldValue(254, 0, Fit.SubfieldIndexMainField);
+				if (val == null)
+				{
+					return null;
+				}
 
-            return (Convert.ToUInt16(val));
-            
-        }
+				return (Convert.ToUInt16(val));
 
-        /// <summary>
-        /// Set MessageIndex field</summary>
-        /// <param name="messageIndex_">Nullable field value to be set</param>
-        public void SetMessageIndex(ushort? messageIndex_)
-        {
-            SetFieldValue(254, 0, messageIndex_, Fit.SubfieldIndexMainField);
-        }
-        
-        ///<summary>
-        /// Retrieves the FriendlyName field
-        /// Comment: Used for Morning Report greeting</summary>
-        /// <returns>Returns byte[] representing the FriendlyName field</returns>
-        public byte[] GetFriendlyName()
-        {
-            byte[] data = (byte[])GetFieldValue(0, 0, Fit.SubfieldIndexMainField);
-            return data.Take(data.Length - 1).ToArray();
-        }
+			}
+			set
+			{
+				SetFieldValue(254, 0, value, Fit.SubfieldIndexMainField);
+			}
+		}
 
-        ///<summary>
-        /// Retrieves the FriendlyName field
-        /// Comment: Used for Morning Report greeting</summary>
-        /// <returns>Returns String representing the FriendlyName field</returns>
-        public String GetFriendlyNameAsString()
-        {
-            byte[] data = (byte[])GetFieldValue(0, 0, Fit.SubfieldIndexMainField);
-            return data != null ? Encoding.UTF8.GetString(data, 0, data.Length - 1) : null;
-        }
+		///<summary>
+		/// Retrieves the FriendlyName field
+		/// Comment: Used for Morning Report greeting</summary>
+		/// <returns>Returns byte[] representing the FriendlyName field</returns>
+		public byte[] FriendlyName
+		{
+			get
+			{
+				byte[] data = (byte[])GetFieldValue(0, 0, Fit.SubfieldIndexMainField);
+				return data.Take(data.Length - 1).ToArray();
+			}
+			set
+			{
+				SetFieldValue(0, 0, value, Fit.SubfieldIndexMainField);
+			}
+		}
 
-        ///<summary>
-        /// Set FriendlyName field
-        /// Comment: Used for Morning Report greeting</summary>
-        /// <param name="friendlyName_"> field value to be set</param>
-        public void SetFriendlyName(String friendlyName_)
-        {
-            byte[] data = Encoding.UTF8.GetBytes(friendlyName_);
-            byte[] zdata = new byte[data.Length + 1];
-            data.CopyTo(zdata, 0);
-            SetFieldValue(0, 0, zdata, Fit.SubfieldIndexMainField);
-        }
+		///<summary>
+		/// Retrieves the FriendlyName field
+		/// Comment: Used for Morning Report greeting</summary>
+		/// <returns>Returns String representing the FriendlyName field</returns>
+		public String GetFriendlyNameAsString()
+		{
+			byte[] data = (byte[])GetFieldValue(0, 0, Fit.SubfieldIndexMainField);
+			return data != null ? Encoding.UTF8.GetString(data, 0, data.Length - 1) : null;
+		}
 
-        
-        /// <summary>
-        /// Set FriendlyName field
-        /// Comment: Used for Morning Report greeting</summary>
-        /// <param name="friendlyName_">field value to be set</param>
-        public void SetFriendlyName(byte[] friendlyName_)
-        {
-            SetFieldValue(0, 0, friendlyName_, Fit.SubfieldIndexMainField);
-        }
-        
-        ///<summary>
-        /// Retrieves the Gender field</summary>
-        /// <returns>Returns nullable Gender enum representing the Gender field</returns>
-        public Gender? GetGender()
-        {
-            object obj = GetFieldValue(1, 0, Fit.SubfieldIndexMainField);
-            Gender? value = obj == null ? (Gender?)null : (Gender)obj;
-            return value;
-        }
+		///<summary>
+		/// Set FriendlyName field
+		/// Comment: Used for Morning Report greeting</summary>
+		/// <param name="friendlyName_"> field value to be set</param>
+		public void SetFriendlyName(String friendlyName_)
+		{
+			byte[] data = Encoding.UTF8.GetBytes(friendlyName_);
+			byte[] zdata = new byte[data.Length + 1];
+			data.CopyTo(zdata, 0);
+			SetFieldValue(0, 0, zdata, Fit.SubfieldIndexMainField);
+		}
 
-        /// <summary>
-        /// Set Gender field</summary>
-        /// <param name="gender_">Nullable field value to be set</param>
-        public void SetGender(Gender? gender_)
-        {
-            SetFieldValue(1, 0, gender_, Fit.SubfieldIndexMainField);
-        }
-        
-        ///<summary>
-        /// Retrieves the Age field
-        /// Units: years</summary>
-        /// <returns>Returns nullable byte representing the Age field</returns>
-        public byte? GetAge()
-        {
-            Object val = GetFieldValue(2, 0, Fit.SubfieldIndexMainField);
-            if(val == null)
-            {
-                return null;
-            }
+		///<summary>
+		/// Retrieves the Gender field</summary>
+		/// <returns>Returns nullable Gender enum representing the Gender field</returns>
+		public Gender? Gender
+		{
+			get
+			{
+				object obj = GetFieldValue(1, 0, Fit.SubfieldIndexMainField);
+				Gender? value = obj == null ? (Gender?)null : (Gender)obj;
+				return value;
+			}
+			set
+			{
+				SetFieldValue(1, 0, value, Fit.SubfieldIndexMainField);
+			}
+		}
 
-            return (Convert.ToByte(val));
-            
-        }
+		///<summary>
+		/// Retrieves the Age field
+		/// Units: years</summary>
+		/// <returns>Returns nullable byte representing the Age field</returns>
+		public byte? Age
+		{
+			get
+			{
+				Object val = GetFieldValue(2, 0, Fit.SubfieldIndexMainField);
+				if (val == null)
+				{
+					return null;
+				}
 
-        /// <summary>
-        /// Set Age field
-        /// Units: years</summary>
-        /// <param name="age_">Nullable field value to be set</param>
-        public void SetAge(byte? age_)
-        {
-            SetFieldValue(2, 0, age_, Fit.SubfieldIndexMainField);
-        }
-        
-        ///<summary>
-        /// Retrieves the Height field
-        /// Units: m</summary>
-        /// <returns>Returns nullable float representing the Height field</returns>
-        public float? GetHeight()
-        {
-            Object val = GetFieldValue(3, 0, Fit.SubfieldIndexMainField);
-            if(val == null)
-            {
-                return null;
-            }
+				return (Convert.ToByte(val));
 
-            return (Convert.ToSingle(val));
-            
-        }
+			}
+			set
+			{
+				SetFieldValue(2, 0, value, Fit.SubfieldIndexMainField);
+			}
+		}
 
-        /// <summary>
-        /// Set Height field
-        /// Units: m</summary>
-        /// <param name="height_">Nullable field value to be set</param>
-        public void SetHeight(float? height_)
-        {
-            SetFieldValue(3, 0, height_, Fit.SubfieldIndexMainField);
-        }
-        
-        ///<summary>
-        /// Retrieves the Weight field
-        /// Units: kg</summary>
-        /// <returns>Returns nullable float representing the Weight field</returns>
-        public float? GetWeight()
-        {
-            Object val = GetFieldValue(4, 0, Fit.SubfieldIndexMainField);
-            if(val == null)
-            {
-                return null;
-            }
+		///<summary>
+		/// Retrieves the Height field
+		/// Units: m</summary>
+		/// <returns>Returns nullable float representing the Height field</returns>
+		public float? Height
+		{
+			get
+			{
+				Object val = GetFieldValue(3, 0, Fit.SubfieldIndexMainField);
+				if (val == null)
+				{
+					return null;
+				}
 
-            return (Convert.ToSingle(val));
-            
-        }
+				return (Convert.ToSingle(val));
 
-        /// <summary>
-        /// Set Weight field
-        /// Units: kg</summary>
-        /// <param name="weight_">Nullable field value to be set</param>
-        public void SetWeight(float? weight_)
-        {
-            SetFieldValue(4, 0, weight_, Fit.SubfieldIndexMainField);
-        }
-        
-        ///<summary>
-        /// Retrieves the Language field</summary>
-        /// <returns>Returns nullable Language enum representing the Language field</returns>
-        public Language? GetLanguage()
-        {
-            object obj = GetFieldValue(5, 0, Fit.SubfieldIndexMainField);
-            Language? value = obj == null ? (Language?)null : (Language)obj;
-            return value;
-        }
+			}
+			set
+			{
+				SetFieldValue(3, 0, value, Fit.SubfieldIndexMainField);
+			}
+		}
 
-        /// <summary>
-        /// Set Language field</summary>
-        /// <param name="language_">Nullable field value to be set</param>
-        public void SetLanguage(Language? language_)
-        {
-            SetFieldValue(5, 0, language_, Fit.SubfieldIndexMainField);
-        }
-        
-        ///<summary>
-        /// Retrieves the ElevSetting field</summary>
-        /// <returns>Returns nullable DisplayMeasure enum representing the ElevSetting field</returns>
-        public DisplayMeasure? GetElevSetting()
-        {
-            object obj = GetFieldValue(6, 0, Fit.SubfieldIndexMainField);
-            DisplayMeasure? value = obj == null ? (DisplayMeasure?)null : (DisplayMeasure)obj;
-            return value;
-        }
+		///<summary>
+		/// Retrieves the Weight field
+		/// Units: kg</summary>
+		/// <returns>Returns nullable float representing the Weight field</returns>
+		public float? Weight
+		{
+			get
+			{
+				Object val = GetFieldValue(4, 0, Fit.SubfieldIndexMainField);
+				if (val == null)
+				{
+					return null;
+				}
 
-        /// <summary>
-        /// Set ElevSetting field</summary>
-        /// <param name="elevSetting_">Nullable field value to be set</param>
-        public void SetElevSetting(DisplayMeasure? elevSetting_)
-        {
-            SetFieldValue(6, 0, elevSetting_, Fit.SubfieldIndexMainField);
-        }
-        
-        ///<summary>
-        /// Retrieves the WeightSetting field</summary>
-        /// <returns>Returns nullable DisplayMeasure enum representing the WeightSetting field</returns>
-        public DisplayMeasure? GetWeightSetting()
-        {
-            object obj = GetFieldValue(7, 0, Fit.SubfieldIndexMainField);
-            DisplayMeasure? value = obj == null ? (DisplayMeasure?)null : (DisplayMeasure)obj;
-            return value;
-        }
+				return (Convert.ToSingle(val));
 
-        /// <summary>
-        /// Set WeightSetting field</summary>
-        /// <param name="weightSetting_">Nullable field value to be set</param>
-        public void SetWeightSetting(DisplayMeasure? weightSetting_)
-        {
-            SetFieldValue(7, 0, weightSetting_, Fit.SubfieldIndexMainField);
-        }
-        
-        ///<summary>
-        /// Retrieves the RestingHeartRate field
-        /// Units: bpm</summary>
-        /// <returns>Returns nullable byte representing the RestingHeartRate field</returns>
-        public byte? GetRestingHeartRate()
-        {
-            Object val = GetFieldValue(8, 0, Fit.SubfieldIndexMainField);
-            if(val == null)
-            {
-                return null;
-            }
+			}
+			set
+			{
+				SetFieldValue(4, 0, value, Fit.SubfieldIndexMainField);
+			}
+		}
 
-            return (Convert.ToByte(val));
-            
-        }
+		///<summary>
+		/// Retrieves the Language field</summary>
+		/// <returns>Returns nullable Language enum representing the Language field</returns>
+		public Language? Language
+		{
+			get
+			{
+				object obj = GetFieldValue(5, 0, Fit.SubfieldIndexMainField);
+				Language? value = obj == null ? (Language?)null : (Language)obj;
+				return value;
+			}
+			set
+			{
+				SetFieldValue(5, 0, value, Fit.SubfieldIndexMainField);
+			}
+		}
 
-        /// <summary>
-        /// Set RestingHeartRate field
-        /// Units: bpm</summary>
-        /// <param name="restingHeartRate_">Nullable field value to be set</param>
-        public void SetRestingHeartRate(byte? restingHeartRate_)
-        {
-            SetFieldValue(8, 0, restingHeartRate_, Fit.SubfieldIndexMainField);
-        }
-        
-        ///<summary>
-        /// Retrieves the DefaultMaxRunningHeartRate field
-        /// Units: bpm</summary>
-        /// <returns>Returns nullable byte representing the DefaultMaxRunningHeartRate field</returns>
-        public byte? GetDefaultMaxRunningHeartRate()
-        {
-            Object val = GetFieldValue(9, 0, Fit.SubfieldIndexMainField);
-            if(val == null)
-            {
-                return null;
-            }
+		///<summary>
+		/// Retrieves the ElevSetting field</summary>
+		/// <returns>Returns nullable DisplayMeasure enum representing the ElevSetting field</returns>
+		public DisplayMeasure? ElevSetting
+		{
+			get
+			{
+				object obj = GetFieldValue(6, 0, Fit.SubfieldIndexMainField);
+				DisplayMeasure? value = obj == null ? (DisplayMeasure?)null : (DisplayMeasure)obj;
+				return value;
+			}
+			set
+			{
+				SetFieldValue(6, 0, value, Fit.SubfieldIndexMainField);
+			}
+		}
 
-            return (Convert.ToByte(val));
-            
-        }
+		///<summary>
+		/// Retrieves the WeightSetting field</summary>
+		/// <returns>Returns nullable DisplayMeasure enum representing the WeightSetting field</returns>
+		public DisplayMeasure? WeightSetting
+		{
+			get
+			{
+				object obj = GetFieldValue(7, 0, Fit.SubfieldIndexMainField);
+				DisplayMeasure? value = obj == null ? (DisplayMeasure?)null : (DisplayMeasure)obj;
+				return value;
+			}
+			set
+			{
+				SetFieldValue(7, 0, value, Fit.SubfieldIndexMainField);
+			}
+		}
 
-        /// <summary>
-        /// Set DefaultMaxRunningHeartRate field
-        /// Units: bpm</summary>
-        /// <param name="defaultMaxRunningHeartRate_">Nullable field value to be set</param>
-        public void SetDefaultMaxRunningHeartRate(byte? defaultMaxRunningHeartRate_)
-        {
-            SetFieldValue(9, 0, defaultMaxRunningHeartRate_, Fit.SubfieldIndexMainField);
-        }
-        
-        ///<summary>
-        /// Retrieves the DefaultMaxBikingHeartRate field
-        /// Units: bpm</summary>
-        /// <returns>Returns nullable byte representing the DefaultMaxBikingHeartRate field</returns>
-        public byte? GetDefaultMaxBikingHeartRate()
-        {
-            Object val = GetFieldValue(10, 0, Fit.SubfieldIndexMainField);
-            if(val == null)
-            {
-                return null;
-            }
+		///<summary>
+		/// Retrieves the RestingHeartRate field
+		/// Units: bpm</summary>
+		/// <returns>Returns nullable byte representing the RestingHeartRate field</returns>
+		public byte? RestingHeartRate
+		{
+			get
+			{
+				Object val = GetFieldValue(8, 0, Fit.SubfieldIndexMainField);
+				if (val == null)
+				{
+					return null;
+				}
 
-            return (Convert.ToByte(val));
-            
-        }
+				return (Convert.ToByte(val));
 
-        /// <summary>
-        /// Set DefaultMaxBikingHeartRate field
-        /// Units: bpm</summary>
-        /// <param name="defaultMaxBikingHeartRate_">Nullable field value to be set</param>
-        public void SetDefaultMaxBikingHeartRate(byte? defaultMaxBikingHeartRate_)
-        {
-            SetFieldValue(10, 0, defaultMaxBikingHeartRate_, Fit.SubfieldIndexMainField);
-        }
-        
-        ///<summary>
-        /// Retrieves the DefaultMaxHeartRate field
-        /// Units: bpm</summary>
-        /// <returns>Returns nullable byte representing the DefaultMaxHeartRate field</returns>
-        public byte? GetDefaultMaxHeartRate()
-        {
-            Object val = GetFieldValue(11, 0, Fit.SubfieldIndexMainField);
-            if(val == null)
-            {
-                return null;
-            }
+			}
+			set
+			{
+				SetFieldValue(8, 0, value, Fit.SubfieldIndexMainField);
+			}
+		}
 
-            return (Convert.ToByte(val));
-            
-        }
+		///<summary>
+		/// Retrieves the DefaultMaxRunningHeartRate field
+		/// Units: bpm</summary>
+		/// <returns>Returns nullable byte representing the DefaultMaxRunningHeartRate field</returns>
+		public byte? DefaultMaxRunningHeartRate
+		{
+			get
+			{
+				Object val = GetFieldValue(9, 0, Fit.SubfieldIndexMainField);
+				if (val == null)
+				{
+					return null;
+				}
 
-        /// <summary>
-        /// Set DefaultMaxHeartRate field
-        /// Units: bpm</summary>
-        /// <param name="defaultMaxHeartRate_">Nullable field value to be set</param>
-        public void SetDefaultMaxHeartRate(byte? defaultMaxHeartRate_)
-        {
-            SetFieldValue(11, 0, defaultMaxHeartRate_, Fit.SubfieldIndexMainField);
-        }
-        
-        ///<summary>
-        /// Retrieves the HrSetting field</summary>
-        /// <returns>Returns nullable DisplayHeart enum representing the HrSetting field</returns>
-        public DisplayHeart? GetHrSetting()
-        {
-            object obj = GetFieldValue(12, 0, Fit.SubfieldIndexMainField);
-            DisplayHeart? value = obj == null ? (DisplayHeart?)null : (DisplayHeart)obj;
-            return value;
-        }
+				return (Convert.ToByte(val));
 
-        /// <summary>
-        /// Set HrSetting field</summary>
-        /// <param name="hrSetting_">Nullable field value to be set</param>
-        public void SetHrSetting(DisplayHeart? hrSetting_)
-        {
-            SetFieldValue(12, 0, hrSetting_, Fit.SubfieldIndexMainField);
-        }
-        
-        ///<summary>
-        /// Retrieves the SpeedSetting field</summary>
-        /// <returns>Returns nullable DisplayMeasure enum representing the SpeedSetting field</returns>
-        public DisplayMeasure? GetSpeedSetting()
-        {
-            object obj = GetFieldValue(13, 0, Fit.SubfieldIndexMainField);
-            DisplayMeasure? value = obj == null ? (DisplayMeasure?)null : (DisplayMeasure)obj;
-            return value;
-        }
+			}
+			set
+			{
+				SetFieldValue(9, 0, value, Fit.SubfieldIndexMainField);
+			}
+		}
 
-        /// <summary>
-        /// Set SpeedSetting field</summary>
-        /// <param name="speedSetting_">Nullable field value to be set</param>
-        public void SetSpeedSetting(DisplayMeasure? speedSetting_)
-        {
-            SetFieldValue(13, 0, speedSetting_, Fit.SubfieldIndexMainField);
-        }
-        
-        ///<summary>
-        /// Retrieves the DistSetting field</summary>
-        /// <returns>Returns nullable DisplayMeasure enum representing the DistSetting field</returns>
-        public DisplayMeasure? GetDistSetting()
-        {
-            object obj = GetFieldValue(14, 0, Fit.SubfieldIndexMainField);
-            DisplayMeasure? value = obj == null ? (DisplayMeasure?)null : (DisplayMeasure)obj;
-            return value;
-        }
+		///<summary>
+		/// Retrieves the DefaultMaxBikingHeartRate field
+		/// Units: bpm</summary>
+		/// <returns>Returns nullable byte representing the DefaultMaxBikingHeartRate field</returns>
+		public byte? DefaultMaxBikingHeartRate
+		{
+			get
+			{
+				Object val = GetFieldValue(10, 0, Fit.SubfieldIndexMainField);
+				if (val == null)
+				{
+					return null;
+				}
 
-        /// <summary>
-        /// Set DistSetting field</summary>
-        /// <param name="distSetting_">Nullable field value to be set</param>
-        public void SetDistSetting(DisplayMeasure? distSetting_)
-        {
-            SetFieldValue(14, 0, distSetting_, Fit.SubfieldIndexMainField);
-        }
-        
-        ///<summary>
-        /// Retrieves the PowerSetting field</summary>
-        /// <returns>Returns nullable DisplayPower enum representing the PowerSetting field</returns>
-        public DisplayPower? GetPowerSetting()
-        {
-            object obj = GetFieldValue(16, 0, Fit.SubfieldIndexMainField);
-            DisplayPower? value = obj == null ? (DisplayPower?)null : (DisplayPower)obj;
-            return value;
-        }
+				return (Convert.ToByte(val));
 
-        /// <summary>
-        /// Set PowerSetting field</summary>
-        /// <param name="powerSetting_">Nullable field value to be set</param>
-        public void SetPowerSetting(DisplayPower? powerSetting_)
-        {
-            SetFieldValue(16, 0, powerSetting_, Fit.SubfieldIndexMainField);
-        }
-        
-        ///<summary>
-        /// Retrieves the ActivityClass field</summary>
-        /// <returns>Returns nullable ActivityClass enum representing the ActivityClass field</returns>
-        public ActivityClass? GetActivityClass()
-        {
-            object obj = GetFieldValue(17, 0, Fit.SubfieldIndexMainField);
-            ActivityClass? value = obj == null ? (ActivityClass?)null : (ActivityClass)obj;
-            return value;
-        }
+			}
+			set
+			{
+				SetFieldValue(10, 0, value, Fit.SubfieldIndexMainField);
+			}
+		}
 
-        /// <summary>
-        /// Set ActivityClass field</summary>
-        /// <param name="activityClass_">Nullable field value to be set</param>
-        public void SetActivityClass(ActivityClass? activityClass_)
-        {
-            SetFieldValue(17, 0, activityClass_, Fit.SubfieldIndexMainField);
-        }
-        
-        ///<summary>
-        /// Retrieves the PositionSetting field</summary>
-        /// <returns>Returns nullable DisplayPosition enum representing the PositionSetting field</returns>
-        public DisplayPosition? GetPositionSetting()
-        {
-            object obj = GetFieldValue(18, 0, Fit.SubfieldIndexMainField);
-            DisplayPosition? value = obj == null ? (DisplayPosition?)null : (DisplayPosition)obj;
-            return value;
-        }
+		///<summary>
+		/// Retrieves the DefaultMaxHeartRate field
+		/// Units: bpm</summary>
+		/// <returns>Returns nullable byte representing the DefaultMaxHeartRate field</returns>
+		public byte? DefaultMaxHeartRate
+		{
+			get
+			{
+				Object val = GetFieldValue(11, 0, Fit.SubfieldIndexMainField);
+				if (val == null)
+				{
+					return null;
+				}
 
-        /// <summary>
-        /// Set PositionSetting field</summary>
-        /// <param name="positionSetting_">Nullable field value to be set</param>
-        public void SetPositionSetting(DisplayPosition? positionSetting_)
-        {
-            SetFieldValue(18, 0, positionSetting_, Fit.SubfieldIndexMainField);
-        }
-        
-        ///<summary>
-        /// Retrieves the TemperatureSetting field</summary>
-        /// <returns>Returns nullable DisplayMeasure enum representing the TemperatureSetting field</returns>
-        public DisplayMeasure? GetTemperatureSetting()
-        {
-            object obj = GetFieldValue(21, 0, Fit.SubfieldIndexMainField);
-            DisplayMeasure? value = obj == null ? (DisplayMeasure?)null : (DisplayMeasure)obj;
-            return value;
-        }
+				return (Convert.ToByte(val));
 
-        /// <summary>
-        /// Set TemperatureSetting field</summary>
-        /// <param name="temperatureSetting_">Nullable field value to be set</param>
-        public void SetTemperatureSetting(DisplayMeasure? temperatureSetting_)
-        {
-            SetFieldValue(21, 0, temperatureSetting_, Fit.SubfieldIndexMainField);
-        }
-        
-        ///<summary>
-        /// Retrieves the LocalId field</summary>
-        /// <returns>Returns nullable ushort representing the LocalId field</returns>
-        public ushort? GetLocalId()
-        {
-            Object val = GetFieldValue(22, 0, Fit.SubfieldIndexMainField);
-            if(val == null)
-            {
-                return null;
-            }
+			}
+			set
+			{
+				SetFieldValue(11, 0, value, Fit.SubfieldIndexMainField);
+			}
+		}
 
-            return (Convert.ToUInt16(val));
-            
-        }
+		///<summary>
+		/// Retrieves the HrSetting field</summary>
+		/// <returns>Returns nullable DisplayHeart enum representing the HrSetting field</returns>
+		public DisplayHeart? HrSetting
+		{
+			get
+			{
+				object obj = GetFieldValue(12, 0, Fit.SubfieldIndexMainField);
+				DisplayHeart? value = obj == null ? (DisplayHeart?)null : (DisplayHeart)obj;
+				return value;
+			}
+			set
+			{
+				SetFieldValue(12, 0, value, Fit.SubfieldIndexMainField);
+			}
+		}
 
-        /// <summary>
-        /// Set LocalId field</summary>
-        /// <param name="localId_">Nullable field value to be set</param>
-        public void SetLocalId(ushort? localId_)
-        {
-            SetFieldValue(22, 0, localId_, Fit.SubfieldIndexMainField);
-        }
-        
-        
-        /// <summary>
-        ///
-        /// </summary>
-        /// <returns>returns number of elements in field GlobalId</returns>
-        public int GetNumGlobalId()
-        {
-            return GetNumFieldValues(23, Fit.SubfieldIndexMainField);
-        }
+		///<summary>
+		/// Retrieves the SpeedSetting field</summary>
+		/// <returns>Returns nullable DisplayMeasure enum representing the SpeedSetting field</returns>
+		public DisplayMeasure? SpeedSetting
+		{
+			get
+			{
+				object obj = GetFieldValue(13, 0, Fit.SubfieldIndexMainField);
+				DisplayMeasure? value = obj == null ? (DisplayMeasure?)null : (DisplayMeasure)obj;
+				return value;
+			}
+			set
+			{
+				SetFieldValue(13, 0, value, Fit.SubfieldIndexMainField);
+			}
+		}
 
-        ///<summary>
-        /// Retrieves the GlobalId field</summary>
-        /// <param name="index">0 based index of GlobalId element to retrieve</param>
-        /// <returns>Returns nullable byte representing the GlobalId field</returns>
-        public byte? GetGlobalId(int index)
-        {
-            Object val = GetFieldValue(23, index, Fit.SubfieldIndexMainField);
-            if(val == null)
-            {
-                return null;
-            }
+		///<summary>
+		/// Retrieves the DistSetting field</summary>
+		/// <returns>Returns nullable DisplayMeasure enum representing the DistSetting field</returns>
+		public DisplayMeasure? DistSetting
+		{
+			get
+			{
+				object obj = GetFieldValue(14, 0, Fit.SubfieldIndexMainField);
+				DisplayMeasure? value = obj == null ? (DisplayMeasure?)null : (DisplayMeasure)obj;
+				return value;
+			}
+			set
+			{
+				SetFieldValue(14, 0, value, Fit.SubfieldIndexMainField);
+			}
+		}
 
-            return (Convert.ToByte(val));
-            
-        }
+		///<summary>
+		/// Retrieves the PowerSetting field</summary>
+		/// <returns>Returns nullable DisplayPower enum representing the PowerSetting field</returns>
+		public DisplayPower? PowerSetting
+		{
+			get
+			{
+				object obj = GetFieldValue(16, 0, Fit.SubfieldIndexMainField);
+				DisplayPower? value = obj == null ? (DisplayPower?)null : (DisplayPower)obj;
+				return value;
+			}
+			set
+			{
+				SetFieldValue(16, 0, value, Fit.SubfieldIndexMainField);
+			}
+		}
 
-        /// <summary>
-        /// Set GlobalId field</summary>
-        /// <param name="index">0 based index of global_id</param>
-        /// <param name="globalId_">Nullable field value to be set</param>
-        public void SetGlobalId(int index, byte? globalId_)
-        {
-            SetFieldValue(23, index, globalId_, Fit.SubfieldIndexMainField);
-        }
-        
-        ///<summary>
-        /// Retrieves the WakeTime field
-        /// Comment: Typical wake time</summary>
-        /// <returns>Returns nullable uint representing the WakeTime field</returns>
-        public uint? GetWakeTime()
-        {
-            Object val = GetFieldValue(28, 0, Fit.SubfieldIndexMainField);
-            if(val == null)
-            {
-                return null;
-            }
+		///<summary>
+		/// Retrieves the ActivityClass field</summary>
+		/// <returns>Returns nullable ActivityClass enum representing the ActivityClass field</returns>
+		public ActivityClass? ActivityClass
+		{
+			get
+			{
+				object obj = GetFieldValue(17, 0, Fit.SubfieldIndexMainField);
+				ActivityClass? value = obj == null ? (ActivityClass?)null : (ActivityClass)obj;
+				return value;
+			}
+			set
+			{
+				SetFieldValue(17, 0, value, Fit.SubfieldIndexMainField);
+			}
+		}
 
-            return (Convert.ToUInt32(val));
-            
-        }
+		///<summary>
+		/// Retrieves the PositionSetting field</summary>
+		/// <returns>Returns nullable DisplayPosition enum representing the PositionSetting field</returns>
+		public DisplayPosition? PositionSetting
+		{
+			get
+			{
+				object obj = GetFieldValue(18, 0, Fit.SubfieldIndexMainField);
+				DisplayPosition? value = obj == null ? (DisplayPosition?)null : (DisplayPosition)obj;
+				return value;
+			}
+			set
+			{
+				SetFieldValue(18, 0, value, Fit.SubfieldIndexMainField);
+			}
+		}
 
-        /// <summary>
-        /// Set WakeTime field
-        /// Comment: Typical wake time</summary>
-        /// <param name="wakeTime_">Nullable field value to be set</param>
-        public void SetWakeTime(uint? wakeTime_)
-        {
-            SetFieldValue(28, 0, wakeTime_, Fit.SubfieldIndexMainField);
-        }
-        
-        ///<summary>
-        /// Retrieves the SleepTime field
-        /// Comment: Typical bed time</summary>
-        /// <returns>Returns nullable uint representing the SleepTime field</returns>
-        public uint? GetSleepTime()
-        {
-            Object val = GetFieldValue(29, 0, Fit.SubfieldIndexMainField);
-            if(val == null)
-            {
-                return null;
-            }
+		///<summary>
+		/// Retrieves the TemperatureSetting field</summary>
+		/// <returns>Returns nullable DisplayMeasure enum representing the TemperatureSetting field</returns>
+		public DisplayMeasure? TemperatureSetting
+		{
+			get
+			{
+				object obj = GetFieldValue(21, 0, Fit.SubfieldIndexMainField);
+				DisplayMeasure? value = obj == null ? (DisplayMeasure?)null : (DisplayMeasure)obj;
+				return value;
+			}
+			set
+			{
+				SetFieldValue(21, 0, value, Fit.SubfieldIndexMainField);
+			}
+		}
 
-            return (Convert.ToUInt32(val));
-            
-        }
+		///<summary>
+		/// Retrieves the LocalId field</summary>
+		/// <returns>Returns nullable ushort representing the LocalId field</returns>
+		public ushort? LocalId
+		{
+			get
+			{
+				Object val = GetFieldValue(22, 0, Fit.SubfieldIndexMainField);
+				if (val == null)
+				{
+					return null;
+				}
 
-        /// <summary>
-        /// Set SleepTime field
-        /// Comment: Typical bed time</summary>
-        /// <param name="sleepTime_">Nullable field value to be set</param>
-        public void SetSleepTime(uint? sleepTime_)
-        {
-            SetFieldValue(29, 0, sleepTime_, Fit.SubfieldIndexMainField);
-        }
-        
-        ///<summary>
-        /// Retrieves the HeightSetting field</summary>
-        /// <returns>Returns nullable DisplayMeasure enum representing the HeightSetting field</returns>
-        public DisplayMeasure? GetHeightSetting()
-        {
-            object obj = GetFieldValue(30, 0, Fit.SubfieldIndexMainField);
-            DisplayMeasure? value = obj == null ? (DisplayMeasure?)null : (DisplayMeasure)obj;
-            return value;
-        }
+				return (Convert.ToUInt16(val));
 
-        /// <summary>
-        /// Set HeightSetting field</summary>
-        /// <param name="heightSetting_">Nullable field value to be set</param>
-        public void SetHeightSetting(DisplayMeasure? heightSetting_)
-        {
-            SetFieldValue(30, 0, heightSetting_, Fit.SubfieldIndexMainField);
-        }
-        
-        ///<summary>
-        /// Retrieves the UserRunningStepLength field
-        /// Units: m
-        /// Comment: User defined running step length set to 0 for auto length</summary>
-        /// <returns>Returns nullable float representing the UserRunningStepLength field</returns>
-        public float? GetUserRunningStepLength()
-        {
-            Object val = GetFieldValue(31, 0, Fit.SubfieldIndexMainField);
-            if(val == null)
-            {
-                return null;
-            }
+			}
+			set
+			{
+				SetFieldValue(22, 0, value, Fit.SubfieldIndexMainField);
+			}
+		}
 
-            return (Convert.ToSingle(val));
-            
-        }
 
-        /// <summary>
-        /// Set UserRunningStepLength field
-        /// Units: m
-        /// Comment: User defined running step length set to 0 for auto length</summary>
-        /// <param name="userRunningStepLength_">Nullable field value to be set</param>
-        public void SetUserRunningStepLength(float? userRunningStepLength_)
-        {
-            SetFieldValue(31, 0, userRunningStepLength_, Fit.SubfieldIndexMainField);
-        }
-        
-        ///<summary>
-        /// Retrieves the UserWalkingStepLength field
-        /// Units: m
-        /// Comment: User defined walking step length set to 0 for auto length</summary>
-        /// <returns>Returns nullable float representing the UserWalkingStepLength field</returns>
-        public float? GetUserWalkingStepLength()
-        {
-            Object val = GetFieldValue(32, 0, Fit.SubfieldIndexMainField);
-            if(val == null)
-            {
-                return null;
-            }
+		/// <summary>
+		///
+		/// </summary>
+		/// <returns>returns number of elements in field GlobalId</returns>
+		public int GetNumGlobalId()
+		{
+			return GetNumFieldValues(23, Fit.SubfieldIndexMainField);
+		}
 
-            return (Convert.ToSingle(val));
-            
-        }
+		///<summary>
+		/// Retrieves the GlobalId field</summary>
+		/// <param name="index">0 based index of GlobalId element to retrieve</param>
+		/// <returns>Returns nullable byte representing the GlobalId field</returns>
+		public byte? GetGlobalId(int index)
+		{
+			Object val = GetFieldValue(23, index, Fit.SubfieldIndexMainField);
+			if (val == null)
+			{
+				return null;
+			}
 
-        /// <summary>
-        /// Set UserWalkingStepLength field
-        /// Units: m
-        /// Comment: User defined walking step length set to 0 for auto length</summary>
-        /// <param name="userWalkingStepLength_">Nullable field value to be set</param>
-        public void SetUserWalkingStepLength(float? userWalkingStepLength_)
-        {
-            SetFieldValue(32, 0, userWalkingStepLength_, Fit.SubfieldIndexMainField);
-        }
-        
-        ///<summary>
-        /// Retrieves the DepthSetting field</summary>
-        /// <returns>Returns nullable DisplayMeasure enum representing the DepthSetting field</returns>
-        public DisplayMeasure? GetDepthSetting()
-        {
-            object obj = GetFieldValue(47, 0, Fit.SubfieldIndexMainField);
-            DisplayMeasure? value = obj == null ? (DisplayMeasure?)null : (DisplayMeasure)obj;
-            return value;
-        }
+			return (Convert.ToByte(val));
 
-        /// <summary>
-        /// Set DepthSetting field</summary>
-        /// <param name="depthSetting_">Nullable field value to be set</param>
-        public void SetDepthSetting(DisplayMeasure? depthSetting_)
-        {
-            SetFieldValue(47, 0, depthSetting_, Fit.SubfieldIndexMainField);
-        }
-        
-        ///<summary>
-        /// Retrieves the DiveCount field</summary>
-        /// <returns>Returns nullable uint representing the DiveCount field</returns>
-        public uint? GetDiveCount()
-        {
-            Object val = GetFieldValue(49, 0, Fit.SubfieldIndexMainField);
-            if(val == null)
-            {
-                return null;
-            }
+		}
 
-            return (Convert.ToUInt32(val));
-            
-        }
+		/// <summary>
+		/// Set GlobalId field</summary>
+		/// <param name="index">0 based index of global_id</param>
+		/// <param name="globalId_">Nullable field value to be set</param>
+		public void SetGlobalId(int index, byte? globalId_)
+		{
+			SetFieldValue(23, index, globalId_, Fit.SubfieldIndexMainField);
+		}
 
-        /// <summary>
-        /// Set DiveCount field</summary>
-        /// <param name="diveCount_">Nullable field value to be set</param>
-        public void SetDiveCount(uint? diveCount_)
-        {
-            SetFieldValue(49, 0, diveCount_, Fit.SubfieldIndexMainField);
-        }
-        
-        #endregion // Methods
-    } // Class
+		///<summary>
+		/// Retrieves the WakeTime field
+		/// Comment: Typical wake time</summary>
+		/// <returns>Returns nullable uint representing the WakeTime field</returns>
+		public uint? WakeTime
+		{
+			get
+			{
+				Object val = GetFieldValue(28, 0, Fit.SubfieldIndexMainField);
+				if (val == null)
+				{
+					return null;
+				}
+
+				return (Convert.ToUInt32(val));
+
+			}
+			set
+			{
+				SetFieldValue(28, 0, value, Fit.SubfieldIndexMainField);
+			}
+		}
+
+		///<summary>
+		/// Retrieves the SleepTime field
+		/// Comment: Typical bed time</summary>
+		/// <returns>Returns nullable uint representing the SleepTime field</returns>
+		public uint? SleepTime
+		{
+			get
+			{
+				Object val = GetFieldValue(29, 0, Fit.SubfieldIndexMainField);
+				if (val == null)
+				{
+					return null;
+				}
+
+				return (Convert.ToUInt32(val));
+
+			}
+			set
+			{
+				SetFieldValue(29, 0, value, Fit.SubfieldIndexMainField);
+			}
+		}
+
+		///<summary>
+		/// Retrieves the HeightSetting field</summary>
+		/// <returns>Returns nullable DisplayMeasure enum representing the HeightSetting field</returns>
+		public DisplayMeasure? HeightSetting
+		{
+			get
+			{
+				object obj = GetFieldValue(30, 0, Fit.SubfieldIndexMainField);
+				DisplayMeasure? value = obj == null ? (DisplayMeasure?)null : (DisplayMeasure)obj;
+				return value;
+			}
+			set
+			{
+				SetFieldValue(30, 0, value, Fit.SubfieldIndexMainField);
+			}
+		}
+
+		///<summary>
+		/// Retrieves the UserRunningStepLength field
+		/// Units: m
+		/// Comment: User defined running step length set to 0 for auto length</summary>
+		/// <returns>Returns nullable float representing the UserRunningStepLength field</returns>
+		public float? UserRunningStepLength
+		{
+			get
+			{
+				Object val = GetFieldValue(31, 0, Fit.SubfieldIndexMainField);
+				if (val == null)
+				{
+					return null;
+				}
+
+				return (Convert.ToSingle(val));
+
+			}
+			set
+			{
+				SetFieldValue(31, 0, value, Fit.SubfieldIndexMainField);
+			}
+		}
+
+		///<summary>
+		/// Retrieves the UserWalkingStepLength field
+		/// Units: m
+		/// Comment: User defined walking step length set to 0 for auto length</summary>
+		/// <returns>Returns nullable float representing the UserWalkingStepLength field</returns>
+		public float? UserWalkingStepLength
+		{
+			get
+			{
+				Object val = GetFieldValue(32, 0, Fit.SubfieldIndexMainField);
+				if (val == null)
+				{
+					return null;
+				}
+
+				return (Convert.ToSingle(val));
+
+			}
+			set
+			{
+				SetFieldValue(32, 0, value, Fit.SubfieldIndexMainField);
+			}
+		}
+
+		///<summary>
+		/// Retrieves the DepthSetting field</summary>
+		/// <returns>Returns nullable DisplayMeasure enum representing the DepthSetting field</returns>
+		public DisplayMeasure? DepthSetting
+		{
+			get
+			{
+				object obj = GetFieldValue(47, 0, Fit.SubfieldIndexMainField);
+				DisplayMeasure? value = obj == null ? (DisplayMeasure?)null : (DisplayMeasure)obj;
+				return value;
+			}
+			set
+			{
+				SetFieldValue(47, 0, value, Fit.SubfieldIndexMainField);
+			}
+		}
+
+		///<summary>
+		/// Retrieves the DiveCount field</summary>
+		/// <returns>Returns nullable uint representing the DiveCount field</returns>
+		public uint? DiveCount
+		{
+			get
+			{
+				Object val = GetFieldValue(49, 0, Fit.SubfieldIndexMainField);
+				if (val == null)
+				{
+					return null;
+				}
+
+				return (Convert.ToUInt32(val));
+
+			}
+			set
+			{
+				SetFieldValue(49, 0, value, Fit.SubfieldIndexMainField);
+			}
+		}
+
+		#endregion // Methods
+	} // Class
 } // namespace

--- a/Dynastream/Fit/Profile/Mesgs/VideoClipMesg.cs
+++ b/Dynastream/Fit/Profile/Mesgs/VideoClipMesg.cs
@@ -21,209 +21,198 @@ using System.Linq;
 
 namespace Dynastream.Fit
 {
-    /// <summary>
-    /// Implements the VideoClip profile message.
-    /// </summary>
-    public class VideoClipMesg : Mesg
-    {
-        #region Fields
-        #endregion
+	/// <summary>
+	/// Implements the VideoClip profile message.
+	/// </summary>
+	public class VideoClipMesg : Mesg
+	{
+		#region Fields
+		#endregion
 
-        /// <summary>
-        /// Field Numbers for <see cref="VideoClipMesg"/>
-        /// </summary>
-        public sealed class FieldDefNum
-        {
-            public const byte ClipNumber = 0;
-            public const byte StartTimestamp = 1;
-            public const byte StartTimestampMs = 2;
-            public const byte EndTimestamp = 3;
-            public const byte EndTimestampMs = 4;
-            public const byte ClipStart = 6;
-            public const byte ClipEnd = 7;
-            public const byte Invalid = Fit.FieldNumInvalid;
-        }
+		/// <summary>
+		/// Field Numbers for <see cref="VideoClipMesg"/>
+		/// </summary>
+		public sealed class FieldDefNum
+		{
+			public const byte ClipNumber = 0;
+			public const byte StartTimestamp = 1;
+			public const byte StartTimestampMs = 2;
+			public const byte EndTimestamp = 3;
+			public const byte EndTimestampMs = 4;
+			public const byte ClipStart = 6;
+			public const byte ClipEnd = 7;
+			public const byte Invalid = Fit.FieldNumInvalid;
+		}
 
-        #region Constructors
-        public VideoClipMesg() : base(Profile.GetMesg(MesgNum.VideoClip))
-        {
-        }
+		#region Constructors
+		public VideoClipMesg() : base(Profile.GetMesg(MesgNum.VideoClip))
+		{
+		}
 
-        public VideoClipMesg(Mesg mesg) : base(mesg)
-        {
-        }
-        #endregion // Constructors
+		public VideoClipMesg(Mesg mesg) : base(mesg)
+		{
+		}
+		#endregion // Constructors
 
-        #region Methods
-        ///<summary>
-        /// Retrieves the ClipNumber field</summary>
-        /// <returns>Returns nullable ushort representing the ClipNumber field</returns>
-        public ushort? GetClipNumber()
-        {
-            Object val = GetFieldValue(0, 0, Fit.SubfieldIndexMainField);
-            if(val == null)
-            {
-                return null;
-            }
+		#region Methods
+		///<summary>
+		/// Retrieves the ClipNumber field</summary>
+		/// <returns>Returns nullable ushort representing the ClipNumber field</returns>
+		public ushort? ClipNumber
+		{
+			get
+			{
+				Object val = GetFieldValue(0, 0, Fit.SubfieldIndexMainField);
+				if (val == null)
+				{
+					return null;
+				}
 
-            return (Convert.ToUInt16(val));
-            
-        }
+				return (Convert.ToUInt16(val));
 
-        /// <summary>
-        /// Set ClipNumber field</summary>
-        /// <param name="clipNumber_">Nullable field value to be set</param>
-        public void SetClipNumber(ushort? clipNumber_)
-        {
-            SetFieldValue(0, 0, clipNumber_, Fit.SubfieldIndexMainField);
-        }
-        
-        ///<summary>
-        /// Retrieves the StartTimestamp field</summary>
-        /// <returns>Returns DateTime representing the StartTimestamp field</returns>
-        public DateTime GetStartTimestamp()
-        {
-            Object val = GetFieldValue(1, 0, Fit.SubfieldIndexMainField);
-            if(val == null)
-            {
-                return null;
-            }
+			}
+			set
+			{
+				SetFieldValue(0, 0, value, Fit.SubfieldIndexMainField);
+			}
+		}
 
-            return TimestampToDateTime(Convert.ToUInt32(val));
-            
-        }
+		///<summary>
+		/// Retrieves the StartTimestamp field</summary>
+		/// <returns>Returns DateTime representing the StartTimestamp field</returns>
+		public DateTime StartTimestamp
+		{
+			get
+			{
+				Object val = GetFieldValue(1, 0, Fit.SubfieldIndexMainField);
+				if (val == null)
+				{
+					return null;
+				}
 
-        /// <summary>
-        /// Set StartTimestamp field</summary>
-        /// <param name="startTimestamp_">Nullable field value to be set</param>
-        public void SetStartTimestamp(DateTime startTimestamp_)
-        {
-            SetFieldValue(1, 0, startTimestamp_.GetTimeStamp(), Fit.SubfieldIndexMainField);
-        }
-        
-        ///<summary>
-        /// Retrieves the StartTimestampMs field</summary>
-        /// <returns>Returns nullable ushort representing the StartTimestampMs field</returns>
-        public ushort? GetStartTimestampMs()
-        {
-            Object val = GetFieldValue(2, 0, Fit.SubfieldIndexMainField);
-            if(val == null)
-            {
-                return null;
-            }
+				return TimestampToDateTime(Convert.ToUInt32(val));
 
-            return (Convert.ToUInt16(val));
-            
-        }
+			}
+			set
+			{
+				SetFieldValue(1, 0, value.GetTimeStamp(), Fit.SubfieldIndexMainField);
+			}
+		}
 
-        /// <summary>
-        /// Set StartTimestampMs field</summary>
-        /// <param name="startTimestampMs_">Nullable field value to be set</param>
-        public void SetStartTimestampMs(ushort? startTimestampMs_)
-        {
-            SetFieldValue(2, 0, startTimestampMs_, Fit.SubfieldIndexMainField);
-        }
-        
-        ///<summary>
-        /// Retrieves the EndTimestamp field</summary>
-        /// <returns>Returns DateTime representing the EndTimestamp field</returns>
-        public DateTime GetEndTimestamp()
-        {
-            Object val = GetFieldValue(3, 0, Fit.SubfieldIndexMainField);
-            if(val == null)
-            {
-                return null;
-            }
+		///<summary>
+		/// Retrieves the StartTimestampMs field</summary>
+		/// <returns>Returns nullable ushort representing the StartTimestampMs field</returns>
+		public ushort? StartTimestampMs
+		{
+			get
+			{
+				Object val = GetFieldValue(2, 0, Fit.SubfieldIndexMainField);
+				if (val == null)
+				{
+					return null;
+				}
 
-            return TimestampToDateTime(Convert.ToUInt32(val));
-            
-        }
+				return (Convert.ToUInt16(val));
 
-        /// <summary>
-        /// Set EndTimestamp field</summary>
-        /// <param name="endTimestamp_">Nullable field value to be set</param>
-        public void SetEndTimestamp(DateTime endTimestamp_)
-        {
-            SetFieldValue(3, 0, endTimestamp_.GetTimeStamp(), Fit.SubfieldIndexMainField);
-        }
-        
-        ///<summary>
-        /// Retrieves the EndTimestampMs field</summary>
-        /// <returns>Returns nullable ushort representing the EndTimestampMs field</returns>
-        public ushort? GetEndTimestampMs()
-        {
-            Object val = GetFieldValue(4, 0, Fit.SubfieldIndexMainField);
-            if(val == null)
-            {
-                return null;
-            }
+			}
+			set
+			{
+				SetFieldValue(2, 0, value, Fit.SubfieldIndexMainField);
+			}
+		}
 
-            return (Convert.ToUInt16(val));
-            
-        }
+		///<summary>
+		/// Retrieves the EndTimestamp field</summary>
+		/// <returns>Returns DateTime representing the EndTimestamp field</returns>
+		public DateTime EndTimestamp
+		{
+			get
+			{
+				Object val = GetFieldValue(3, 0, Fit.SubfieldIndexMainField);
+				if (val == null)
+				{
+					return null;
+				}
 
-        /// <summary>
-        /// Set EndTimestampMs field</summary>
-        /// <param name="endTimestampMs_">Nullable field value to be set</param>
-        public void SetEndTimestampMs(ushort? endTimestampMs_)
-        {
-            SetFieldValue(4, 0, endTimestampMs_, Fit.SubfieldIndexMainField);
-        }
-        
-        ///<summary>
-        /// Retrieves the ClipStart field
-        /// Units: ms
-        /// Comment: Start of clip in video time</summary>
-        /// <returns>Returns nullable uint representing the ClipStart field</returns>
-        public uint? GetClipStart()
-        {
-            Object val = GetFieldValue(6, 0, Fit.SubfieldIndexMainField);
-            if(val == null)
-            {
-                return null;
-            }
+				return TimestampToDateTime(Convert.ToUInt32(val));
 
-            return (Convert.ToUInt32(val));
-            
-        }
+			}
+			set
+			{
+				SetFieldValue(3, 0, value.GetTimeStamp(), Fit.SubfieldIndexMainField);
+			}
+		}
 
-        /// <summary>
-        /// Set ClipStart field
-        /// Units: ms
-        /// Comment: Start of clip in video time</summary>
-        /// <param name="clipStart_">Nullable field value to be set</param>
-        public void SetClipStart(uint? clipStart_)
-        {
-            SetFieldValue(6, 0, clipStart_, Fit.SubfieldIndexMainField);
-        }
-        
-        ///<summary>
-        /// Retrieves the ClipEnd field
-        /// Units: ms
-        /// Comment: End of clip in video time</summary>
-        /// <returns>Returns nullable uint representing the ClipEnd field</returns>
-        public uint? GetClipEnd()
-        {
-            Object val = GetFieldValue(7, 0, Fit.SubfieldIndexMainField);
-            if(val == null)
-            {
-                return null;
-            }
+		///<summary>
+		/// Retrieves the EndTimestampMs field</summary>
+		/// <returns>Returns nullable ushort representing the EndTimestampMs field</returns>
+		public ushort? EndTimestampMs
+		{
+			get
+			{
+				Object val = GetFieldValue(4, 0, Fit.SubfieldIndexMainField);
+				if (val == null)
+				{
+					return null;
+				}
 
-            return (Convert.ToUInt32(val));
-            
-        }
+				return (Convert.ToUInt16(val));
 
-        /// <summary>
-        /// Set ClipEnd field
-        /// Units: ms
-        /// Comment: End of clip in video time</summary>
-        /// <param name="clipEnd_">Nullable field value to be set</param>
-        public void SetClipEnd(uint? clipEnd_)
-        {
-            SetFieldValue(7, 0, clipEnd_, Fit.SubfieldIndexMainField);
-        }
-        
-        #endregion // Methods
-    } // Class
+			}
+			set
+			{
+				SetFieldValue(4, 0, value, Fit.SubfieldIndexMainField);
+			}
+		}
+
+		///<summary>
+		/// Retrieves the ClipStart field
+		/// Units: ms
+		/// Comment: Start of clip in video time</summary>
+		/// <returns>Returns nullable uint representing the ClipStart field</returns>
+		public uint? ClipStart
+		{
+			get
+			{
+				Object val = GetFieldValue(6, 0, Fit.SubfieldIndexMainField);
+				if (val == null)
+				{
+					return null;
+				}
+
+				return (Convert.ToUInt32(val));
+
+			}
+			set
+			{
+				SetFieldValue(6, 0, value, Fit.SubfieldIndexMainField);
+			}
+		}
+
+		///<summary>
+		/// Retrieves the ClipEnd field
+		/// Units: ms
+		/// Comment: End of clip in video time</summary>
+		/// <returns>Returns nullable uint representing the ClipEnd field</returns>
+		public uint? ClipEnd
+		{
+			get
+			{
+				Object val = GetFieldValue(7, 0, Fit.SubfieldIndexMainField);
+				if (val == null)
+				{
+					return null;
+				}
+
+				return (Convert.ToUInt32(val));
+
+			}
+			set
+			{
+				SetFieldValue(7, 0, value, Fit.SubfieldIndexMainField);
+			}
+		}
+
+		#endregion // Methods
+	} // Class
 } // namespace

--- a/Dynastream/Fit/Profile/Mesgs/VideoDescriptionMesg.cs
+++ b/Dynastream/Fit/Profile/Mesgs/VideoDescriptionMesg.cs
@@ -21,124 +21,118 @@ using System.Linq;
 
 namespace Dynastream.Fit
 {
-    /// <summary>
-    /// Implements the VideoDescription profile message.
-    /// </summary>
-    public class VideoDescriptionMesg : Mesg
-    {
-        #region Fields
-        #endregion
+	/// <summary>
+	/// Implements the VideoDescription profile message.
+	/// </summary>
+	public class VideoDescriptionMesg : Mesg
+	{
+		#region Fields
+		#endregion
 
-        /// <summary>
-        /// Field Numbers for <see cref="VideoDescriptionMesg"/>
-        /// </summary>
-        public sealed class FieldDefNum
-        {
-            public const byte MessageIndex = 254;
-            public const byte MessageCount = 0;
-            public const byte Text = 1;
-            public const byte Invalid = Fit.FieldNumInvalid;
-        }
+		/// <summary>
+		/// Field Numbers for <see cref="VideoDescriptionMesg"/>
+		/// </summary>
+		public sealed class FieldDefNum
+		{
+			public const byte MessageIndex = 254;
+			public const byte MessageCount = 0;
+			public const byte Text = 1;
+			public const byte Invalid = Fit.FieldNumInvalid;
+		}
 
-        #region Constructors
-        public VideoDescriptionMesg() : base(Profile.GetMesg(MesgNum.VideoDescription))
-        {
-        }
+		#region Constructors
+		public VideoDescriptionMesg() : base(Profile.GetMesg(MesgNum.VideoDescription))
+		{
+		}
 
-        public VideoDescriptionMesg(Mesg mesg) : base(mesg)
-        {
-        }
-        #endregion // Constructors
+		public VideoDescriptionMesg(Mesg mesg) : base(mesg)
+		{
+		}
+		#endregion // Constructors
 
-        #region Methods
-        ///<summary>
-        /// Retrieves the MessageIndex field
-        /// Comment: Long descriptions will be split into multiple parts</summary>
-        /// <returns>Returns nullable ushort representing the MessageIndex field</returns>
-        public ushort? GetMessageIndex()
-        {
-            Object val = GetFieldValue(254, 0, Fit.SubfieldIndexMainField);
-            if(val == null)
-            {
-                return null;
-            }
+		#region Methods
+		///<summary>
+		/// Retrieves the MessageIndex field
+		/// Comment: Long descriptions will be split into multiple parts</summary>
+		/// <returns>Returns nullable ushort representing the MessageIndex field</returns>
+		public ushort? MessageIndex
+		{
+			get
+			{
+				Object val = GetFieldValue(254, 0, Fit.SubfieldIndexMainField);
+				if (val == null)
+				{
+					return null;
+				}
 
-            return (Convert.ToUInt16(val));
-            
-        }
+				return (Convert.ToUInt16(val));
 
-        /// <summary>
-        /// Set MessageIndex field
-        /// Comment: Long descriptions will be split into multiple parts</summary>
-        /// <param name="messageIndex_">Nullable field value to be set</param>
-        public void SetMessageIndex(ushort? messageIndex_)
-        {
-            SetFieldValue(254, 0, messageIndex_, Fit.SubfieldIndexMainField);
-        }
-        
-        ///<summary>
-        /// Retrieves the MessageCount field
-        /// Comment: Total number of description parts</summary>
-        /// <returns>Returns nullable ushort representing the MessageCount field</returns>
-        public ushort? GetMessageCount()
-        {
-            Object val = GetFieldValue(0, 0, Fit.SubfieldIndexMainField);
-            if(val == null)
-            {
-                return null;
-            }
+			}
+			set
+			{
+				SetFieldValue(254, 0, value, Fit.SubfieldIndexMainField);
+			}
+		}
 
-            return (Convert.ToUInt16(val));
-            
-        }
+		///<summary>
+		/// Retrieves the MessageCount field
+		/// Comment: Total number of description parts</summary>
+		/// <returns>Returns nullable ushort representing the MessageCount field</returns>
+		public ushort? MessageCount
+		{
+			get
+			{
+				Object val = GetFieldValue(0, 0, Fit.SubfieldIndexMainField);
+				if (val == null)
+				{
+					return null;
+				}
 
-        /// <summary>
-        /// Set MessageCount field
-        /// Comment: Total number of description parts</summary>
-        /// <param name="messageCount_">Nullable field value to be set</param>
-        public void SetMessageCount(ushort? messageCount_)
-        {
-            SetFieldValue(0, 0, messageCount_, Fit.SubfieldIndexMainField);
-        }
-        
-        ///<summary>
-        /// Retrieves the Text field</summary>
-        /// <returns>Returns byte[] representing the Text field</returns>
-        public byte[] GetText()
-        {
-            byte[] data = (byte[])GetFieldValue(1, 0, Fit.SubfieldIndexMainField);
-            return data.Take(data.Length - 1).ToArray();
-        }
+				return (Convert.ToUInt16(val));
 
-        ///<summary>
-        /// Retrieves the Text field</summary>
-        /// <returns>Returns String representing the Text field</returns>
-        public String GetTextAsString()
-        {
-            byte[] data = (byte[])GetFieldValue(1, 0, Fit.SubfieldIndexMainField);
-            return data != null ? Encoding.UTF8.GetString(data, 0, data.Length - 1) : null;
-        }
+			}
+			set
+			{
+				SetFieldValue(0, 0, value, Fit.SubfieldIndexMainField);
+			}
+		}
 
-        ///<summary>
-        /// Set Text field</summary>
-        /// <param name="text_"> field value to be set</param>
-        public void SetText(String text_)
-        {
-            byte[] data = Encoding.UTF8.GetBytes(text_);
-            byte[] zdata = new byte[data.Length + 1];
-            data.CopyTo(zdata, 0);
-            SetFieldValue(1, 0, zdata, Fit.SubfieldIndexMainField);
-        }
+		///<summary>
+		/// Retrieves the Text field</summary>
+		/// <returns>Returns byte[] representing the Text field</returns>
+		public byte[] Text
+		{
+			get
+			{
+				byte[] data = (byte[])GetFieldValue(1, 0, Fit.SubfieldIndexMainField);
+				return data.Take(data.Length - 1).ToArray();
+			}
+			set
+			{
+				SetFieldValue(1, 0, value, Fit.SubfieldIndexMainField);
+			}
+		}
 
-        
-        /// <summary>
-        /// Set Text field</summary>
-        /// <param name="text_">field value to be set</param>
-        public void SetText(byte[] text_)
-        {
-            SetFieldValue(1, 0, text_, Fit.SubfieldIndexMainField);
-        }
-        
-        #endregion // Methods
-    } // Class
+		///<summary>
+		/// Retrieves the Text field</summary>
+		/// <returns>Returns String representing the Text field</returns>
+		public String GetTextAsString()
+		{
+			byte[] data = (byte[])GetFieldValue(1, 0, Fit.SubfieldIndexMainField);
+			return data != null ? Encoding.UTF8.GetString(data, 0, data.Length - 1) : null;
+		}
+
+		///<summary>
+		/// Set Text field</summary>
+		/// <param name="text_"> field value to be set</param>
+		public void SetText(String text_)
+		{
+			byte[] data = Encoding.UTF8.GetBytes(text_);
+			byte[] zdata = new byte[data.Length + 1];
+			data.CopyTo(zdata, 0);
+			SetFieldValue(1, 0, zdata, Fit.SubfieldIndexMainField);
+		}
+
+		#endregion // Methods
+	} // Class
 } // namespace

--- a/Dynastream/Fit/Profile/Mesgs/VideoFrameMesg.cs
+++ b/Dynastream/Fit/Profile/Mesgs/VideoFrameMesg.cs
@@ -21,115 +21,107 @@ using System.Linq;
 
 namespace Dynastream.Fit
 {
-    /// <summary>
-    /// Implements the VideoFrame profile message.
-    /// </summary>
-    public class VideoFrameMesg : Mesg
-    {
-        #region Fields
-        #endregion
+	/// <summary>
+	/// Implements the VideoFrame profile message.
+	/// </summary>
+	public class VideoFrameMesg : Mesg
+	{
+		#region Fields
+		#endregion
 
-        /// <summary>
-        /// Field Numbers for <see cref="VideoFrameMesg"/>
-        /// </summary>
-        public sealed class FieldDefNum
-        {
-            public const byte Timestamp = 253;
-            public const byte TimestampMs = 0;
-            public const byte FrameNumber = 1;
-            public const byte Invalid = Fit.FieldNumInvalid;
-        }
+		/// <summary>
+		/// Field Numbers for <see cref="VideoFrameMesg"/>
+		/// </summary>
+		public sealed class FieldDefNum
+		{
+			public const byte Timestamp = 253;
+			public const byte TimestampMs = 0;
+			public const byte FrameNumber = 1;
+			public const byte Invalid = Fit.FieldNumInvalid;
+		}
 
-        #region Constructors
-        public VideoFrameMesg() : base(Profile.GetMesg(MesgNum.VideoFrame))
-        {
-        }
+		#region Constructors
+		public VideoFrameMesg() : base(Profile.GetMesg(MesgNum.VideoFrame))
+		{
+		}
 
-        public VideoFrameMesg(Mesg mesg) : base(mesg)
-        {
-        }
-        #endregion // Constructors
+		public VideoFrameMesg(Mesg mesg) : base(mesg)
+		{
+		}
+		#endregion // Constructors
 
-        #region Methods
-        ///<summary>
-        /// Retrieves the Timestamp field
-        /// Units: s
-        /// Comment: Whole second part of the timestamp</summary>
-        /// <returns>Returns DateTime representing the Timestamp field</returns>
-        public DateTime GetTimestamp()
-        {
-            Object val = GetFieldValue(253, 0, Fit.SubfieldIndexMainField);
-            if(val == null)
-            {
-                return null;
-            }
+		#region Methods
+		///<summary>
+		/// Retrieves the Timestamp field
+		/// Units: s
+		/// Comment: Whole second part of the timestamp</summary>
+		/// <returns>Returns DateTime representing the Timestamp field</returns>
+		public DateTime Timestamp
+		{
+			get
+			{
+				Object val = GetFieldValue(253, 0, Fit.SubfieldIndexMainField);
+				if (val == null)
+				{
+					return null;
+				}
 
-            return TimestampToDateTime(Convert.ToUInt32(val));
-            
-        }
+				return TimestampToDateTime(Convert.ToUInt32(val));
 
-        /// <summary>
-        /// Set Timestamp field
-        /// Units: s
-        /// Comment: Whole second part of the timestamp</summary>
-        /// <param name="timestamp_">Nullable field value to be set</param>
-        public void SetTimestamp(DateTime timestamp_)
-        {
-            SetFieldValue(253, 0, timestamp_.GetTimeStamp(), Fit.SubfieldIndexMainField);
-        }
-        
-        ///<summary>
-        /// Retrieves the TimestampMs field
-        /// Units: ms
-        /// Comment: Millisecond part of the timestamp.</summary>
-        /// <returns>Returns nullable ushort representing the TimestampMs field</returns>
-        public ushort? GetTimestampMs()
-        {
-            Object val = GetFieldValue(0, 0, Fit.SubfieldIndexMainField);
-            if(val == null)
-            {
-                return null;
-            }
+			}
+			set
+			{
+				SetFieldValue(253, 0, value.GetTimeStamp(), Fit.SubfieldIndexMainField);
+			}
+		}
 
-            return (Convert.ToUInt16(val));
-            
-        }
+		///<summary>
+		/// Retrieves the TimestampMs field
+		/// Units: ms
+		/// Comment: Millisecond part of the timestamp.</summary>
+		/// <returns>Returns nullable ushort representing the TimestampMs field</returns>
+		public ushort? TimestampMs
+		{
+			get
+			{
+				Object val = GetFieldValue(0, 0, Fit.SubfieldIndexMainField);
+				if (val == null)
+				{
+					return null;
+				}
 
-        /// <summary>
-        /// Set TimestampMs field
-        /// Units: ms
-        /// Comment: Millisecond part of the timestamp.</summary>
-        /// <param name="timestampMs_">Nullable field value to be set</param>
-        public void SetTimestampMs(ushort? timestampMs_)
-        {
-            SetFieldValue(0, 0, timestampMs_, Fit.SubfieldIndexMainField);
-        }
-        
-        ///<summary>
-        /// Retrieves the FrameNumber field
-        /// Comment: Number of the frame that the timestamp and timestamp_ms correlate to</summary>
-        /// <returns>Returns nullable uint representing the FrameNumber field</returns>
-        public uint? GetFrameNumber()
-        {
-            Object val = GetFieldValue(1, 0, Fit.SubfieldIndexMainField);
-            if(val == null)
-            {
-                return null;
-            }
+				return (Convert.ToUInt16(val));
 
-            return (Convert.ToUInt32(val));
-            
-        }
+			}
+			set
+			{
+				SetFieldValue(0, 0, value, Fit.SubfieldIndexMainField);
+			}
+		}
 
-        /// <summary>
-        /// Set FrameNumber field
-        /// Comment: Number of the frame that the timestamp and timestamp_ms correlate to</summary>
-        /// <param name="frameNumber_">Nullable field value to be set</param>
-        public void SetFrameNumber(uint? frameNumber_)
-        {
-            SetFieldValue(1, 0, frameNumber_, Fit.SubfieldIndexMainField);
-        }
-        
-        #endregion // Methods
-    } // Class
+		///<summary>
+		/// Retrieves the FrameNumber field
+		/// Comment: Number of the frame that the timestamp and timestamp_ms correlate to</summary>
+		/// <returns>Returns nullable uint representing the FrameNumber field</returns>
+		public uint? FrameNumber
+		{
+			get
+			{
+				Object val = GetFieldValue(1, 0, Fit.SubfieldIndexMainField);
+				if (val == null)
+				{
+					return null;
+				}
+
+				return (Convert.ToUInt32(val));
+
+			}
+			set
+			{
+				SetFieldValue(1, 0, value, Fit.SubfieldIndexMainField);
+			}
+		}
+
+		#endregion // Methods
+	} // Class
 } // namespace

--- a/Dynastream/Fit/Profile/Mesgs/VideoMesg.cs
+++ b/Dynastream/Fit/Profile/Mesgs/VideoMesg.cs
@@ -21,139 +21,132 @@ using System.Linq;
 
 namespace Dynastream.Fit
 {
-    /// <summary>
-    /// Implements the Video profile message.
-    /// </summary>
-    public class VideoMesg : Mesg
-    {
-        #region Fields
-        #endregion
+	/// <summary>
+	/// Implements the Video profile message.
+	/// </summary>
+	public class VideoMesg : Mesg
+	{
+		#region Fields
+		#endregion
 
-        /// <summary>
-        /// Field Numbers for <see cref="VideoMesg"/>
-        /// </summary>
-        public sealed class FieldDefNum
-        {
-            public const byte Url = 0;
-            public const byte HostingProvider = 1;
-            public const byte Duration = 2;
-            public const byte Invalid = Fit.FieldNumInvalid;
-        }
+		/// <summary>
+		/// Field Numbers for <see cref="VideoMesg"/>
+		/// </summary>
+		public sealed class FieldDefNum
+		{
+			public const byte Url = 0;
+			public const byte HostingProvider = 1;
+			public const byte Duration = 2;
+			public const byte Invalid = Fit.FieldNumInvalid;
+		}
 
-        #region Constructors
-        public VideoMesg() : base(Profile.GetMesg(MesgNum.Video))
-        {
-        }
+		#region Constructors
+		public VideoMesg() : base(Profile.GetMesg(MesgNum.Video))
+		{
+		}
 
-        public VideoMesg(Mesg mesg) : base(mesg)
-        {
-        }
-        #endregion // Constructors
+		public VideoMesg(Mesg mesg) : base(mesg)
+		{
+		}
+		#endregion // Constructors
 
-        #region Methods
-        ///<summary>
-        /// Retrieves the Url field</summary>
-        /// <returns>Returns byte[] representing the Url field</returns>
-        public byte[] GetUrl()
-        {
-            byte[] data = (byte[])GetFieldValue(0, 0, Fit.SubfieldIndexMainField);
-            return data.Take(data.Length - 1).ToArray();
-        }
+		#region Methods
+		///<summary>
+		/// Retrieves the Url field</summary>
+		/// <returns>Returns byte[] representing the Url field</returns>
+		public byte[] Url
+		{
+			get
+			{
+				byte[] data = (byte[])GetFieldValue(0, 0, Fit.SubfieldIndexMainField);
+				return data.Take(data.Length - 1).ToArray();
+			}
+			set
+			{
+				SetFieldValue(0, 0, value, Fit.SubfieldIndexMainField);
+			}
+		}
 
-        ///<summary>
-        /// Retrieves the Url field</summary>
-        /// <returns>Returns String representing the Url field</returns>
-        public String GetUrlAsString()
-        {
-            byte[] data = (byte[])GetFieldValue(0, 0, Fit.SubfieldIndexMainField);
-            return data != null ? Encoding.UTF8.GetString(data, 0, data.Length - 1) : null;
-        }
+		///<summary>
+		/// Retrieves the Url field</summary>
+		/// <returns>Returns String representing the Url field</returns>
+		public String GetUrlAsString()
+		{
+			byte[] data = (byte[])GetFieldValue(0, 0, Fit.SubfieldIndexMainField);
+			return data != null ? Encoding.UTF8.GetString(data, 0, data.Length - 1) : null;
+		}
 
-        ///<summary>
-        /// Set Url field</summary>
-        /// <param name="url_"> field value to be set</param>
-        public void SetUrl(String url_)
-        {
-            byte[] data = Encoding.UTF8.GetBytes(url_);
-            byte[] zdata = new byte[data.Length + 1];
-            data.CopyTo(zdata, 0);
-            SetFieldValue(0, 0, zdata, Fit.SubfieldIndexMainField);
-        }
+		///<summary>
+		/// Set Url field</summary>
+		/// <param name="url_"> field value to be set</param>
+		public void SetUrl(String url_)
+		{
+			byte[] data = Encoding.UTF8.GetBytes(url_);
+			byte[] zdata = new byte[data.Length + 1];
+			data.CopyTo(zdata, 0);
+			SetFieldValue(0, 0, zdata, Fit.SubfieldIndexMainField);
+		}
 
-        
-        /// <summary>
-        /// Set Url field</summary>
-        /// <param name="url_">field value to be set</param>
-        public void SetUrl(byte[] url_)
-        {
-            SetFieldValue(0, 0, url_, Fit.SubfieldIndexMainField);
-        }
-        
-        ///<summary>
-        /// Retrieves the HostingProvider field</summary>
-        /// <returns>Returns byte[] representing the HostingProvider field</returns>
-        public byte[] GetHostingProvider()
-        {
-            byte[] data = (byte[])GetFieldValue(1, 0, Fit.SubfieldIndexMainField);
-            return data.Take(data.Length - 1).ToArray();
-        }
+		///<summary>
+		/// Retrieves the HostingProvider field</summary>
+		/// <returns>Returns byte[] representing the HostingProvider field</returns>
+		public byte[] HostingProvider
+		{
+			get
+			{
+				byte[] data = (byte[])GetFieldValue(1, 0, Fit.SubfieldIndexMainField);
+				return data.Take(data.Length - 1).ToArray();
+			}
+			set
+			{
+				SetFieldValue(1, 0, value, Fit.SubfieldIndexMainField);
+			}
+		}
 
-        ///<summary>
-        /// Retrieves the HostingProvider field</summary>
-        /// <returns>Returns String representing the HostingProvider field</returns>
-        public String GetHostingProviderAsString()
-        {
-            byte[] data = (byte[])GetFieldValue(1, 0, Fit.SubfieldIndexMainField);
-            return data != null ? Encoding.UTF8.GetString(data, 0, data.Length - 1) : null;
-        }
+		///<summary>
+		/// Retrieves the HostingProvider field</summary>
+		/// <returns>Returns String representing the HostingProvider field</returns>
+		public String GetHostingProviderAsString()
+		{
+			byte[] data = (byte[])GetFieldValue(1, 0, Fit.SubfieldIndexMainField);
+			return data != null ? Encoding.UTF8.GetString(data, 0, data.Length - 1) : null;
+		}
 
-        ///<summary>
-        /// Set HostingProvider field</summary>
-        /// <param name="hostingProvider_"> field value to be set</param>
-        public void SetHostingProvider(String hostingProvider_)
-        {
-            byte[] data = Encoding.UTF8.GetBytes(hostingProvider_);
-            byte[] zdata = new byte[data.Length + 1];
-            data.CopyTo(zdata, 0);
-            SetFieldValue(1, 0, zdata, Fit.SubfieldIndexMainField);
-        }
+		///<summary>
+		/// Set HostingProvider field</summary>
+		/// <param name="hostingProvider_"> field value to be set</param>
+		public void SetHostingProvider(String hostingProvider_)
+		{
+			byte[] data = Encoding.UTF8.GetBytes(hostingProvider_);
+			byte[] zdata = new byte[data.Length + 1];
+			data.CopyTo(zdata, 0);
+			SetFieldValue(1, 0, zdata, Fit.SubfieldIndexMainField);
+		}
 
-        
-        /// <summary>
-        /// Set HostingProvider field</summary>
-        /// <param name="hostingProvider_">field value to be set</param>
-        public void SetHostingProvider(byte[] hostingProvider_)
-        {
-            SetFieldValue(1, 0, hostingProvider_, Fit.SubfieldIndexMainField);
-        }
-        
-        ///<summary>
-        /// Retrieves the Duration field
-        /// Units: ms
-        /// Comment: Playback time of video</summary>
-        /// <returns>Returns nullable uint representing the Duration field</returns>
-        public uint? GetDuration()
-        {
-            Object val = GetFieldValue(2, 0, Fit.SubfieldIndexMainField);
-            if(val == null)
-            {
-                return null;
-            }
+		///<summary>
+		/// Retrieves the Duration field
+		/// Units: ms
+		/// Comment: Playback time of video</summary>
+		/// <returns>Returns nullable uint representing the Duration field</returns>
+		public uint? Duration
+		{
+			get
+			{
+				Object val = GetFieldValue(2, 0, Fit.SubfieldIndexMainField);
+				if (val == null)
+				{
+					return null;
+				}
 
-            return (Convert.ToUInt32(val));
-            
-        }
+				return (Convert.ToUInt32(val));
 
-        /// <summary>
-        /// Set Duration field
-        /// Units: ms
-        /// Comment: Playback time of video</summary>
-        /// <param name="duration_">Nullable field value to be set</param>
-        public void SetDuration(uint? duration_)
-        {
-            SetFieldValue(2, 0, duration_, Fit.SubfieldIndexMainField);
-        }
-        
-        #endregion // Methods
-    } // Class
+			}
+			set
+			{
+				SetFieldValue(2, 0, value, Fit.SubfieldIndexMainField);
+			}
+		}
+
+		#endregion // Methods
+	} // Class
 } // namespace

--- a/Dynastream/Fit/Profile/Mesgs/VideoTitleMesg.cs
+++ b/Dynastream/Fit/Profile/Mesgs/VideoTitleMesg.cs
@@ -21,124 +21,118 @@ using System.Linq;
 
 namespace Dynastream.Fit
 {
-    /// <summary>
-    /// Implements the VideoTitle profile message.
-    /// </summary>
-    public class VideoTitleMesg : Mesg
-    {
-        #region Fields
-        #endregion
+	/// <summary>
+	/// Implements the VideoTitle profile message.
+	/// </summary>
+	public class VideoTitleMesg : Mesg
+	{
+		#region Fields
+		#endregion
 
-        /// <summary>
-        /// Field Numbers for <see cref="VideoTitleMesg"/>
-        /// </summary>
-        public sealed class FieldDefNum
-        {
-            public const byte MessageIndex = 254;
-            public const byte MessageCount = 0;
-            public const byte Text = 1;
-            public const byte Invalid = Fit.FieldNumInvalid;
-        }
+		/// <summary>
+		/// Field Numbers for <see cref="VideoTitleMesg"/>
+		/// </summary>
+		public sealed class FieldDefNum
+		{
+			public const byte MessageIndex = 254;
+			public const byte MessageCount = 0;
+			public const byte Text = 1;
+			public const byte Invalid = Fit.FieldNumInvalid;
+		}
 
-        #region Constructors
-        public VideoTitleMesg() : base(Profile.GetMesg(MesgNum.VideoTitle))
-        {
-        }
+		#region Constructors
+		public VideoTitleMesg() : base(Profile.GetMesg(MesgNum.VideoTitle))
+		{
+		}
 
-        public VideoTitleMesg(Mesg mesg) : base(mesg)
-        {
-        }
-        #endregion // Constructors
+		public VideoTitleMesg(Mesg mesg) : base(mesg)
+		{
+		}
+		#endregion // Constructors
 
-        #region Methods
-        ///<summary>
-        /// Retrieves the MessageIndex field
-        /// Comment: Long titles will be split into multiple parts</summary>
-        /// <returns>Returns nullable ushort representing the MessageIndex field</returns>
-        public ushort? GetMessageIndex()
-        {
-            Object val = GetFieldValue(254, 0, Fit.SubfieldIndexMainField);
-            if(val == null)
-            {
-                return null;
-            }
+		#region Methods
+		///<summary>
+		/// Retrieves the MessageIndex field
+		/// Comment: Long titles will be split into multiple parts</summary>
+		/// <returns>Returns nullable ushort representing the MessageIndex field</returns>
+		public ushort? MessageIndex
+		{
+			get
+			{
+				Object val = GetFieldValue(254, 0, Fit.SubfieldIndexMainField);
+				if (val == null)
+				{
+					return null;
+				}
 
-            return (Convert.ToUInt16(val));
-            
-        }
+				return (Convert.ToUInt16(val));
 
-        /// <summary>
-        /// Set MessageIndex field
-        /// Comment: Long titles will be split into multiple parts</summary>
-        /// <param name="messageIndex_">Nullable field value to be set</param>
-        public void SetMessageIndex(ushort? messageIndex_)
-        {
-            SetFieldValue(254, 0, messageIndex_, Fit.SubfieldIndexMainField);
-        }
-        
-        ///<summary>
-        /// Retrieves the MessageCount field
-        /// Comment: Total number of title parts</summary>
-        /// <returns>Returns nullable ushort representing the MessageCount field</returns>
-        public ushort? GetMessageCount()
-        {
-            Object val = GetFieldValue(0, 0, Fit.SubfieldIndexMainField);
-            if(val == null)
-            {
-                return null;
-            }
+			}
+			set
+			{
+				SetFieldValue(254, 0, value, Fit.SubfieldIndexMainField);
+			}
+		}
 
-            return (Convert.ToUInt16(val));
-            
-        }
+		///<summary>
+		/// Retrieves the MessageCount field
+		/// Comment: Total number of title parts</summary>
+		/// <returns>Returns nullable ushort representing the MessageCount field</returns>
+		public ushort? MessageCount
+		{
+			get
+			{
+				Object val = GetFieldValue(0, 0, Fit.SubfieldIndexMainField);
+				if (val == null)
+				{
+					return null;
+				}
 
-        /// <summary>
-        /// Set MessageCount field
-        /// Comment: Total number of title parts</summary>
-        /// <param name="messageCount_">Nullable field value to be set</param>
-        public void SetMessageCount(ushort? messageCount_)
-        {
-            SetFieldValue(0, 0, messageCount_, Fit.SubfieldIndexMainField);
-        }
-        
-        ///<summary>
-        /// Retrieves the Text field</summary>
-        /// <returns>Returns byte[] representing the Text field</returns>
-        public byte[] GetText()
-        {
-            byte[] data = (byte[])GetFieldValue(1, 0, Fit.SubfieldIndexMainField);
-            return data.Take(data.Length - 1).ToArray();
-        }
+				return (Convert.ToUInt16(val));
 
-        ///<summary>
-        /// Retrieves the Text field</summary>
-        /// <returns>Returns String representing the Text field</returns>
-        public String GetTextAsString()
-        {
-            byte[] data = (byte[])GetFieldValue(1, 0, Fit.SubfieldIndexMainField);
-            return data != null ? Encoding.UTF8.GetString(data, 0, data.Length - 1) : null;
-        }
+			}
+			set
+			{
+				SetFieldValue(0, 0, value, Fit.SubfieldIndexMainField);
+			}
+		}
 
-        ///<summary>
-        /// Set Text field</summary>
-        /// <param name="text_"> field value to be set</param>
-        public void SetText(String text_)
-        {
-            byte[] data = Encoding.UTF8.GetBytes(text_);
-            byte[] zdata = new byte[data.Length + 1];
-            data.CopyTo(zdata, 0);
-            SetFieldValue(1, 0, zdata, Fit.SubfieldIndexMainField);
-        }
+		///<summary>
+		/// Retrieves the Text field</summary>
+		/// <returns>Returns byte[] representing the Text field</returns>
+		public byte[] Text
+		{
+			get
+			{
+				byte[] data = (byte[])GetFieldValue(1, 0, Fit.SubfieldIndexMainField);
+				return data.Take(data.Length - 1).ToArray();
+			}
+			set
+			{
+				SetFieldValue(1, 0, value, Fit.SubfieldIndexMainField);
+			}
+		}
 
-        
-        /// <summary>
-        /// Set Text field</summary>
-        /// <param name="text_">field value to be set</param>
-        public void SetText(byte[] text_)
-        {
-            SetFieldValue(1, 0, text_, Fit.SubfieldIndexMainField);
-        }
-        
-        #endregion // Methods
-    } // Class
+		///<summary>
+		/// Retrieves the Text field</summary>
+		/// <returns>Returns String representing the Text field</returns>
+		public String GetTextAsString()
+		{
+			byte[] data = (byte[])GetFieldValue(1, 0, Fit.SubfieldIndexMainField);
+			return data != null ? Encoding.UTF8.GetString(data, 0, data.Length - 1) : null;
+		}
+
+		///<summary>
+		/// Set Text field</summary>
+		/// <param name="text_"> field value to be set</param>
+		public void SetText(String text_)
+		{
+			byte[] data = Encoding.UTF8.GetBytes(text_);
+			byte[] zdata = new byte[data.Length + 1];
+			data.CopyTo(zdata, 0);
+			SetFieldValue(1, 0, zdata, Fit.SubfieldIndexMainField);
+		}
+
+		#endregion // Methods
+	} // Class
 } // namespace

--- a/Dynastream/Fit/Profile/Mesgs/WatchfaceSettingsMesg.cs
+++ b/Dynastream/Fit/Profile/Mesgs/WatchfaceSettingsMesg.cs
@@ -21,142 +21,139 @@ using System.Linq;
 
 namespace Dynastream.Fit
 {
-    /// <summary>
-    /// Implements the WatchfaceSettings profile message.
-    /// </summary>
-    public class WatchfaceSettingsMesg : Mesg
-    {
-        #region Fields
-        static class LayoutSubfield
-        {
-            public static ushort DigitalLayout = 0;
-            public static ushort AnalogLayout = 1;
-            public static ushort Subfields = 2;
-            public static ushort Active = Fit.SubfieldIndexActiveSubfield;
-            public static ushort MainField = Fit.SubfieldIndexMainField;
-        }
-        #endregion
+	/// <summary>
+	/// Implements the WatchfaceSettings profile message.
+	/// </summary>
+	public class WatchfaceSettingsMesg : Mesg
+	{
+		#region Fields
+		static class LayoutSubfield
+		{
+			public static ushort DigitalLayout = 0;
+			public static ushort AnalogLayout = 1;
+			public static ushort Subfields = 2;
+			public static ushort Active = Fit.SubfieldIndexActiveSubfield;
+			public static ushort MainField = Fit.SubfieldIndexMainField;
+		}
+		#endregion
 
-        /// <summary>
-        /// Field Numbers for <see cref="WatchfaceSettingsMesg"/>
-        /// </summary>
-        public sealed class FieldDefNum
-        {
-            public const byte MessageIndex = 254;
-            public const byte Mode = 0;
-            public const byte Layout = 1;
-            public const byte Invalid = Fit.FieldNumInvalid;
-        }
+		/// <summary>
+		/// Field Numbers for <see cref="WatchfaceSettingsMesg"/>
+		/// </summary>
+		public sealed class FieldDefNum
+		{
+			public const byte MessageIndex = 254;
+			public const byte Mode = 0;
+			public const byte Layout = 1;
+			public const byte Invalid = Fit.FieldNumInvalid;
+		}
 
-        #region Constructors
-        public WatchfaceSettingsMesg() : base(Profile.GetMesg(MesgNum.WatchfaceSettings))
-        {
-        }
+		#region Constructors
+		public WatchfaceSettingsMesg() : base(Profile.GetMesg(MesgNum.WatchfaceSettings))
+		{
+		}
 
-        public WatchfaceSettingsMesg(Mesg mesg) : base(mesg)
-        {
-        }
-        #endregion // Constructors
+		public WatchfaceSettingsMesg(Mesg mesg) : base(mesg)
+		{
+		}
+		#endregion // Constructors
 
-        #region Methods
-        ///<summary>
-        /// Retrieves the MessageIndex field</summary>
-        /// <returns>Returns nullable ushort representing the MessageIndex field</returns>
-        public ushort? GetMessageIndex()
-        {
-            Object val = GetFieldValue(254, 0, Fit.SubfieldIndexMainField);
-            if(val == null)
-            {
-                return null;
-            }
+		#region Methods
+		///<summary>
+		/// Retrieves the MessageIndex field</summary>
+		/// <returns>Returns nullable ushort representing the MessageIndex field</returns>
+		public ushort? MessageIndex
+		{
+			get
+			{
+				Object val = GetFieldValue(254, 0, Fit.SubfieldIndexMainField);
+				if (val == null)
+				{
+					return null;
+				}
 
-            return (Convert.ToUInt16(val));
-            
-        }
+				return (Convert.ToUInt16(val));
 
-        /// <summary>
-        /// Set MessageIndex field</summary>
-        /// <param name="messageIndex_">Nullable field value to be set</param>
-        public void SetMessageIndex(ushort? messageIndex_)
-        {
-            SetFieldValue(254, 0, messageIndex_, Fit.SubfieldIndexMainField);
-        }
-        
-        ///<summary>
-        /// Retrieves the Mode field</summary>
-        /// <returns>Returns nullable WatchfaceMode enum representing the Mode field</returns>
-        public WatchfaceMode? GetMode()
-        {
-            object obj = GetFieldValue(0, 0, Fit.SubfieldIndexMainField);
-            WatchfaceMode? value = obj == null ? (WatchfaceMode?)null : (WatchfaceMode)obj;
-            return value;
-        }
+			}
+			set
+			{
+				SetFieldValue(254, 0, value, Fit.SubfieldIndexMainField);
+			}
+		}
 
-        /// <summary>
-        /// Set Mode field</summary>
-        /// <param name="mode_">Nullable field value to be set</param>
-        public void SetMode(WatchfaceMode? mode_)
-        {
-            SetFieldValue(0, 0, mode_, Fit.SubfieldIndexMainField);
-        }
-        
-        ///<summary>
-        /// Retrieves the Layout field</summary>
-        /// <returns>Returns nullable byte representing the Layout field</returns>
-        public byte? GetLayout()
-        {
-            Object val = GetFieldValue(1, 0, Fit.SubfieldIndexMainField);
-            if(val == null)
-            {
-                return null;
-            }
+		///<summary>
+		/// Retrieves the Mode field</summary>
+		/// <returns>Returns nullable WatchfaceMode enum representing the Mode field</returns>
+		public WatchfaceMode? Mode
+		{
+			get
+			{
+				object obj = GetFieldValue(0, 0, Fit.SubfieldIndexMainField);
+				WatchfaceMode? value = obj == null ? (WatchfaceMode?)null : (WatchfaceMode)obj;
+				return value;
+			}
+			set
+			{
+				SetFieldValue(0, 0, value, Fit.SubfieldIndexMainField);
+			}
+		}
 
-            return (Convert.ToByte(val));
-            
-        }
+		///<summary>
+		/// Retrieves the Layout field</summary>
+		/// <returns>Returns nullable byte representing the Layout field</returns>
+		public byte? Layout
+		{
+			get
+			{
+				Object val = GetFieldValue(1, 0, Fit.SubfieldIndexMainField);
+				if (val == null)
+				{
+					return null;
+				}
 
-        /// <summary>
-        /// Set Layout field</summary>
-        /// <param name="layout_">Nullable field value to be set</param>
-        public void SetLayout(byte? layout_)
-        {
-            SetFieldValue(1, 0, layout_, Fit.SubfieldIndexMainField);
-        }
-        
+				return (Convert.ToByte(val));
 
-        /// <summary>
-        /// Retrieves the DigitalLayout subfield</summary>
-        /// <returns>Nullable DigitalWatchfaceLayout enum representing the DigitalLayout subfield</returns>
-        public DigitalWatchfaceLayout? GetDigitalLayout()
-        {
-            return (DigitalWatchfaceLayout?)GetFieldValue(1, 0, LayoutSubfield.DigitalLayout);
-        }
+			}
+			set
+			{
+				SetFieldValue(1, 0, value, Fit.SubfieldIndexMainField);
+			}
+		}
 
-        /// <summary>
-        ///
-        /// Set DigitalLayout subfield</summary>
-        /// <param name="digitalLayout">Subfield value to be set</param>
-        public void SetDigitalLayout(byte? digitalLayout)
-        {
-            SetFieldValue(1, 0, digitalLayout, LayoutSubfield.DigitalLayout);
-        }
 
-        /// <summary>
-        /// Retrieves the AnalogLayout subfield</summary>
-        /// <returns>Nullable AnalogWatchfaceLayout enum representing the AnalogLayout subfield</returns>
-        public AnalogWatchfaceLayout? GetAnalogLayout()
-        {
-            return (AnalogWatchfaceLayout?)GetFieldValue(1, 0, LayoutSubfield.AnalogLayout);
-        }
+		/// <summary>
+		/// Retrieves the DigitalLayout subfield</summary>
+		/// <returns>Nullable DigitalWatchfaceLayout enum representing the DigitalLayout subfield</returns>
+		public DigitalWatchfaceLayout? GetDigitalLayout()
+		{
+			return (DigitalWatchfaceLayout?)GetFieldValue(1, 0, LayoutSubfield.DigitalLayout);
+		}
 
-        /// <summary>
-        ///
-        /// Set AnalogLayout subfield</summary>
-        /// <param name="analogLayout">Subfield value to be set</param>
-        public void SetAnalogLayout(byte? analogLayout)
-        {
-            SetFieldValue(1, 0, analogLayout, LayoutSubfield.AnalogLayout);
-        }
-        #endregion // Methods
-    } // Class
+		/// <summary>
+		///
+		/// Set DigitalLayout subfield</summary>
+		/// <param name="digitalLayout">Subfield value to be set</param>
+		public void SetDigitalLayout(byte? digitalLayout)
+		{
+			SetFieldValue(1, 0, digitalLayout, LayoutSubfield.DigitalLayout);
+		}
+
+		/// <summary>
+		/// Retrieves the AnalogLayout subfield</summary>
+		/// <returns>Nullable AnalogWatchfaceLayout enum representing the AnalogLayout subfield</returns>
+		public AnalogWatchfaceLayout? GetAnalogLayout()
+		{
+			return (AnalogWatchfaceLayout?)GetFieldValue(1, 0, LayoutSubfield.AnalogLayout);
+		}
+
+		/// <summary>
+		///
+		/// Set AnalogLayout subfield</summary>
+		/// <param name="analogLayout">Subfield value to be set</param>
+		public void SetAnalogLayout(byte? analogLayout)
+		{
+			SetFieldValue(1, 0, analogLayout, LayoutSubfield.AnalogLayout);
+		}
+		#endregion // Methods
+	} // Class
 } // namespace

--- a/Dynastream/Fit/Profile/Mesgs/WeatherAlertMesg.cs
+++ b/Dynastream/Fit/Profile/Mesgs/WeatherAlertMesg.cs
@@ -21,194 +21,182 @@ using System.Linq;
 
 namespace Dynastream.Fit
 {
-    /// <summary>
-    /// Implements the WeatherAlert profile message.
-    /// </summary>
-    public class WeatherAlertMesg : Mesg
-    {
-        #region Fields
-        #endregion
+	/// <summary>
+	/// Implements the WeatherAlert profile message.
+	/// </summary>
+	public class WeatherAlertMesg : Mesg
+	{
+		#region Fields
+		#endregion
 
-        /// <summary>
-        /// Field Numbers for <see cref="WeatherAlertMesg"/>
-        /// </summary>
-        public sealed class FieldDefNum
-        {
-            public const byte Timestamp = 253;
-            public const byte ReportId = 0;
-            public const byte IssueTime = 1;
-            public const byte ExpireTime = 2;
-            public const byte Severity = 3;
-            public const byte Type = 4;
-            public const byte Invalid = Fit.FieldNumInvalid;
-        }
+		/// <summary>
+		/// Field Numbers for <see cref="WeatherAlertMesg"/>
+		/// </summary>
+		public sealed class FieldDefNum
+		{
+			public const byte Timestamp = 253;
+			public const byte ReportId = 0;
+			public const byte IssueTime = 1;
+			public const byte ExpireTime = 2;
+			public const byte Severity = 3;
+			public const byte Type = 4;
+			public const byte Invalid = Fit.FieldNumInvalid;
+		}
 
-        #region Constructors
-        public WeatherAlertMesg() : base(Profile.GetMesg(MesgNum.WeatherAlert))
-        {
-        }
+		#region Constructors
+		public WeatherAlertMesg() : base(Profile.GetMesg(MesgNum.WeatherAlert))
+		{
+		}
 
-        public WeatherAlertMesg(Mesg mesg) : base(mesg)
-        {
-        }
-        #endregion // Constructors
+		public WeatherAlertMesg(Mesg mesg) : base(mesg)
+		{
+		}
+		#endregion // Constructors
 
-        #region Methods
-        ///<summary>
-        /// Retrieves the Timestamp field</summary>
-        /// <returns>Returns DateTime representing the Timestamp field</returns>
-        public DateTime GetTimestamp()
-        {
-            Object val = GetFieldValue(253, 0, Fit.SubfieldIndexMainField);
-            if(val == null)
-            {
-                return null;
-            }
+		#region Methods
+		///<summary>
+		/// Retrieves the Timestamp field</summary>
+		/// <returns>Returns DateTime representing the Timestamp field</returns>
+		public DateTime Timestamp
+		{
+			get
+			{
+				Object val = GetFieldValue(253, 0, Fit.SubfieldIndexMainField);
+				if (val == null)
+				{
+					return null;
+				}
 
-            return TimestampToDateTime(Convert.ToUInt32(val));
-            
-        }
+				return TimestampToDateTime(Convert.ToUInt32(val));
 
-        /// <summary>
-        /// Set Timestamp field</summary>
-        /// <param name="timestamp_">Nullable field value to be set</param>
-        public void SetTimestamp(DateTime timestamp_)
-        {
-            SetFieldValue(253, 0, timestamp_.GetTimeStamp(), Fit.SubfieldIndexMainField);
-        }
-        
-        ///<summary>
-        /// Retrieves the ReportId field
-        /// Comment: Unique identifier from GCS report ID string, length is 12</summary>
-        /// <returns>Returns byte[] representing the ReportId field</returns>
-        public byte[] GetReportId()
-        {
-            byte[] data = (byte[])GetFieldValue(0, 0, Fit.SubfieldIndexMainField);
-            return data.Take(data.Length - 1).ToArray();
-        }
+			}
+			set
+			{
+				SetFieldValue(253, 0, value.GetTimeStamp(), Fit.SubfieldIndexMainField);
+			}
+		}
 
-        ///<summary>
-        /// Retrieves the ReportId field
-        /// Comment: Unique identifier from GCS report ID string, length is 12</summary>
-        /// <returns>Returns String representing the ReportId field</returns>
-        public String GetReportIdAsString()
-        {
-            byte[] data = (byte[])GetFieldValue(0, 0, Fit.SubfieldIndexMainField);
-            return data != null ? Encoding.UTF8.GetString(data, 0, data.Length - 1) : null;
-        }
+		///<summary>
+		/// Retrieves the ReportId field
+		/// Comment: Unique identifier from GCS report ID string, length is 12</summary>
+		/// <returns>Returns byte[] representing the ReportId field</returns>
+		public byte[] ReportId
+		{
+			get
+			{
+				byte[] data = (byte[])GetFieldValue(0, 0, Fit.SubfieldIndexMainField);
+				return data.Take(data.Length - 1).ToArray();
+			}
+			set
+			{
+				SetFieldValue(0, 0, value, Fit.SubfieldIndexMainField);
+			}
+		}
 
-        ///<summary>
-        /// Set ReportId field
-        /// Comment: Unique identifier from GCS report ID string, length is 12</summary>
-        /// <param name="reportId_"> field value to be set</param>
-        public void SetReportId(String reportId_)
-        {
-            byte[] data = Encoding.UTF8.GetBytes(reportId_);
-            byte[] zdata = new byte[data.Length + 1];
-            data.CopyTo(zdata, 0);
-            SetFieldValue(0, 0, zdata, Fit.SubfieldIndexMainField);
-        }
+		///<summary>
+		/// Retrieves the ReportId field
+		/// Comment: Unique identifier from GCS report ID string, length is 12</summary>
+		/// <returns>Returns String representing the ReportId field</returns>
+		public String GetReportIdAsString()
+		{
+			byte[] data = (byte[])GetFieldValue(0, 0, Fit.SubfieldIndexMainField);
+			return data != null ? Encoding.UTF8.GetString(data, 0, data.Length - 1) : null;
+		}
 
-        
-        /// <summary>
-        /// Set ReportId field
-        /// Comment: Unique identifier from GCS report ID string, length is 12</summary>
-        /// <param name="reportId_">field value to be set</param>
-        public void SetReportId(byte[] reportId_)
-        {
-            SetFieldValue(0, 0, reportId_, Fit.SubfieldIndexMainField);
-        }
-        
-        ///<summary>
-        /// Retrieves the IssueTime field
-        /// Comment: Time alert was issued</summary>
-        /// <returns>Returns DateTime representing the IssueTime field</returns>
-        public DateTime GetIssueTime()
-        {
-            Object val = GetFieldValue(1, 0, Fit.SubfieldIndexMainField);
-            if(val == null)
-            {
-                return null;
-            }
+		///<summary>
+		/// Set ReportId field
+		/// Comment: Unique identifier from GCS report ID string, length is 12</summary>
+		/// <param name="reportId_"> field value to be set</param>
+		public void SetReportId(String reportId_)
+		{
+			byte[] data = Encoding.UTF8.GetBytes(reportId_);
+			byte[] zdata = new byte[data.Length + 1];
+			data.CopyTo(zdata, 0);
+			SetFieldValue(0, 0, zdata, Fit.SubfieldIndexMainField);
+		}
 
-            return TimestampToDateTime(Convert.ToUInt32(val));
-            
-        }
+		///<summary>
+		/// Retrieves the IssueTime field
+		/// Comment: Time alert was issued</summary>
+		/// <returns>Returns DateTime representing the IssueTime field</returns>
+		public DateTime IssueTime
+		{
+			get
+			{
+				Object val = GetFieldValue(1, 0, Fit.SubfieldIndexMainField);
+				if (val == null)
+				{
+					return null;
+				}
 
-        /// <summary>
-        /// Set IssueTime field
-        /// Comment: Time alert was issued</summary>
-        /// <param name="issueTime_">Nullable field value to be set</param>
-        public void SetIssueTime(DateTime issueTime_)
-        {
-            SetFieldValue(1, 0, issueTime_.GetTimeStamp(), Fit.SubfieldIndexMainField);
-        }
-        
-        ///<summary>
-        /// Retrieves the ExpireTime field
-        /// Comment: Time alert expires</summary>
-        /// <returns>Returns DateTime representing the ExpireTime field</returns>
-        public DateTime GetExpireTime()
-        {
-            Object val = GetFieldValue(2, 0, Fit.SubfieldIndexMainField);
-            if(val == null)
-            {
-                return null;
-            }
+				return TimestampToDateTime(Convert.ToUInt32(val));
 
-            return TimestampToDateTime(Convert.ToUInt32(val));
-            
-        }
+			}
+			set
+			{
+				SetFieldValue(1, 0, value.GetTimeStamp(), Fit.SubfieldIndexMainField);
+			}
+		}
 
-        /// <summary>
-        /// Set ExpireTime field
-        /// Comment: Time alert expires</summary>
-        /// <param name="expireTime_">Nullable field value to be set</param>
-        public void SetExpireTime(DateTime expireTime_)
-        {
-            SetFieldValue(2, 0, expireTime_.GetTimeStamp(), Fit.SubfieldIndexMainField);
-        }
-        
-        ///<summary>
-        /// Retrieves the Severity field
-        /// Comment: Warning, Watch, Advisory, Statement</summary>
-        /// <returns>Returns nullable WeatherSeverity enum representing the Severity field</returns>
-        public WeatherSeverity? GetSeverity()
-        {
-            object obj = GetFieldValue(3, 0, Fit.SubfieldIndexMainField);
-            WeatherSeverity? value = obj == null ? (WeatherSeverity?)null : (WeatherSeverity)obj;
-            return value;
-        }
+		///<summary>
+		/// Retrieves the ExpireTime field
+		/// Comment: Time alert expires</summary>
+		/// <returns>Returns DateTime representing the ExpireTime field</returns>
+		public DateTime ExpireTime
+		{
+			get
+			{
+				Object val = GetFieldValue(2, 0, Fit.SubfieldIndexMainField);
+				if (val == null)
+				{
+					return null;
+				}
 
-        /// <summary>
-        /// Set Severity field
-        /// Comment: Warning, Watch, Advisory, Statement</summary>
-        /// <param name="severity_">Nullable field value to be set</param>
-        public void SetSeverity(WeatherSeverity? severity_)
-        {
-            SetFieldValue(3, 0, severity_, Fit.SubfieldIndexMainField);
-        }
-        
-        ///<summary>
-        /// Retrieves the Type field
-        /// Comment: Tornado, Severe Thunderstorm, etc.</summary>
-        /// <returns>Returns nullable WeatherSevereType enum representing the Type field</returns>
-        new public WeatherSevereType? GetType()
-        {
-            object obj = GetFieldValue(4, 0, Fit.SubfieldIndexMainField);
-            WeatherSevereType? value = obj == null ? (WeatherSevereType?)null : (WeatherSevereType)obj;
-            return value;
-        }
+				return TimestampToDateTime(Convert.ToUInt32(val));
 
-        /// <summary>
-        /// Set Type field
-        /// Comment: Tornado, Severe Thunderstorm, etc.</summary>
-        /// <param name="type_">Nullable field value to be set</param>
-        public void SetType(WeatherSevereType? type_)
-        {
-            SetFieldValue(4, 0, type_, Fit.SubfieldIndexMainField);
-        }
-        
-        #endregion // Methods
-    } // Class
+			}
+			set
+			{
+				SetFieldValue(2, 0, value.GetTimeStamp(), Fit.SubfieldIndexMainField);
+			}
+		}
+
+		///<summary>
+		/// Retrieves the Severity field
+		/// Comment: Warning, Watch, Advisory, Statement</summary>
+		/// <returns>Returns nullable WeatherSeverity enum representing the Severity field</returns>
+		public WeatherSeverity? Severity
+		{
+			get
+			{
+				object obj = GetFieldValue(3, 0, Fit.SubfieldIndexMainField);
+				WeatherSeverity? value = obj == null ? (WeatherSeverity?)null : (WeatherSeverity)obj;
+				return value;
+			}
+			set
+			{
+				SetFieldValue(3, 0, value, Fit.SubfieldIndexMainField);
+			}
+		}
+
+		///<summary>
+		/// Retrieves the Type field
+		/// Comment: Tornado, Severe Thunderstorm, etc.</summary>
+		/// <returns>Returns nullable WeatherSevereType enum representing the Type field</returns>
+		public WeatherSevereType? Type
+		{
+			get
+			{
+				object obj = GetFieldValue(4, 0, Fit.SubfieldIndexMainField);
+				WeatherSevereType? value = obj == null ? (WeatherSevereType?)null : (WeatherSevereType)obj;
+				return value;
+			}
+			set
+			{
+				SetFieldValue(4, 0, value, Fit.SubfieldIndexMainField);
+			}
+		}
+
+		#endregion // Methods
+	} // Class
 } // namespace

--- a/Dynastream/Fit/Profile/Mesgs/WeatherConditionsMesg.cs
+++ b/Dynastream/Fit/Profile/Mesgs/WeatherConditionsMesg.cs
@@ -21,447 +21,416 @@ using System.Linq;
 
 namespace Dynastream.Fit
 {
-    /// <summary>
-    /// Implements the WeatherConditions profile message.
-    /// </summary>
-    public class WeatherConditionsMesg : Mesg
-    {
-        #region Fields
-        #endregion
+	/// <summary>
+	/// Implements the WeatherConditions profile message.
+	/// </summary>
+	public class WeatherConditionsMesg : Mesg
+	{
+		#region Fields
+		#endregion
 
-        /// <summary>
-        /// Field Numbers for <see cref="WeatherConditionsMesg"/>
-        /// </summary>
-        public sealed class FieldDefNum
-        {
-            public const byte Timestamp = 253;
-            public const byte WeatherReport = 0;
-            public const byte Temperature = 1;
-            public const byte Condition = 2;
-            public const byte WindDirection = 3;
-            public const byte WindSpeed = 4;
-            public const byte PrecipitationProbability = 5;
-            public const byte TemperatureFeelsLike = 6;
-            public const byte RelativeHumidity = 7;
-            public const byte Location = 8;
-            public const byte ObservedAtTime = 9;
-            public const byte ObservedLocationLat = 10;
-            public const byte ObservedLocationLong = 11;
-            public const byte DayOfWeek = 12;
-            public const byte HighTemperature = 13;
-            public const byte LowTemperature = 14;
-            public const byte Invalid = Fit.FieldNumInvalid;
-        }
+		/// <summary>
+		/// Field Numbers for <see cref="WeatherConditionsMesg"/>
+		/// </summary>
+		public sealed class FieldDefNum
+		{
+			public const byte Timestamp = 253;
+			public const byte WeatherReport = 0;
+			public const byte Temperature = 1;
+			public const byte Condition = 2;
+			public const byte WindDirection = 3;
+			public const byte WindSpeed = 4;
+			public const byte PrecipitationProbability = 5;
+			public const byte TemperatureFeelsLike = 6;
+			public const byte RelativeHumidity = 7;
+			public const byte Location = 8;
+			public const byte ObservedAtTime = 9;
+			public const byte ObservedLocationLat = 10;
+			public const byte ObservedLocationLong = 11;
+			public const byte DayOfWeek = 12;
+			public const byte HighTemperature = 13;
+			public const byte LowTemperature = 14;
+			public const byte Invalid = Fit.FieldNumInvalid;
+		}
 
-        #region Constructors
-        public WeatherConditionsMesg() : base(Profile.GetMesg(MesgNum.WeatherConditions))
-        {
-        }
+		#region Constructors
+		public WeatherConditionsMesg() : base(Profile.GetMesg(MesgNum.WeatherConditions))
+		{
+		}
 
-        public WeatherConditionsMesg(Mesg mesg) : base(mesg)
-        {
-        }
-        #endregion // Constructors
+		public WeatherConditionsMesg(Mesg mesg) : base(mesg)
+		{
+		}
+		#endregion // Constructors
 
-        #region Methods
-        ///<summary>
-        /// Retrieves the Timestamp field
-        /// Comment: time of update for current conditions, else forecast time</summary>
-        /// <returns>Returns DateTime representing the Timestamp field</returns>
-        public DateTime GetTimestamp()
-        {
-            Object val = GetFieldValue(253, 0, Fit.SubfieldIndexMainField);
-            if(val == null)
-            {
-                return null;
-            }
+		#region Methods
+		///<summary>
+		/// Retrieves the Timestamp field
+		/// Comment: time of update for current conditions, else forecast time</summary>
+		/// <returns>Returns DateTime representing the Timestamp field</returns>
+		public DateTime Timestamp
+		{
+			get
+			{
+				Object val = GetFieldValue(253, 0, Fit.SubfieldIndexMainField);
+				if (val == null)
+				{
+					return null;
+				}
 
-            return TimestampToDateTime(Convert.ToUInt32(val));
-            
-        }
+				return TimestampToDateTime(Convert.ToUInt32(val));
 
-        /// <summary>
-        /// Set Timestamp field
-        /// Comment: time of update for current conditions, else forecast time</summary>
-        /// <param name="timestamp_">Nullable field value to be set</param>
-        public void SetTimestamp(DateTime timestamp_)
-        {
-            SetFieldValue(253, 0, timestamp_.GetTimeStamp(), Fit.SubfieldIndexMainField);
-        }
-        
-        ///<summary>
-        /// Retrieves the WeatherReport field
-        /// Comment: Current or forecast</summary>
-        /// <returns>Returns nullable WeatherReport enum representing the WeatherReport field</returns>
-        public WeatherReport? GetWeatherReport()
-        {
-            object obj = GetFieldValue(0, 0, Fit.SubfieldIndexMainField);
-            WeatherReport? value = obj == null ? (WeatherReport?)null : (WeatherReport)obj;
-            return value;
-        }
+			}
+			set
+			{
+				SetFieldValue(253, 0, value.GetTimeStamp(), Fit.SubfieldIndexMainField);
+			}
+		}
 
-        /// <summary>
-        /// Set WeatherReport field
-        /// Comment: Current or forecast</summary>
-        /// <param name="weatherReport_">Nullable field value to be set</param>
-        public void SetWeatherReport(WeatherReport? weatherReport_)
-        {
-            SetFieldValue(0, 0, weatherReport_, Fit.SubfieldIndexMainField);
-        }
-        
-        ///<summary>
-        /// Retrieves the Temperature field
-        /// Units: C</summary>
-        /// <returns>Returns nullable sbyte representing the Temperature field</returns>
-        public sbyte? GetTemperature()
-        {
-            Object val = GetFieldValue(1, 0, Fit.SubfieldIndexMainField);
-            if(val == null)
-            {
-                return null;
-            }
+		///<summary>
+		/// Retrieves the WeatherReport field
+		/// Comment: Current or forecast</summary>
+		/// <returns>Returns nullable WeatherReport enum representing the WeatherReport field</returns>
+		public WeatherReport? WeatherReport
+		{
+			get
+			{
+				object obj = GetFieldValue(0, 0, Fit.SubfieldIndexMainField);
+				WeatherReport? value = obj == null ? (WeatherReport?)null : (WeatherReport)obj;
+				return value;
+			}
+			set
+			{
+				SetFieldValue(0, 0, value, Fit.SubfieldIndexMainField);
+			}
+		}
 
-            return (Convert.ToSByte(val));
-            
-        }
+		///<summary>
+		/// Retrieves the Temperature field
+		/// Units: C</summary>
+		/// <returns>Returns nullable sbyte representing the Temperature field</returns>
+		public sbyte? Temperature
+		{
+			get
+			{
+				Object val = GetFieldValue(1, 0, Fit.SubfieldIndexMainField);
+				if (val == null)
+				{
+					return null;
+				}
 
-        /// <summary>
-        /// Set Temperature field
-        /// Units: C</summary>
-        /// <param name="temperature_">Nullable field value to be set</param>
-        public void SetTemperature(sbyte? temperature_)
-        {
-            SetFieldValue(1, 0, temperature_, Fit.SubfieldIndexMainField);
-        }
-        
-        ///<summary>
-        /// Retrieves the Condition field
-        /// Comment: Corresponds to GSC Response weatherIcon field</summary>
-        /// <returns>Returns nullable WeatherStatus enum representing the Condition field</returns>
-        public WeatherStatus? GetCondition()
-        {
-            object obj = GetFieldValue(2, 0, Fit.SubfieldIndexMainField);
-            WeatherStatus? value = obj == null ? (WeatherStatus?)null : (WeatherStatus)obj;
-            return value;
-        }
+				return (Convert.ToSByte(val));
 
-        /// <summary>
-        /// Set Condition field
-        /// Comment: Corresponds to GSC Response weatherIcon field</summary>
-        /// <param name="condition_">Nullable field value to be set</param>
-        public void SetCondition(WeatherStatus? condition_)
-        {
-            SetFieldValue(2, 0, condition_, Fit.SubfieldIndexMainField);
-        }
-        
-        ///<summary>
-        /// Retrieves the WindDirection field
-        /// Units: degrees</summary>
-        /// <returns>Returns nullable ushort representing the WindDirection field</returns>
-        public ushort? GetWindDirection()
-        {
-            Object val = GetFieldValue(3, 0, Fit.SubfieldIndexMainField);
-            if(val == null)
-            {
-                return null;
-            }
+			}
+			set
+			{
+				SetFieldValue(1, 0, value, Fit.SubfieldIndexMainField);
+			}
+		}
 
-            return (Convert.ToUInt16(val));
-            
-        }
+		///<summary>
+		/// Retrieves the Condition field
+		/// Comment: Corresponds to GSC Response weatherIcon field</summary>
+		/// <returns>Returns nullable WeatherStatus enum representing the Condition field</returns>
+		public WeatherStatus? Condition
+		{
+			get
+			{
+				object obj = GetFieldValue(2, 0, Fit.SubfieldIndexMainField);
+				WeatherStatus? value = obj == null ? (WeatherStatus?)null : (WeatherStatus)obj;
+				return value;
+			}
+			set
+			{
+				SetFieldValue(2, 0, value, Fit.SubfieldIndexMainField);
+			}
+		}
 
-        /// <summary>
-        /// Set WindDirection field
-        /// Units: degrees</summary>
-        /// <param name="windDirection_">Nullable field value to be set</param>
-        public void SetWindDirection(ushort? windDirection_)
-        {
-            SetFieldValue(3, 0, windDirection_, Fit.SubfieldIndexMainField);
-        }
-        
-        ///<summary>
-        /// Retrieves the WindSpeed field
-        /// Units: m/s</summary>
-        /// <returns>Returns nullable float representing the WindSpeed field</returns>
-        public float? GetWindSpeed()
-        {
-            Object val = GetFieldValue(4, 0, Fit.SubfieldIndexMainField);
-            if(val == null)
-            {
-                return null;
-            }
+		///<summary>
+		/// Retrieves the WindDirection field
+		/// Units: degrees</summary>
+		/// <returns>Returns nullable ushort representing the WindDirection field</returns>
+		public ushort? WindDirection
+		{
+			get
+			{
+				Object val = GetFieldValue(3, 0, Fit.SubfieldIndexMainField);
+				if (val == null)
+				{
+					return null;
+				}
 
-            return (Convert.ToSingle(val));
-            
-        }
+				return (Convert.ToUInt16(val));
 
-        /// <summary>
-        /// Set WindSpeed field
-        /// Units: m/s</summary>
-        /// <param name="windSpeed_">Nullable field value to be set</param>
-        public void SetWindSpeed(float? windSpeed_)
-        {
-            SetFieldValue(4, 0, windSpeed_, Fit.SubfieldIndexMainField);
-        }
-        
-        ///<summary>
-        /// Retrieves the PrecipitationProbability field
-        /// Comment: range 0-100</summary>
-        /// <returns>Returns nullable byte representing the PrecipitationProbability field</returns>
-        public byte? GetPrecipitationProbability()
-        {
-            Object val = GetFieldValue(5, 0, Fit.SubfieldIndexMainField);
-            if(val == null)
-            {
-                return null;
-            }
+			}
+			set
+			{
+				SetFieldValue(3, 0, value, Fit.SubfieldIndexMainField);
+			}
+		}
 
-            return (Convert.ToByte(val));
-            
-        }
+		///<summary>
+		/// Retrieves the WindSpeed field
+		/// Units: m/s</summary>
+		/// <returns>Returns nullable float representing the WindSpeed field</returns>
+		public float? WindSpeed
+		{
+			get
+			{
+				Object val = GetFieldValue(4, 0, Fit.SubfieldIndexMainField);
+				if (val == null)
+				{
+					return null;
+				}
 
-        /// <summary>
-        /// Set PrecipitationProbability field
-        /// Comment: range 0-100</summary>
-        /// <param name="precipitationProbability_">Nullable field value to be set</param>
-        public void SetPrecipitationProbability(byte? precipitationProbability_)
-        {
-            SetFieldValue(5, 0, precipitationProbability_, Fit.SubfieldIndexMainField);
-        }
-        
-        ///<summary>
-        /// Retrieves the TemperatureFeelsLike field
-        /// Units: C
-        /// Comment: Heat Index if GCS heatIdx above or equal to 90F or wind chill if GCS windChill below or equal to 32F</summary>
-        /// <returns>Returns nullable sbyte representing the TemperatureFeelsLike field</returns>
-        public sbyte? GetTemperatureFeelsLike()
-        {
-            Object val = GetFieldValue(6, 0, Fit.SubfieldIndexMainField);
-            if(val == null)
-            {
-                return null;
-            }
+				return (Convert.ToSingle(val));
 
-            return (Convert.ToSByte(val));
-            
-        }
+			}
+			set
+			{
+				SetFieldValue(4, 0, value, Fit.SubfieldIndexMainField);
+			}
+		}
 
-        /// <summary>
-        /// Set TemperatureFeelsLike field
-        /// Units: C
-        /// Comment: Heat Index if GCS heatIdx above or equal to 90F or wind chill if GCS windChill below or equal to 32F</summary>
-        /// <param name="temperatureFeelsLike_">Nullable field value to be set</param>
-        public void SetTemperatureFeelsLike(sbyte? temperatureFeelsLike_)
-        {
-            SetFieldValue(6, 0, temperatureFeelsLike_, Fit.SubfieldIndexMainField);
-        }
-        
-        ///<summary>
-        /// Retrieves the RelativeHumidity field</summary>
-        /// <returns>Returns nullable byte representing the RelativeHumidity field</returns>
-        public byte? GetRelativeHumidity()
-        {
-            Object val = GetFieldValue(7, 0, Fit.SubfieldIndexMainField);
-            if(val == null)
-            {
-                return null;
-            }
+		///<summary>
+		/// Retrieves the PrecipitationProbability field
+		/// Comment: range 0-100</summary>
+		/// <returns>Returns nullable byte representing the PrecipitationProbability field</returns>
+		public byte? PrecipitationProbability
+		{
+			get
+			{
+				Object val = GetFieldValue(5, 0, Fit.SubfieldIndexMainField);
+				if (val == null)
+				{
+					return null;
+				}
 
-            return (Convert.ToByte(val));
-            
-        }
+				return (Convert.ToByte(val));
 
-        /// <summary>
-        /// Set RelativeHumidity field</summary>
-        /// <param name="relativeHumidity_">Nullable field value to be set</param>
-        public void SetRelativeHumidity(byte? relativeHumidity_)
-        {
-            SetFieldValue(7, 0, relativeHumidity_, Fit.SubfieldIndexMainField);
-        }
-        
-        ///<summary>
-        /// Retrieves the Location field
-        /// Comment: string corresponding to GCS response location string</summary>
-        /// <returns>Returns byte[] representing the Location field</returns>
-        public byte[] GetLocation()
-        {
-            byte[] data = (byte[])GetFieldValue(8, 0, Fit.SubfieldIndexMainField);
-            return data.Take(data.Length - 1).ToArray();
-        }
+			}
+			set
+			{
+				SetFieldValue(5, 0, value, Fit.SubfieldIndexMainField);
+			}
+		}
 
-        ///<summary>
-        /// Retrieves the Location field
-        /// Comment: string corresponding to GCS response location string</summary>
-        /// <returns>Returns String representing the Location field</returns>
-        public String GetLocationAsString()
-        {
-            byte[] data = (byte[])GetFieldValue(8, 0, Fit.SubfieldIndexMainField);
-            return data != null ? Encoding.UTF8.GetString(data, 0, data.Length - 1) : null;
-        }
+		///<summary>
+		/// Retrieves the TemperatureFeelsLike field
+		/// Units: C
+		/// Comment: Heat Index if GCS heatIdx above or equal to 90F or wind chill if GCS windChill below or equal to 32F</summary>
+		/// <returns>Returns nullable sbyte representing the TemperatureFeelsLike field</returns>
+		public sbyte? TemperatureFeelsLike
+		{
+			get
+			{
+				Object val = GetFieldValue(6, 0, Fit.SubfieldIndexMainField);
+				if (val == null)
+				{
+					return null;
+				}
 
-        ///<summary>
-        /// Set Location field
-        /// Comment: string corresponding to GCS response location string</summary>
-        /// <param name="location_"> field value to be set</param>
-        public void SetLocation(String location_)
-        {
-            byte[] data = Encoding.UTF8.GetBytes(location_);
-            byte[] zdata = new byte[data.Length + 1];
-            data.CopyTo(zdata, 0);
-            SetFieldValue(8, 0, zdata, Fit.SubfieldIndexMainField);
-        }
+				return (Convert.ToSByte(val));
 
-        
-        /// <summary>
-        /// Set Location field
-        /// Comment: string corresponding to GCS response location string</summary>
-        /// <param name="location_">field value to be set</param>
-        public void SetLocation(byte[] location_)
-        {
-            SetFieldValue(8, 0, location_, Fit.SubfieldIndexMainField);
-        }
-        
-        ///<summary>
-        /// Retrieves the ObservedAtTime field</summary>
-        /// <returns>Returns DateTime representing the ObservedAtTime field</returns>
-        public DateTime GetObservedAtTime()
-        {
-            Object val = GetFieldValue(9, 0, Fit.SubfieldIndexMainField);
-            if(val == null)
-            {
-                return null;
-            }
+			}
+			set
+			{
+				SetFieldValue(6, 0, value, Fit.SubfieldIndexMainField);
+			}
+		}
 
-            return TimestampToDateTime(Convert.ToUInt32(val));
-            
-        }
+		///<summary>
+		/// Retrieves the RelativeHumidity field</summary>
+		/// <returns>Returns nullable byte representing the RelativeHumidity field</returns>
+		public byte? RelativeHumidity
+		{
+			get
+			{
+				Object val = GetFieldValue(7, 0, Fit.SubfieldIndexMainField);
+				if (val == null)
+				{
+					return null;
+				}
 
-        /// <summary>
-        /// Set ObservedAtTime field</summary>
-        /// <param name="observedAtTime_">Nullable field value to be set</param>
-        public void SetObservedAtTime(DateTime observedAtTime_)
-        {
-            SetFieldValue(9, 0, observedAtTime_.GetTimeStamp(), Fit.SubfieldIndexMainField);
-        }
-        
-        ///<summary>
-        /// Retrieves the ObservedLocationLat field
-        /// Units: semicircles</summary>
-        /// <returns>Returns nullable int representing the ObservedLocationLat field</returns>
-        public int? GetObservedLocationLat()
-        {
-            Object val = GetFieldValue(10, 0, Fit.SubfieldIndexMainField);
-            if(val == null)
-            {
-                return null;
-            }
+				return (Convert.ToByte(val));
 
-            return (Convert.ToInt32(val));
-            
-        }
+			}
+			set
+			{
+				SetFieldValue(7, 0, value, Fit.SubfieldIndexMainField);
+			}
+		}
 
-        /// <summary>
-        /// Set ObservedLocationLat field
-        /// Units: semicircles</summary>
-        /// <param name="observedLocationLat_">Nullable field value to be set</param>
-        public void SetObservedLocationLat(int? observedLocationLat_)
-        {
-            SetFieldValue(10, 0, observedLocationLat_, Fit.SubfieldIndexMainField);
-        }
-        
-        ///<summary>
-        /// Retrieves the ObservedLocationLong field
-        /// Units: semicircles</summary>
-        /// <returns>Returns nullable int representing the ObservedLocationLong field</returns>
-        public int? GetObservedLocationLong()
-        {
-            Object val = GetFieldValue(11, 0, Fit.SubfieldIndexMainField);
-            if(val == null)
-            {
-                return null;
-            }
+		///<summary>
+		/// Retrieves the Location field
+		/// Comment: string corresponding to GCS response location string</summary>
+		/// <returns>Returns byte[] representing the Location field</returns>
+		public byte[] Location
+		{
+			get
+			{
+				byte[] data = (byte[])GetFieldValue(8, 0, Fit.SubfieldIndexMainField);
+				return data.Take(data.Length - 1).ToArray();
+			}
+			set
+			{
+				SetFieldValue(8, 0, value, Fit.SubfieldIndexMainField);
+			}
+		}
 
-            return (Convert.ToInt32(val));
-            
-        }
+		///<summary>
+		/// Retrieves the Location field
+		/// Comment: string corresponding to GCS response location string</summary>
+		/// <returns>Returns String representing the Location field</returns>
+		public String GetLocationAsString()
+		{
+			byte[] data = (byte[])GetFieldValue(8, 0, Fit.SubfieldIndexMainField);
+			return data != null ? Encoding.UTF8.GetString(data, 0, data.Length - 1) : null;
+		}
 
-        /// <summary>
-        /// Set ObservedLocationLong field
-        /// Units: semicircles</summary>
-        /// <param name="observedLocationLong_">Nullable field value to be set</param>
-        public void SetObservedLocationLong(int? observedLocationLong_)
-        {
-            SetFieldValue(11, 0, observedLocationLong_, Fit.SubfieldIndexMainField);
-        }
-        
-        ///<summary>
-        /// Retrieves the DayOfWeek field</summary>
-        /// <returns>Returns nullable DayOfWeek enum representing the DayOfWeek field</returns>
-        public DayOfWeek? GetDayOfWeek()
-        {
-            object obj = GetFieldValue(12, 0, Fit.SubfieldIndexMainField);
-            DayOfWeek? value = obj == null ? (DayOfWeek?)null : (DayOfWeek)obj;
-            return value;
-        }
+		///<summary>
+		/// Set Location field
+		/// Comment: string corresponding to GCS response location string</summary>
+		/// <param name="location_"> field value to be set</param>
+		public void SetLocation(String location_)
+		{
+			byte[] data = Encoding.UTF8.GetBytes(location_);
+			byte[] zdata = new byte[data.Length + 1];
+			data.CopyTo(zdata, 0);
+			SetFieldValue(8, 0, zdata, Fit.SubfieldIndexMainField);
+		}
 
-        /// <summary>
-        /// Set DayOfWeek field</summary>
-        /// <param name="dayOfWeek_">Nullable field value to be set</param>
-        public void SetDayOfWeek(DayOfWeek? dayOfWeek_)
-        {
-            SetFieldValue(12, 0, dayOfWeek_, Fit.SubfieldIndexMainField);
-        }
-        
-        ///<summary>
-        /// Retrieves the HighTemperature field
-        /// Units: C</summary>
-        /// <returns>Returns nullable sbyte representing the HighTemperature field</returns>
-        public sbyte? GetHighTemperature()
-        {
-            Object val = GetFieldValue(13, 0, Fit.SubfieldIndexMainField);
-            if(val == null)
-            {
-                return null;
-            }
+		///<summary>
+		/// Retrieves the ObservedAtTime field</summary>
+		/// <returns>Returns DateTime representing the ObservedAtTime field</returns>
+		public DateTime ObservedAtTime
+		{
+			get
+			{
+				Object val = GetFieldValue(9, 0, Fit.SubfieldIndexMainField);
+				if (val == null)
+				{
+					return null;
+				}
 
-            return (Convert.ToSByte(val));
-            
-        }
+				return TimestampToDateTime(Convert.ToUInt32(val));
 
-        /// <summary>
-        /// Set HighTemperature field
-        /// Units: C</summary>
-        /// <param name="highTemperature_">Nullable field value to be set</param>
-        public void SetHighTemperature(sbyte? highTemperature_)
-        {
-            SetFieldValue(13, 0, highTemperature_, Fit.SubfieldIndexMainField);
-        }
-        
-        ///<summary>
-        /// Retrieves the LowTemperature field
-        /// Units: C</summary>
-        /// <returns>Returns nullable sbyte representing the LowTemperature field</returns>
-        public sbyte? GetLowTemperature()
-        {
-            Object val = GetFieldValue(14, 0, Fit.SubfieldIndexMainField);
-            if(val == null)
-            {
-                return null;
-            }
+			}
+			set
+			{
+				SetFieldValue(9, 0, value.GetTimeStamp(), Fit.SubfieldIndexMainField);
+			}
+		}
 
-            return (Convert.ToSByte(val));
-            
-        }
+		///<summary>
+		/// Retrieves the ObservedLocationLat field
+		/// Units: semicircles</summary>
+		/// <returns>Returns nullable int representing the ObservedLocationLat field</returns>
+		public int? ObservedLocationLat
+		{
+			get
+			{
+				Object val = GetFieldValue(10, 0, Fit.SubfieldIndexMainField);
+				if (val == null)
+				{
+					return null;
+				}
 
-        /// <summary>
-        /// Set LowTemperature field
-        /// Units: C</summary>
-        /// <param name="lowTemperature_">Nullable field value to be set</param>
-        public void SetLowTemperature(sbyte? lowTemperature_)
-        {
-            SetFieldValue(14, 0, lowTemperature_, Fit.SubfieldIndexMainField);
-        }
-        
-        #endregion // Methods
-    } // Class
+				return (Convert.ToInt32(val));
+
+			}
+			set
+			{
+				SetFieldValue(10, 0, value, Fit.SubfieldIndexMainField);
+			}
+		}
+
+		///<summary>
+		/// Retrieves the ObservedLocationLong field
+		/// Units: semicircles</summary>
+		/// <returns>Returns nullable int representing the ObservedLocationLong field</returns>
+		public int? ObservedLocationLong
+		{
+			get
+			{
+				Object val = GetFieldValue(11, 0, Fit.SubfieldIndexMainField);
+				if (val == null)
+				{
+					return null;
+				}
+
+				return (Convert.ToInt32(val));
+
+			}
+			set
+			{
+				SetFieldValue(11, 0, value, Fit.SubfieldIndexMainField);
+			}
+		}
+
+		///<summary>
+		/// Retrieves the DayOfWeek field</summary>
+		/// <returns>Returns nullable DayOfWeek enum representing the DayOfWeek field</returns>
+		public DayOfWeek? DayOfWeek
+		{
+			get
+			{
+				object obj = GetFieldValue(12, 0, Fit.SubfieldIndexMainField);
+				DayOfWeek? value = obj == null ? (DayOfWeek?)null : (DayOfWeek)obj;
+				return value;
+			}
+			set
+			{
+				SetFieldValue(12, 0, value, Fit.SubfieldIndexMainField);
+			}
+		}
+
+		///<summary>
+		/// Retrieves the HighTemperature field
+		/// Units: C</summary>
+		/// <returns>Returns nullable sbyte representing the HighTemperature field</returns>
+		public sbyte? HighTemperature
+		{
+			get
+			{
+				Object val = GetFieldValue(13, 0, Fit.SubfieldIndexMainField);
+				if (val == null)
+				{
+					return null;
+				}
+
+				return (Convert.ToSByte(val));
+
+			}
+			set
+			{
+				SetFieldValue(13, 0, value, Fit.SubfieldIndexMainField);
+			}
+		}
+
+		///<summary>
+		/// Retrieves the LowTemperature field
+		/// Units: C</summary>
+		/// <returns>Returns nullable sbyte representing the LowTemperature field</returns>
+		public sbyte? LowTemperature
+		{
+			get
+			{
+				Object val = GetFieldValue(14, 0, Fit.SubfieldIndexMainField);
+				if (val == null)
+				{
+					return null;
+				}
+
+				return (Convert.ToSByte(val));
+
+			}
+			set
+			{
+				SetFieldValue(14, 0, value, Fit.SubfieldIndexMainField);
+			}
+		}
+
+		#endregion // Methods
+	} // Class
 } // namespace

--- a/Dynastream/Fit/Profile/Mesgs/WeightScaleMesg.cs
+++ b/Dynastream/Fit/Profile/Mesgs/WeightScaleMesg.cs
@@ -21,395 +21,368 @@ using System.Linq;
 
 namespace Dynastream.Fit
 {
-    /// <summary>
-    /// Implements the WeightScale profile message.
-    /// </summary>
-    public class WeightScaleMesg : Mesg
-    {
-        #region Fields
-        #endregion
+	/// <summary>
+	/// Implements the WeightScale profile message.
+	/// </summary>
+	public class WeightScaleMesg : Mesg
+	{
+		#region Fields
+		#endregion
 
-        /// <summary>
-        /// Field Numbers for <see cref="WeightScaleMesg"/>
-        /// </summary>
-        public sealed class FieldDefNum
-        {
-            public const byte Timestamp = 253;
-            public const byte Weight = 0;
-            public const byte PercentFat = 1;
-            public const byte PercentHydration = 2;
-            public const byte VisceralFatMass = 3;
-            public const byte BoneMass = 4;
-            public const byte MuscleMass = 5;
-            public const byte BasalMet = 7;
-            public const byte PhysiqueRating = 8;
-            public const byte ActiveMet = 9;
-            public const byte MetabolicAge = 10;
-            public const byte VisceralFatRating = 11;
-            public const byte UserProfileIndex = 12;
-            public const byte Bmi = 13;
-            public const byte Invalid = Fit.FieldNumInvalid;
-        }
+		/// <summary>
+		/// Field Numbers for <see cref="WeightScaleMesg"/>
+		/// </summary>
+		public sealed class FieldDefNum
+		{
+			public const byte Timestamp = 253;
+			public const byte Weight = 0;
+			public const byte PercentFat = 1;
+			public const byte PercentHydration = 2;
+			public const byte VisceralFatMass = 3;
+			public const byte BoneMass = 4;
+			public const byte MuscleMass = 5;
+			public const byte BasalMet = 7;
+			public const byte PhysiqueRating = 8;
+			public const byte ActiveMet = 9;
+			public const byte MetabolicAge = 10;
+			public const byte VisceralFatRating = 11;
+			public const byte UserProfileIndex = 12;
+			public const byte Bmi = 13;
+			public const byte Invalid = Fit.FieldNumInvalid;
+		}
 
-        #region Constructors
-        public WeightScaleMesg() : base(Profile.GetMesg(MesgNum.WeightScale))
-        {
-        }
+		#region Constructors
+		public WeightScaleMesg() : base(Profile.GetMesg(MesgNum.WeightScale))
+		{
+		}
 
-        public WeightScaleMesg(Mesg mesg) : base(mesg)
-        {
-        }
-        #endregion // Constructors
+		public WeightScaleMesg(Mesg mesg) : base(mesg)
+		{
+		}
+		#endregion // Constructors
 
-        #region Methods
-        ///<summary>
-        /// Retrieves the Timestamp field
-        /// Units: s</summary>
-        /// <returns>Returns DateTime representing the Timestamp field</returns>
-        public DateTime GetTimestamp()
-        {
-            Object val = GetFieldValue(253, 0, Fit.SubfieldIndexMainField);
-            if(val == null)
-            {
-                return null;
-            }
+		#region Methods
+		///<summary>
+		/// Retrieves the Timestamp field
+		/// Units: s</summary>
+		/// <returns>Returns DateTime representing the Timestamp field</returns>
+		public DateTime Timestamp
+		{
+			get
+			{
+				Object val = GetFieldValue(253, 0, Fit.SubfieldIndexMainField);
+				if (val == null)
+				{
+					return null;
+				}
 
-            return TimestampToDateTime(Convert.ToUInt32(val));
-            
-        }
+				return TimestampToDateTime(Convert.ToUInt32(val));
 
-        /// <summary>
-        /// Set Timestamp field
-        /// Units: s</summary>
-        /// <param name="timestamp_">Nullable field value to be set</param>
-        public void SetTimestamp(DateTime timestamp_)
-        {
-            SetFieldValue(253, 0, timestamp_.GetTimeStamp(), Fit.SubfieldIndexMainField);
-        }
-        
-        ///<summary>
-        /// Retrieves the Weight field
-        /// Units: kg</summary>
-        /// <returns>Returns nullable float representing the Weight field</returns>
-        public float? GetWeight()
-        {
-            Object val = GetFieldValue(0, 0, Fit.SubfieldIndexMainField);
-            if(val == null)
-            {
-                return null;
-            }
+			}
+			set
+			{
+				SetFieldValue(253, 0, value.GetTimeStamp(), Fit.SubfieldIndexMainField);
+			}
+		}
 
-            return (Convert.ToSingle(val));
-            
-        }
+		///<summary>
+		/// Retrieves the Weight field
+		/// Units: kg</summary>
+		/// <returns>Returns nullable float representing the Weight field</returns>
+		public float? Weight
+		{
+			get
+			{
+				Object val = GetFieldValue(0, 0, Fit.SubfieldIndexMainField);
+				if (val == null)
+				{
+					return null;
+				}
 
-        /// <summary>
-        /// Set Weight field
-        /// Units: kg</summary>
-        /// <param name="weight_">Nullable field value to be set</param>
-        public void SetWeight(float? weight_)
-        {
-            SetFieldValue(0, 0, weight_, Fit.SubfieldIndexMainField);
-        }
-        
-        ///<summary>
-        /// Retrieves the PercentFat field
-        /// Units: %</summary>
-        /// <returns>Returns nullable float representing the PercentFat field</returns>
-        public float? GetPercentFat()
-        {
-            Object val = GetFieldValue(1, 0, Fit.SubfieldIndexMainField);
-            if(val == null)
-            {
-                return null;
-            }
+				return (Convert.ToSingle(val));
 
-            return (Convert.ToSingle(val));
-            
-        }
+			}
+			set
+			{
+				SetFieldValue(0, 0, value, Fit.SubfieldIndexMainField);
+			}
+		}
 
-        /// <summary>
-        /// Set PercentFat field
-        /// Units: %</summary>
-        /// <param name="percentFat_">Nullable field value to be set</param>
-        public void SetPercentFat(float? percentFat_)
-        {
-            SetFieldValue(1, 0, percentFat_, Fit.SubfieldIndexMainField);
-        }
-        
-        ///<summary>
-        /// Retrieves the PercentHydration field
-        /// Units: %</summary>
-        /// <returns>Returns nullable float representing the PercentHydration field</returns>
-        public float? GetPercentHydration()
-        {
-            Object val = GetFieldValue(2, 0, Fit.SubfieldIndexMainField);
-            if(val == null)
-            {
-                return null;
-            }
+		///<summary>
+		/// Retrieves the PercentFat field
+		/// Units: %</summary>
+		/// <returns>Returns nullable float representing the PercentFat field</returns>
+		public float? PercentFat
+		{
+			get
+			{
+				Object val = GetFieldValue(1, 0, Fit.SubfieldIndexMainField);
+				if (val == null)
+				{
+					return null;
+				}
 
-            return (Convert.ToSingle(val));
-            
-        }
+				return (Convert.ToSingle(val));
 
-        /// <summary>
-        /// Set PercentHydration field
-        /// Units: %</summary>
-        /// <param name="percentHydration_">Nullable field value to be set</param>
-        public void SetPercentHydration(float? percentHydration_)
-        {
-            SetFieldValue(2, 0, percentHydration_, Fit.SubfieldIndexMainField);
-        }
-        
-        ///<summary>
-        /// Retrieves the VisceralFatMass field
-        /// Units: kg</summary>
-        /// <returns>Returns nullable float representing the VisceralFatMass field</returns>
-        public float? GetVisceralFatMass()
-        {
-            Object val = GetFieldValue(3, 0, Fit.SubfieldIndexMainField);
-            if(val == null)
-            {
-                return null;
-            }
+			}
+			set
+			{
+				SetFieldValue(1, 0, value, Fit.SubfieldIndexMainField);
+			}
+		}
 
-            return (Convert.ToSingle(val));
-            
-        }
+		///<summary>
+		/// Retrieves the PercentHydration field
+		/// Units: %</summary>
+		/// <returns>Returns nullable float representing the PercentHydration field</returns>
+		public float? PercentHydration
+		{
+			get
+			{
+				Object val = GetFieldValue(2, 0, Fit.SubfieldIndexMainField);
+				if (val == null)
+				{
+					return null;
+				}
 
-        /// <summary>
-        /// Set VisceralFatMass field
-        /// Units: kg</summary>
-        /// <param name="visceralFatMass_">Nullable field value to be set</param>
-        public void SetVisceralFatMass(float? visceralFatMass_)
-        {
-            SetFieldValue(3, 0, visceralFatMass_, Fit.SubfieldIndexMainField);
-        }
-        
-        ///<summary>
-        /// Retrieves the BoneMass field
-        /// Units: kg</summary>
-        /// <returns>Returns nullable float representing the BoneMass field</returns>
-        public float? GetBoneMass()
-        {
-            Object val = GetFieldValue(4, 0, Fit.SubfieldIndexMainField);
-            if(val == null)
-            {
-                return null;
-            }
+				return (Convert.ToSingle(val));
 
-            return (Convert.ToSingle(val));
-            
-        }
+			}
+			set
+			{
+				SetFieldValue(2, 0, value, Fit.SubfieldIndexMainField);
+			}
+		}
 
-        /// <summary>
-        /// Set BoneMass field
-        /// Units: kg</summary>
-        /// <param name="boneMass_">Nullable field value to be set</param>
-        public void SetBoneMass(float? boneMass_)
-        {
-            SetFieldValue(4, 0, boneMass_, Fit.SubfieldIndexMainField);
-        }
-        
-        ///<summary>
-        /// Retrieves the MuscleMass field
-        /// Units: kg</summary>
-        /// <returns>Returns nullable float representing the MuscleMass field</returns>
-        public float? GetMuscleMass()
-        {
-            Object val = GetFieldValue(5, 0, Fit.SubfieldIndexMainField);
-            if(val == null)
-            {
-                return null;
-            }
+		///<summary>
+		/// Retrieves the VisceralFatMass field
+		/// Units: kg</summary>
+		/// <returns>Returns nullable float representing the VisceralFatMass field</returns>
+		public float? VisceralFatMass
+		{
+			get
+			{
+				Object val = GetFieldValue(3, 0, Fit.SubfieldIndexMainField);
+				if (val == null)
+				{
+					return null;
+				}
 
-            return (Convert.ToSingle(val));
-            
-        }
+				return (Convert.ToSingle(val));
 
-        /// <summary>
-        /// Set MuscleMass field
-        /// Units: kg</summary>
-        /// <param name="muscleMass_">Nullable field value to be set</param>
-        public void SetMuscleMass(float? muscleMass_)
-        {
-            SetFieldValue(5, 0, muscleMass_, Fit.SubfieldIndexMainField);
-        }
-        
-        ///<summary>
-        /// Retrieves the BasalMet field
-        /// Units: kcal/day</summary>
-        /// <returns>Returns nullable float representing the BasalMet field</returns>
-        public float? GetBasalMet()
-        {
-            Object val = GetFieldValue(7, 0, Fit.SubfieldIndexMainField);
-            if(val == null)
-            {
-                return null;
-            }
+			}
+			set
+			{
+				SetFieldValue(3, 0, value, Fit.SubfieldIndexMainField);
+			}
+		}
 
-            return (Convert.ToSingle(val));
-            
-        }
+		///<summary>
+		/// Retrieves the BoneMass field
+		/// Units: kg</summary>
+		/// <returns>Returns nullable float representing the BoneMass field</returns>
+		public float? BoneMass
+		{
+			get
+			{
+				Object val = GetFieldValue(4, 0, Fit.SubfieldIndexMainField);
+				if (val == null)
+				{
+					return null;
+				}
 
-        /// <summary>
-        /// Set BasalMet field
-        /// Units: kcal/day</summary>
-        /// <param name="basalMet_">Nullable field value to be set</param>
-        public void SetBasalMet(float? basalMet_)
-        {
-            SetFieldValue(7, 0, basalMet_, Fit.SubfieldIndexMainField);
-        }
-        
-        ///<summary>
-        /// Retrieves the PhysiqueRating field</summary>
-        /// <returns>Returns nullable byte representing the PhysiqueRating field</returns>
-        public byte? GetPhysiqueRating()
-        {
-            Object val = GetFieldValue(8, 0, Fit.SubfieldIndexMainField);
-            if(val == null)
-            {
-                return null;
-            }
+				return (Convert.ToSingle(val));
 
-            return (Convert.ToByte(val));
-            
-        }
+			}
+			set
+			{
+				SetFieldValue(4, 0, value, Fit.SubfieldIndexMainField);
+			}
+		}
 
-        /// <summary>
-        /// Set PhysiqueRating field</summary>
-        /// <param name="physiqueRating_">Nullable field value to be set</param>
-        public void SetPhysiqueRating(byte? physiqueRating_)
-        {
-            SetFieldValue(8, 0, physiqueRating_, Fit.SubfieldIndexMainField);
-        }
-        
-        ///<summary>
-        /// Retrieves the ActiveMet field
-        /// Units: kcal/day
-        /// Comment: ~4kJ per kcal, 0.25 allows max 16384 kcal</summary>
-        /// <returns>Returns nullable float representing the ActiveMet field</returns>
-        public float? GetActiveMet()
-        {
-            Object val = GetFieldValue(9, 0, Fit.SubfieldIndexMainField);
-            if(val == null)
-            {
-                return null;
-            }
+		///<summary>
+		/// Retrieves the MuscleMass field
+		/// Units: kg</summary>
+		/// <returns>Returns nullable float representing the MuscleMass field</returns>
+		public float? MuscleMass
+		{
+			get
+			{
+				Object val = GetFieldValue(5, 0, Fit.SubfieldIndexMainField);
+				if (val == null)
+				{
+					return null;
+				}
 
-            return (Convert.ToSingle(val));
-            
-        }
+				return (Convert.ToSingle(val));
 
-        /// <summary>
-        /// Set ActiveMet field
-        /// Units: kcal/day
-        /// Comment: ~4kJ per kcal, 0.25 allows max 16384 kcal</summary>
-        /// <param name="activeMet_">Nullable field value to be set</param>
-        public void SetActiveMet(float? activeMet_)
-        {
-            SetFieldValue(9, 0, activeMet_, Fit.SubfieldIndexMainField);
-        }
-        
-        ///<summary>
-        /// Retrieves the MetabolicAge field
-        /// Units: years</summary>
-        /// <returns>Returns nullable byte representing the MetabolicAge field</returns>
-        public byte? GetMetabolicAge()
-        {
-            Object val = GetFieldValue(10, 0, Fit.SubfieldIndexMainField);
-            if(val == null)
-            {
-                return null;
-            }
+			}
+			set
+			{
+				SetFieldValue(5, 0, value, Fit.SubfieldIndexMainField);
+			}
+		}
 
-            return (Convert.ToByte(val));
-            
-        }
+		///<summary>
+		/// Retrieves the BasalMet field
+		/// Units: kcal/day</summary>
+		/// <returns>Returns nullable float representing the BasalMet field</returns>
+		public float? BasalMet
+		{
+			get
+			{
+				Object val = GetFieldValue(7, 0, Fit.SubfieldIndexMainField);
+				if (val == null)
+				{
+					return null;
+				}
 
-        /// <summary>
-        /// Set MetabolicAge field
-        /// Units: years</summary>
-        /// <param name="metabolicAge_">Nullable field value to be set</param>
-        public void SetMetabolicAge(byte? metabolicAge_)
-        {
-            SetFieldValue(10, 0, metabolicAge_, Fit.SubfieldIndexMainField);
-        }
-        
-        ///<summary>
-        /// Retrieves the VisceralFatRating field</summary>
-        /// <returns>Returns nullable byte representing the VisceralFatRating field</returns>
-        public byte? GetVisceralFatRating()
-        {
-            Object val = GetFieldValue(11, 0, Fit.SubfieldIndexMainField);
-            if(val == null)
-            {
-                return null;
-            }
+				return (Convert.ToSingle(val));
 
-            return (Convert.ToByte(val));
-            
-        }
+			}
+			set
+			{
+				SetFieldValue(7, 0, value, Fit.SubfieldIndexMainField);
+			}
+		}
 
-        /// <summary>
-        /// Set VisceralFatRating field</summary>
-        /// <param name="visceralFatRating_">Nullable field value to be set</param>
-        public void SetVisceralFatRating(byte? visceralFatRating_)
-        {
-            SetFieldValue(11, 0, visceralFatRating_, Fit.SubfieldIndexMainField);
-        }
-        
-        ///<summary>
-        /// Retrieves the UserProfileIndex field
-        /// Comment: Associates this weight scale message to a user. This corresponds to the index of the user profile message in the weight scale file.</summary>
-        /// <returns>Returns nullable ushort representing the UserProfileIndex field</returns>
-        public ushort? GetUserProfileIndex()
-        {
-            Object val = GetFieldValue(12, 0, Fit.SubfieldIndexMainField);
-            if(val == null)
-            {
-                return null;
-            }
+		///<summary>
+		/// Retrieves the PhysiqueRating field</summary>
+		/// <returns>Returns nullable byte representing the PhysiqueRating field</returns>
+		public byte? PhysiqueRating
+		{
+			get
+			{
+				Object val = GetFieldValue(8, 0, Fit.SubfieldIndexMainField);
+				if (val == null)
+				{
+					return null;
+				}
 
-            return (Convert.ToUInt16(val));
-            
-        }
+				return (Convert.ToByte(val));
 
-        /// <summary>
-        /// Set UserProfileIndex field
-        /// Comment: Associates this weight scale message to a user. This corresponds to the index of the user profile message in the weight scale file.</summary>
-        /// <param name="userProfileIndex_">Nullable field value to be set</param>
-        public void SetUserProfileIndex(ushort? userProfileIndex_)
-        {
-            SetFieldValue(12, 0, userProfileIndex_, Fit.SubfieldIndexMainField);
-        }
-        
-        ///<summary>
-        /// Retrieves the Bmi field
-        /// Units: kg/m^2</summary>
-        /// <returns>Returns nullable float representing the Bmi field</returns>
-        public float? GetBmi()
-        {
-            Object val = GetFieldValue(13, 0, Fit.SubfieldIndexMainField);
-            if(val == null)
-            {
-                return null;
-            }
+			}
+			set
+			{
+				SetFieldValue(8, 0, value, Fit.SubfieldIndexMainField);
+			}
+		}
 
-            return (Convert.ToSingle(val));
-            
-        }
+		///<summary>
+		/// Retrieves the ActiveMet field
+		/// Units: kcal/day
+		/// Comment: ~4kJ per kcal, 0.25 allows max 16384 kcal</summary>
+		/// <returns>Returns nullable float representing the ActiveMet field</returns>
+		public float? ActiveMet
+		{
+			get
+			{
+				Object val = GetFieldValue(9, 0, Fit.SubfieldIndexMainField);
+				if (val == null)
+				{
+					return null;
+				}
 
-        /// <summary>
-        /// Set Bmi field
-        /// Units: kg/m^2</summary>
-        /// <param name="bmi_">Nullable field value to be set</param>
-        public void SetBmi(float? bmi_)
-        {
-            SetFieldValue(13, 0, bmi_, Fit.SubfieldIndexMainField);
-        }
-        
-        #endregion // Methods
-    } // Class
+				return (Convert.ToSingle(val));
+
+			}
+			set
+			{
+				SetFieldValue(9, 0, value, Fit.SubfieldIndexMainField);
+			}
+		}
+
+		///<summary>
+		/// Retrieves the MetabolicAge field
+		/// Units: years</summary>
+		/// <returns>Returns nullable byte representing the MetabolicAge field</returns>
+		public byte? MetabolicAge
+		{
+			get
+			{
+				Object val = GetFieldValue(10, 0, Fit.SubfieldIndexMainField);
+				if (val == null)
+				{
+					return null;
+				}
+
+				return (Convert.ToByte(val));
+
+			}
+			set
+			{
+				SetFieldValue(10, 0, value, Fit.SubfieldIndexMainField);
+			}
+		}
+
+		///<summary>
+		/// Retrieves the VisceralFatRating field</summary>
+		/// <returns>Returns nullable byte representing the VisceralFatRating field</returns>
+		public byte? VisceralFatRating
+		{
+			get
+			{
+				Object val = GetFieldValue(11, 0, Fit.SubfieldIndexMainField);
+				if (val == null)
+				{
+					return null;
+				}
+
+				return (Convert.ToByte(val));
+
+			}
+			set
+			{
+				SetFieldValue(11, 0, value, Fit.SubfieldIndexMainField);
+			}
+		}
+
+		///<summary>
+		/// Retrieves the UserProfileIndex field
+		/// Comment: Associates this weight scale message to a user. This corresponds to the index of the user profile message in the weight scale file.</summary>
+		/// <returns>Returns nullable ushort representing the UserProfileIndex field</returns>
+		public ushort? UserProfileIndex
+		{
+			get
+			{
+				Object val = GetFieldValue(12, 0, Fit.SubfieldIndexMainField);
+				if (val == null)
+				{
+					return null;
+				}
+
+				return (Convert.ToUInt16(val));
+
+			}
+			set
+			{
+				SetFieldValue(12, 0, value, Fit.SubfieldIndexMainField);
+			}
+		}
+
+		///<summary>
+		/// Retrieves the Bmi field
+		/// Units: kg/m^2</summary>
+		/// <returns>Returns nullable float representing the Bmi field</returns>
+		public float? Bmi
+		{
+			get
+			{
+				Object val = GetFieldValue(13, 0, Fit.SubfieldIndexMainField);
+				if (val == null)
+				{
+					return null;
+				}
+
+				return (Convert.ToSingle(val));
+
+			}
+			set
+			{
+				SetFieldValue(13, 0, value, Fit.SubfieldIndexMainField);
+			}
+		}
+
+		#endregion // Methods
+	} // Class
 } // namespace

--- a/Dynastream/Fit/Profile/Mesgs/WorkoutMesg.cs
+++ b/Dynastream/Fit/Profile/Mesgs/WorkoutMesg.cs
@@ -21,272 +21,258 @@ using System.Linq;
 
 namespace Dynastream.Fit
 {
-    /// <summary>
-    /// Implements the Workout profile message.
-    /// </summary>
-    public class WorkoutMesg : Mesg
-    {
-        #region Fields
-        #endregion
+	/// <summary>
+	/// Implements the Workout profile message.
+	/// </summary>
+	public class WorkoutMesg : Mesg
+	{
+		#region Fields
+		#endregion
 
-        /// <summary>
-        /// Field Numbers for <see cref="WorkoutMesg"/>
-        /// </summary>
-        public sealed class FieldDefNum
-        {
-            public const byte MessageIndex = 254;
-            public const byte Sport = 4;
-            public const byte Capabilities = 5;
-            public const byte NumValidSteps = 6;
-            public const byte WktName = 8;
-            public const byte SubSport = 11;
-            public const byte PoolLength = 14;
-            public const byte PoolLengthUnit = 15;
-            public const byte WktDescription = 17;
-            public const byte Invalid = Fit.FieldNumInvalid;
-        }
+		/// <summary>
+		/// Field Numbers for <see cref="WorkoutMesg"/>
+		/// </summary>
+		public sealed class FieldDefNum
+		{
+			public const byte MessageIndex = 254;
+			public const byte Sport = 4;
+			public const byte Capabilities = 5;
+			public const byte NumValidSteps = 6;
+			public const byte WktName = 8;
+			public const byte SubSport = 11;
+			public const byte PoolLength = 14;
+			public const byte PoolLengthUnit = 15;
+			public const byte WktDescription = 17;
+			public const byte Invalid = Fit.FieldNumInvalid;
+		}
 
-        #region Constructors
-        public WorkoutMesg() : base(Profile.GetMesg(MesgNum.Workout))
-        {
-        }
+		#region Constructors
+		public WorkoutMesg() : base(Profile.GetMesg(MesgNum.Workout))
+		{
+		}
 
-        public WorkoutMesg(Mesg mesg) : base(mesg)
-        {
-        }
-        #endregion // Constructors
+		public WorkoutMesg(Mesg mesg) : base(mesg)
+		{
+		}
+		#endregion // Constructors
 
-        #region Methods
-        ///<summary>
-        /// Retrieves the MessageIndex field</summary>
-        /// <returns>Returns nullable ushort representing the MessageIndex field</returns>
-        public ushort? GetMessageIndex()
-        {
-            Object val = GetFieldValue(254, 0, Fit.SubfieldIndexMainField);
-            if(val == null)
-            {
-                return null;
-            }
+		#region Methods
+		///<summary>
+		/// Retrieves the MessageIndex field</summary>
+		/// <returns>Returns nullable ushort representing the MessageIndex field</returns>
+		public ushort? MessageIndex
+		{
+			get
+			{
+				Object val = GetFieldValue(254, 0, Fit.SubfieldIndexMainField);
+				if (val == null)
+				{
+					return null;
+				}
 
-            return (Convert.ToUInt16(val));
-            
-        }
+				return (Convert.ToUInt16(val));
 
-        /// <summary>
-        /// Set MessageIndex field</summary>
-        /// <param name="messageIndex_">Nullable field value to be set</param>
-        public void SetMessageIndex(ushort? messageIndex_)
-        {
-            SetFieldValue(254, 0, messageIndex_, Fit.SubfieldIndexMainField);
-        }
-        
-        ///<summary>
-        /// Retrieves the Sport field</summary>
-        /// <returns>Returns nullable Sport enum representing the Sport field</returns>
-        public Sport? GetSport()
-        {
-            object obj = GetFieldValue(4, 0, Fit.SubfieldIndexMainField);
-            Sport? value = obj == null ? (Sport?)null : (Sport)obj;
-            return value;
-        }
+			}
+			set
+			{
+				SetFieldValue(254, 0, value, Fit.SubfieldIndexMainField);
+			}
+		}
 
-        /// <summary>
-        /// Set Sport field</summary>
-        /// <param name="sport_">Nullable field value to be set</param>
-        public void SetSport(Sport? sport_)
-        {
-            SetFieldValue(4, 0, sport_, Fit.SubfieldIndexMainField);
-        }
-        
-        ///<summary>
-        /// Retrieves the Capabilities field</summary>
-        /// <returns>Returns nullable uint representing the Capabilities field</returns>
-        public uint? GetCapabilities()
-        {
-            Object val = GetFieldValue(5, 0, Fit.SubfieldIndexMainField);
-            if(val == null)
-            {
-                return null;
-            }
+		///<summary>
+		/// Retrieves the Sport field</summary>
+		/// <returns>Returns nullable Sport enum representing the Sport field</returns>
+		public Sport? Sport
+		{
+			get
+			{
+				object obj = GetFieldValue(4, 0, Fit.SubfieldIndexMainField);
+				Sport? value = obj == null ? (Sport?)null : (Sport)obj;
+				return value;
+			}
+			set
+			{
+				SetFieldValue(4, 0, value, Fit.SubfieldIndexMainField);
+			}
+		}
 
-            return (Convert.ToUInt32(val));
-            
-        }
+		///<summary>
+		/// Retrieves the Capabilities field</summary>
+		/// <returns>Returns nullable uint representing the Capabilities field</returns>
+		public uint? Capabilities
+		{
+			get
+			{
+				Object val = GetFieldValue(5, 0, Fit.SubfieldIndexMainField);
+				if (val == null)
+				{
+					return null;
+				}
 
-        /// <summary>
-        /// Set Capabilities field</summary>
-        /// <param name="capabilities_">Nullable field value to be set</param>
-        public void SetCapabilities(uint? capabilities_)
-        {
-            SetFieldValue(5, 0, capabilities_, Fit.SubfieldIndexMainField);
-        }
-        
-        ///<summary>
-        /// Retrieves the NumValidSteps field
-        /// Comment: number of valid steps</summary>
-        /// <returns>Returns nullable ushort representing the NumValidSteps field</returns>
-        public ushort? GetNumValidSteps()
-        {
-            Object val = GetFieldValue(6, 0, Fit.SubfieldIndexMainField);
-            if(val == null)
-            {
-                return null;
-            }
+				return (Convert.ToUInt32(val));
 
-            return (Convert.ToUInt16(val));
-            
-        }
+			}
+			set
+			{
+				SetFieldValue(5, 0, value, Fit.SubfieldIndexMainField);
+			}
+		}
 
-        /// <summary>
-        /// Set NumValidSteps field
-        /// Comment: number of valid steps</summary>
-        /// <param name="numValidSteps_">Nullable field value to be set</param>
-        public void SetNumValidSteps(ushort? numValidSteps_)
-        {
-            SetFieldValue(6, 0, numValidSteps_, Fit.SubfieldIndexMainField);
-        }
-        
-        ///<summary>
-        /// Retrieves the WktName field</summary>
-        /// <returns>Returns byte[] representing the WktName field</returns>
-        public byte[] GetWktName()
-        {
-            byte[] data = (byte[])GetFieldValue(8, 0, Fit.SubfieldIndexMainField);
-            return data.Take(data.Length - 1).ToArray();
-        }
+		///<summary>
+		/// Retrieves the NumValidSteps field
+		/// Comment: number of valid steps</summary>
+		/// <returns>Returns nullable ushort representing the NumValidSteps field</returns>
+		public ushort? NumValidSteps
+		{
+			get
+			{
+				Object val = GetFieldValue(6, 0, Fit.SubfieldIndexMainField);
+				if (val == null)
+				{
+					return null;
+				}
 
-        ///<summary>
-        /// Retrieves the WktName field</summary>
-        /// <returns>Returns String representing the WktName field</returns>
-        public String GetWktNameAsString()
-        {
-            byte[] data = (byte[])GetFieldValue(8, 0, Fit.SubfieldIndexMainField);
-            return data != null ? Encoding.UTF8.GetString(data, 0, data.Length - 1) : null;
-        }
+				return (Convert.ToUInt16(val));
 
-        ///<summary>
-        /// Set WktName field</summary>
-        /// <param name="wktName_"> field value to be set</param>
-        public void SetWktName(String wktName_)
-        {
-            byte[] data = Encoding.UTF8.GetBytes(wktName_);
-            byte[] zdata = new byte[data.Length + 1];
-            data.CopyTo(zdata, 0);
-            SetFieldValue(8, 0, zdata, Fit.SubfieldIndexMainField);
-        }
+			}
+			set
+			{
+				SetFieldValue(6, 0, value, Fit.SubfieldIndexMainField);
+			}
+		}
 
-        
-        /// <summary>
-        /// Set WktName field</summary>
-        /// <param name="wktName_">field value to be set</param>
-        public void SetWktName(byte[] wktName_)
-        {
-            SetFieldValue(8, 0, wktName_, Fit.SubfieldIndexMainField);
-        }
-        
-        ///<summary>
-        /// Retrieves the SubSport field</summary>
-        /// <returns>Returns nullable SubSport enum representing the SubSport field</returns>
-        public SubSport? GetSubSport()
-        {
-            object obj = GetFieldValue(11, 0, Fit.SubfieldIndexMainField);
-            SubSport? value = obj == null ? (SubSport?)null : (SubSport)obj;
-            return value;
-        }
+		///<summary>
+		/// Retrieves the WktName field</summary>
+		/// <returns>Returns byte[] representing the WktName field</returns>
+		public byte[] WktName
+		{
+			get
+			{
+				byte[] data = (byte[])GetFieldValue(8, 0, Fit.SubfieldIndexMainField);
+				return data.Take(data.Length - 1).ToArray();
+			}
+			set
+			{
+				SetFieldValue(8, 0, value, Fit.SubfieldIndexMainField);
+			}
+		}
 
-        /// <summary>
-        /// Set SubSport field</summary>
-        /// <param name="subSport_">Nullable field value to be set</param>
-        public void SetSubSport(SubSport? subSport_)
-        {
-            SetFieldValue(11, 0, subSport_, Fit.SubfieldIndexMainField);
-        }
-        
-        ///<summary>
-        /// Retrieves the PoolLength field
-        /// Units: m</summary>
-        /// <returns>Returns nullable float representing the PoolLength field</returns>
-        public float? GetPoolLength()
-        {
-            Object val = GetFieldValue(14, 0, Fit.SubfieldIndexMainField);
-            if(val == null)
-            {
-                return null;
-            }
+		///<summary>
+		/// Retrieves the WktName field</summary>
+		/// <returns>Returns String representing the WktName field</returns>
+		public String GetWktNameAsString()
+		{
+			byte[] data = (byte[])GetFieldValue(8, 0, Fit.SubfieldIndexMainField);
+			return data != null ? Encoding.UTF8.GetString(data, 0, data.Length - 1) : null;
+		}
 
-            return (Convert.ToSingle(val));
-            
-        }
+		///<summary>
+		/// Set WktName field</summary>
+		/// <param name="wktName_"> field value to be set</param>
+		public void SetWktName(String wktName_)
+		{
+			byte[] data = Encoding.UTF8.GetBytes(wktName_);
+			byte[] zdata = new byte[data.Length + 1];
+			data.CopyTo(zdata, 0);
+			SetFieldValue(8, 0, zdata, Fit.SubfieldIndexMainField);
+		}
 
-        /// <summary>
-        /// Set PoolLength field
-        /// Units: m</summary>
-        /// <param name="poolLength_">Nullable field value to be set</param>
-        public void SetPoolLength(float? poolLength_)
-        {
-            SetFieldValue(14, 0, poolLength_, Fit.SubfieldIndexMainField);
-        }
-        
-        ///<summary>
-        /// Retrieves the PoolLengthUnit field</summary>
-        /// <returns>Returns nullable DisplayMeasure enum representing the PoolLengthUnit field</returns>
-        public DisplayMeasure? GetPoolLengthUnit()
-        {
-            object obj = GetFieldValue(15, 0, Fit.SubfieldIndexMainField);
-            DisplayMeasure? value = obj == null ? (DisplayMeasure?)null : (DisplayMeasure)obj;
-            return value;
-        }
+		///<summary>
+		/// Retrieves the SubSport field</summary>
+		/// <returns>Returns nullable SubSport enum representing the SubSport field</returns>
+		public SubSport? SubSport
+		{
+			get
+			{
+				object obj = GetFieldValue(11, 0, Fit.SubfieldIndexMainField);
+				SubSport? value = obj == null ? (SubSport?)null : (SubSport)obj;
+				return value;
+			}
+			set
+			{
+				SetFieldValue(11, 0, value, Fit.SubfieldIndexMainField);
+			}
+		}
 
-        /// <summary>
-        /// Set PoolLengthUnit field</summary>
-        /// <param name="poolLengthUnit_">Nullable field value to be set</param>
-        public void SetPoolLengthUnit(DisplayMeasure? poolLengthUnit_)
-        {
-            SetFieldValue(15, 0, poolLengthUnit_, Fit.SubfieldIndexMainField);
-        }
-        
-        ///<summary>
-        /// Retrieves the WktDescription field
-        /// Comment: Description of the workout</summary>
-        /// <returns>Returns byte[] representing the WktDescription field</returns>
-        public byte[] GetWktDescription()
-        {
-            byte[] data = (byte[])GetFieldValue(17, 0, Fit.SubfieldIndexMainField);
-            return data.Take(data.Length - 1).ToArray();
-        }
+		///<summary>
+		/// Retrieves the PoolLength field
+		/// Units: m</summary>
+		/// <returns>Returns nullable float representing the PoolLength field</returns>
+		public float? PoolLength
+		{
+			get
+			{
+				Object val = GetFieldValue(14, 0, Fit.SubfieldIndexMainField);
+				if (val == null)
+				{
+					return null;
+				}
 
-        ///<summary>
-        /// Retrieves the WktDescription field
-        /// Comment: Description of the workout</summary>
-        /// <returns>Returns String representing the WktDescription field</returns>
-        public String GetWktDescriptionAsString()
-        {
-            byte[] data = (byte[])GetFieldValue(17, 0, Fit.SubfieldIndexMainField);
-            return data != null ? Encoding.UTF8.GetString(data, 0, data.Length - 1) : null;
-        }
+				return (Convert.ToSingle(val));
 
-        ///<summary>
-        /// Set WktDescription field
-        /// Comment: Description of the workout</summary>
-        /// <param name="wktDescription_"> field value to be set</param>
-        public void SetWktDescription(String wktDescription_)
-        {
-            byte[] data = Encoding.UTF8.GetBytes(wktDescription_);
-            byte[] zdata = new byte[data.Length + 1];
-            data.CopyTo(zdata, 0);
-            SetFieldValue(17, 0, zdata, Fit.SubfieldIndexMainField);
-        }
+			}
+			set
+			{
+				SetFieldValue(14, 0, value, Fit.SubfieldIndexMainField);
+			}
+		}
 
-        
-        /// <summary>
-        /// Set WktDescription field
-        /// Comment: Description of the workout</summary>
-        /// <param name="wktDescription_">field value to be set</param>
-        public void SetWktDescription(byte[] wktDescription_)
-        {
-            SetFieldValue(17, 0, wktDescription_, Fit.SubfieldIndexMainField);
-        }
-        
-        #endregion // Methods
-    } // Class
+		///<summary>
+		/// Retrieves the PoolLengthUnit field</summary>
+		/// <returns>Returns nullable DisplayMeasure enum representing the PoolLengthUnit field</returns>
+		public DisplayMeasure? PoolLengthUnit
+		{
+			get
+			{
+				object obj = GetFieldValue(15, 0, Fit.SubfieldIndexMainField);
+				DisplayMeasure? value = obj == null ? (DisplayMeasure?)null : (DisplayMeasure)obj;
+				return value;
+			}
+			set
+			{
+				SetFieldValue(15, 0, value, Fit.SubfieldIndexMainField);
+			}
+		}
+
+		///<summary>
+		/// Retrieves the WktDescription field
+		/// Comment: Description of the workout</summary>
+		/// <returns>Returns byte[] representing the WktDescription field</returns>
+		public byte[] WktDescription
+		{
+			get
+			{
+				byte[] data = (byte[])GetFieldValue(17, 0, Fit.SubfieldIndexMainField);
+				return data.Take(data.Length - 1).ToArray();
+			}
+			set
+			{
+				SetFieldValue(17, 0, value, Fit.SubfieldIndexMainField);
+			}
+		}
+
+		///<summary>
+		/// Retrieves the WktDescription field
+		/// Comment: Description of the workout</summary>
+		/// <returns>Returns String representing the WktDescription field</returns>
+		public String GetWktDescriptionAsString()
+		{
+			byte[] data = (byte[])GetFieldValue(17, 0, Fit.SubfieldIndexMainField);
+			return data != null ? Encoding.UTF8.GetString(data, 0, data.Length - 1) : null;
+		}
+
+		///<summary>
+		/// Set WktDescription field
+		/// Comment: Description of the workout</summary>
+		/// <param name="wktDescription_"> field value to be set</param>
+		public void SetWktDescription(String wktDescription_)
+		{
+			byte[] data = Encoding.UTF8.GetBytes(wktDescription_);
+			byte[] zdata = new byte[data.Length + 1];
+			data.CopyTo(zdata, 0);
+			SetFieldValue(17, 0, zdata, Fit.SubfieldIndexMainField);
+		}
+
+		#endregion // Methods
+	} // Class
 } // namespace

--- a/Dynastream/Fit/Profile/Mesgs/WorkoutSessionMesg.cs
+++ b/Dynastream/Fit/Profile/Mesgs/WorkoutSessionMesg.cs
@@ -21,188 +21,180 @@ using System.Linq;
 
 namespace Dynastream.Fit
 {
-    /// <summary>
-    /// Implements the WorkoutSession profile message.
-    /// </summary>
-    public class WorkoutSessionMesg : Mesg
-    {
-        #region Fields
-        #endregion
+	/// <summary>
+	/// Implements the WorkoutSession profile message.
+	/// </summary>
+	public class WorkoutSessionMesg : Mesg
+	{
+		#region Fields
+		#endregion
 
-        /// <summary>
-        /// Field Numbers for <see cref="WorkoutSessionMesg"/>
-        /// </summary>
-        public sealed class FieldDefNum
-        {
-            public const byte MessageIndex = 254;
-            public const byte Sport = 0;
-            public const byte SubSport = 1;
-            public const byte NumValidSteps = 2;
-            public const byte FirstStepIndex = 3;
-            public const byte PoolLength = 4;
-            public const byte PoolLengthUnit = 5;
-            public const byte Invalid = Fit.FieldNumInvalid;
-        }
+		/// <summary>
+		/// Field Numbers for <see cref="WorkoutSessionMesg"/>
+		/// </summary>
+		public sealed class FieldDefNum
+		{
+			public const byte MessageIndex = 254;
+			public const byte Sport = 0;
+			public const byte SubSport = 1;
+			public const byte NumValidSteps = 2;
+			public const byte FirstStepIndex = 3;
+			public const byte PoolLength = 4;
+			public const byte PoolLengthUnit = 5;
+			public const byte Invalid = Fit.FieldNumInvalid;
+		}
 
-        #region Constructors
-        public WorkoutSessionMesg() : base(Profile.GetMesg(MesgNum.WorkoutSession))
-        {
-        }
+		#region Constructors
+		public WorkoutSessionMesg() : base(Profile.GetMesg(MesgNum.WorkoutSession))
+		{
+		}
 
-        public WorkoutSessionMesg(Mesg mesg) : base(mesg)
-        {
-        }
-        #endregion // Constructors
+		public WorkoutSessionMesg(Mesg mesg) : base(mesg)
+		{
+		}
+		#endregion // Constructors
 
-        #region Methods
-        ///<summary>
-        /// Retrieves the MessageIndex field</summary>
-        /// <returns>Returns nullable ushort representing the MessageIndex field</returns>
-        public ushort? GetMessageIndex()
-        {
-            Object val = GetFieldValue(254, 0, Fit.SubfieldIndexMainField);
-            if(val == null)
-            {
-                return null;
-            }
+		#region Methods
+		///<summary>
+		/// Retrieves the MessageIndex field</summary>
+		/// <returns>Returns nullable ushort representing the MessageIndex field</returns>
+		public ushort? MessageIndex
+		{
+			get
+			{
+				Object val = GetFieldValue(254, 0, Fit.SubfieldIndexMainField);
+				if (val == null)
+				{
+					return null;
+				}
 
-            return (Convert.ToUInt16(val));
-            
-        }
+				return (Convert.ToUInt16(val));
 
-        /// <summary>
-        /// Set MessageIndex field</summary>
-        /// <param name="messageIndex_">Nullable field value to be set</param>
-        public void SetMessageIndex(ushort? messageIndex_)
-        {
-            SetFieldValue(254, 0, messageIndex_, Fit.SubfieldIndexMainField);
-        }
-        
-        ///<summary>
-        /// Retrieves the Sport field</summary>
-        /// <returns>Returns nullable Sport enum representing the Sport field</returns>
-        public Sport? GetSport()
-        {
-            object obj = GetFieldValue(0, 0, Fit.SubfieldIndexMainField);
-            Sport? value = obj == null ? (Sport?)null : (Sport)obj;
-            return value;
-        }
+			}
+			set
+			{
+				SetFieldValue(254, 0, value, Fit.SubfieldIndexMainField);
+			}
+		}
 
-        /// <summary>
-        /// Set Sport field</summary>
-        /// <param name="sport_">Nullable field value to be set</param>
-        public void SetSport(Sport? sport_)
-        {
-            SetFieldValue(0, 0, sport_, Fit.SubfieldIndexMainField);
-        }
-        
-        ///<summary>
-        /// Retrieves the SubSport field</summary>
-        /// <returns>Returns nullable SubSport enum representing the SubSport field</returns>
-        public SubSport? GetSubSport()
-        {
-            object obj = GetFieldValue(1, 0, Fit.SubfieldIndexMainField);
-            SubSport? value = obj == null ? (SubSport?)null : (SubSport)obj;
-            return value;
-        }
+		///<summary>
+		/// Retrieves the Sport field</summary>
+		/// <returns>Returns nullable Sport enum representing the Sport field</returns>
+		public Sport? Sport
+		{
+			get
+			{
+				object obj = GetFieldValue(0, 0, Fit.SubfieldIndexMainField);
+				Sport? value = obj == null ? (Sport?)null : (Sport)obj;
+				return value;
+			}
+			set
+			{
+				SetFieldValue(0, 0, value, Fit.SubfieldIndexMainField);
+			}
+		}
 
-        /// <summary>
-        /// Set SubSport field</summary>
-        /// <param name="subSport_">Nullable field value to be set</param>
-        public void SetSubSport(SubSport? subSport_)
-        {
-            SetFieldValue(1, 0, subSport_, Fit.SubfieldIndexMainField);
-        }
-        
-        ///<summary>
-        /// Retrieves the NumValidSteps field</summary>
-        /// <returns>Returns nullable ushort representing the NumValidSteps field</returns>
-        public ushort? GetNumValidSteps()
-        {
-            Object val = GetFieldValue(2, 0, Fit.SubfieldIndexMainField);
-            if(val == null)
-            {
-                return null;
-            }
+		///<summary>
+		/// Retrieves the SubSport field</summary>
+		/// <returns>Returns nullable SubSport enum representing the SubSport field</returns>
+		public SubSport? SubSport
+		{
+			get
+			{
+				object obj = GetFieldValue(1, 0, Fit.SubfieldIndexMainField);
+				SubSport? value = obj == null ? (SubSport?)null : (SubSport)obj;
+				return value;
+			}
+			set
+			{
+				SetFieldValue(1, 0, value, Fit.SubfieldIndexMainField);
+			}
+		}
 
-            return (Convert.ToUInt16(val));
-            
-        }
+		///<summary>
+		/// Retrieves the NumValidSteps field</summary>
+		/// <returns>Returns nullable ushort representing the NumValidSteps field</returns>
+		public ushort? NumValidSteps
+		{
+			get
+			{
+				Object val = GetFieldValue(2, 0, Fit.SubfieldIndexMainField);
+				if (val == null)
+				{
+					return null;
+				}
 
-        /// <summary>
-        /// Set NumValidSteps field</summary>
-        /// <param name="numValidSteps_">Nullable field value to be set</param>
-        public void SetNumValidSteps(ushort? numValidSteps_)
-        {
-            SetFieldValue(2, 0, numValidSteps_, Fit.SubfieldIndexMainField);
-        }
-        
-        ///<summary>
-        /// Retrieves the FirstStepIndex field</summary>
-        /// <returns>Returns nullable ushort representing the FirstStepIndex field</returns>
-        public ushort? GetFirstStepIndex()
-        {
-            Object val = GetFieldValue(3, 0, Fit.SubfieldIndexMainField);
-            if(val == null)
-            {
-                return null;
-            }
+				return (Convert.ToUInt16(val));
 
-            return (Convert.ToUInt16(val));
-            
-        }
+			}
+			set
+			{
+				SetFieldValue(2, 0, value, Fit.SubfieldIndexMainField);
+			}
+		}
 
-        /// <summary>
-        /// Set FirstStepIndex field</summary>
-        /// <param name="firstStepIndex_">Nullable field value to be set</param>
-        public void SetFirstStepIndex(ushort? firstStepIndex_)
-        {
-            SetFieldValue(3, 0, firstStepIndex_, Fit.SubfieldIndexMainField);
-        }
-        
-        ///<summary>
-        /// Retrieves the PoolLength field
-        /// Units: m</summary>
-        /// <returns>Returns nullable float representing the PoolLength field</returns>
-        public float? GetPoolLength()
-        {
-            Object val = GetFieldValue(4, 0, Fit.SubfieldIndexMainField);
-            if(val == null)
-            {
-                return null;
-            }
+		///<summary>
+		/// Retrieves the FirstStepIndex field</summary>
+		/// <returns>Returns nullable ushort representing the FirstStepIndex field</returns>
+		public ushort? FirstStepIndex
+		{
+			get
+			{
+				Object val = GetFieldValue(3, 0, Fit.SubfieldIndexMainField);
+				if (val == null)
+				{
+					return null;
+				}
 
-            return (Convert.ToSingle(val));
-            
-        }
+				return (Convert.ToUInt16(val));
 
-        /// <summary>
-        /// Set PoolLength field
-        /// Units: m</summary>
-        /// <param name="poolLength_">Nullable field value to be set</param>
-        public void SetPoolLength(float? poolLength_)
-        {
-            SetFieldValue(4, 0, poolLength_, Fit.SubfieldIndexMainField);
-        }
-        
-        ///<summary>
-        /// Retrieves the PoolLengthUnit field</summary>
-        /// <returns>Returns nullable DisplayMeasure enum representing the PoolLengthUnit field</returns>
-        public DisplayMeasure? GetPoolLengthUnit()
-        {
-            object obj = GetFieldValue(5, 0, Fit.SubfieldIndexMainField);
-            DisplayMeasure? value = obj == null ? (DisplayMeasure?)null : (DisplayMeasure)obj;
-            return value;
-        }
+			}
+			set
+			{
+				SetFieldValue(3, 0, value, Fit.SubfieldIndexMainField);
+			}
+		}
 
-        /// <summary>
-        /// Set PoolLengthUnit field</summary>
-        /// <param name="poolLengthUnit_">Nullable field value to be set</param>
-        public void SetPoolLengthUnit(DisplayMeasure? poolLengthUnit_)
-        {
-            SetFieldValue(5, 0, poolLengthUnit_, Fit.SubfieldIndexMainField);
-        }
-        
-        #endregion // Methods
-    } // Class
+		///<summary>
+		/// Retrieves the PoolLength field
+		/// Units: m</summary>
+		/// <returns>Returns nullable float representing the PoolLength field</returns>
+		public float? PoolLength
+		{
+			get
+			{
+				Object val = GetFieldValue(4, 0, Fit.SubfieldIndexMainField);
+				if (val == null)
+				{
+					return null;
+				}
+
+				return (Convert.ToSingle(val));
+
+			}
+			set
+			{
+				SetFieldValue(4, 0, value, Fit.SubfieldIndexMainField);
+			}
+		}
+
+		///<summary>
+		/// Retrieves the PoolLengthUnit field</summary>
+		/// <returns>Returns nullable DisplayMeasure enum representing the PoolLengthUnit field</returns>
+		public DisplayMeasure? PoolLengthUnit
+		{
+			get
+			{
+				object obj = GetFieldValue(5, 0, Fit.SubfieldIndexMainField);
+				DisplayMeasure? value = obj == null ? (DisplayMeasure?)null : (DisplayMeasure)obj;
+				return value;
+			}
+			set
+			{
+				SetFieldValue(5, 0, value, Fit.SubfieldIndexMainField);
+			}
+		}
+
+		#endregion // Methods
+	} // Class
 } // namespace

--- a/Dynastream/Fit/Profile/Mesgs/WorkoutStepMesg.cs
+++ b/Dynastream/Fit/Profile/Mesgs/WorkoutStepMesg.cs
@@ -21,1571 +21,1439 @@ using System.Linq;
 
 namespace Dynastream.Fit
 {
-    /// <summary>
-    /// Implements the WorkoutStep profile message.
-    /// </summary>
-    public class WorkoutStepMesg : Mesg
-    {
-        #region Fields
-        static class DurationValueSubfield
-        {
-            public static ushort DurationTime = 0;
-            public static ushort DurationDistance = 1;
-            public static ushort DurationHr = 2;
-            public static ushort DurationCalories = 3;
-            public static ushort DurationStep = 4;
-            public static ushort DurationPower = 5;
-            public static ushort DurationReps = 6;
-            public static ushort Subfields = 7;
-            public static ushort Active = Fit.SubfieldIndexActiveSubfield;
-            public static ushort MainField = Fit.SubfieldIndexMainField;
-        }
-        static class TargetValueSubfield
-        {
-            public static ushort TargetSpeedZone = 0;
-            public static ushort TargetHrZone = 1;
-            public static ushort TargetCadenceZone = 2;
-            public static ushort TargetPowerZone = 3;
-            public static ushort RepeatSteps = 4;
-            public static ushort RepeatTime = 5;
-            public static ushort RepeatDistance = 6;
-            public static ushort RepeatCalories = 7;
-            public static ushort RepeatHr = 8;
-            public static ushort RepeatPower = 9;
-            public static ushort TargetStrokeType = 10;
-            public static ushort Subfields = 11;
-            public static ushort Active = Fit.SubfieldIndexActiveSubfield;
-            public static ushort MainField = Fit.SubfieldIndexMainField;
-        }
-        static class CustomTargetValueLowSubfield
-        {
-            public static ushort CustomTargetSpeedLow = 0;
-            public static ushort CustomTargetHeartRateLow = 1;
-            public static ushort CustomTargetCadenceLow = 2;
-            public static ushort CustomTargetPowerLow = 3;
-            public static ushort Subfields = 4;
-            public static ushort Active = Fit.SubfieldIndexActiveSubfield;
-            public static ushort MainField = Fit.SubfieldIndexMainField;
-        }
-        static class CustomTargetValueHighSubfield
-        {
-            public static ushort CustomTargetSpeedHigh = 0;
-            public static ushort CustomTargetHeartRateHigh = 1;
-            public static ushort CustomTargetCadenceHigh = 2;
-            public static ushort CustomTargetPowerHigh = 3;
-            public static ushort Subfields = 4;
-            public static ushort Active = Fit.SubfieldIndexActiveSubfield;
-            public static ushort MainField = Fit.SubfieldIndexMainField;
-        }
-        static class SecondaryTargetValueSubfield
-        {
-            public static ushort SecondaryTargetSpeedZone = 0;
-            public static ushort SecondaryTargetHrZone = 1;
-            public static ushort SecondaryTargetCadenceZone = 2;
-            public static ushort SecondaryTargetPowerZone = 3;
-            public static ushort SecondaryTargetStrokeType = 4;
-            public static ushort Subfields = 5;
-            public static ushort Active = Fit.SubfieldIndexActiveSubfield;
-            public static ushort MainField = Fit.SubfieldIndexMainField;
-        }
-        static class SecondaryCustomTargetValueLowSubfield
-        {
-            public static ushort SecondaryCustomTargetSpeedLow = 0;
-            public static ushort SecondaryCustomTargetHeartRateLow = 1;
-            public static ushort SecondaryCustomTargetCadenceLow = 2;
-            public static ushort SecondaryCustomTargetPowerLow = 3;
-            public static ushort Subfields = 4;
-            public static ushort Active = Fit.SubfieldIndexActiveSubfield;
-            public static ushort MainField = Fit.SubfieldIndexMainField;
-        }
-        static class SecondaryCustomTargetValueHighSubfield
-        {
-            public static ushort SecondaryCustomTargetSpeedHigh = 0;
-            public static ushort SecondaryCustomTargetHeartRateHigh = 1;
-            public static ushort SecondaryCustomTargetCadenceHigh = 2;
-            public static ushort SecondaryCustomTargetPowerHigh = 3;
-            public static ushort Subfields = 4;
-            public static ushort Active = Fit.SubfieldIndexActiveSubfield;
-            public static ushort MainField = Fit.SubfieldIndexMainField;
-        }
-        #endregion
-
-        /// <summary>
-        /// Field Numbers for <see cref="WorkoutStepMesg"/>
-        /// </summary>
-        public sealed class FieldDefNum
-        {
-            public const byte MessageIndex = 254;
-            public const byte WktStepName = 0;
-            public const byte DurationType = 1;
-            public const byte DurationValue = 2;
-            public const byte TargetType = 3;
-            public const byte TargetValue = 4;
-            public const byte CustomTargetValueLow = 5;
-            public const byte CustomTargetValueHigh = 6;
-            public const byte Intensity = 7;
-            public const byte Notes = 8;
-            public const byte Equipment = 9;
-            public const byte ExerciseCategory = 10;
-            public const byte ExerciseName = 11;
-            public const byte ExerciseWeight = 12;
-            public const byte WeightDisplayUnit = 13;
-            public const byte SecondaryTargetType = 19;
-            public const byte SecondaryTargetValue = 20;
-            public const byte SecondaryCustomTargetValueLow = 21;
-            public const byte SecondaryCustomTargetValueHigh = 22;
-            public const byte Invalid = Fit.FieldNumInvalid;
-        }
-
-        #region Constructors
-        public WorkoutStepMesg() : base(Profile.GetMesg(MesgNum.WorkoutStep))
-        {
-        }
-
-        public WorkoutStepMesg(Mesg mesg) : base(mesg)
-        {
-        }
-        #endregion // Constructors
-
-        #region Methods
-        ///<summary>
-        /// Retrieves the MessageIndex field</summary>
-        /// <returns>Returns nullable ushort representing the MessageIndex field</returns>
-        public ushort? GetMessageIndex()
-        {
-            Object val = GetFieldValue(254, 0, Fit.SubfieldIndexMainField);
-            if(val == null)
-            {
-                return null;
-            }
-
-            return (Convert.ToUInt16(val));
-            
-        }
-
-        /// <summary>
-        /// Set MessageIndex field</summary>
-        /// <param name="messageIndex_">Nullable field value to be set</param>
-        public void SetMessageIndex(ushort? messageIndex_)
-        {
-            SetFieldValue(254, 0, messageIndex_, Fit.SubfieldIndexMainField);
-        }
-        
-        ///<summary>
-        /// Retrieves the WktStepName field</summary>
-        /// <returns>Returns byte[] representing the WktStepName field</returns>
-        public byte[] GetWktStepName()
-        {
-            byte[] data = (byte[])GetFieldValue(0, 0, Fit.SubfieldIndexMainField);
-            return data.Take(data.Length - 1).ToArray();
-        }
-
-        ///<summary>
-        /// Retrieves the WktStepName field</summary>
-        /// <returns>Returns String representing the WktStepName field</returns>
-        public String GetWktStepNameAsString()
-        {
-            byte[] data = (byte[])GetFieldValue(0, 0, Fit.SubfieldIndexMainField);
-            return data != null ? Encoding.UTF8.GetString(data, 0, data.Length - 1) : null;
-        }
-
-        ///<summary>
-        /// Set WktStepName field</summary>
-        /// <param name="wktStepName_"> field value to be set</param>
-        public void SetWktStepName(String wktStepName_)
-        {
-            byte[] data = Encoding.UTF8.GetBytes(wktStepName_);
-            byte[] zdata = new byte[data.Length + 1];
-            data.CopyTo(zdata, 0);
-            SetFieldValue(0, 0, zdata, Fit.SubfieldIndexMainField);
-        }
-
-        
-        /// <summary>
-        /// Set WktStepName field</summary>
-        /// <param name="wktStepName_">field value to be set</param>
-        public void SetWktStepName(byte[] wktStepName_)
-        {
-            SetFieldValue(0, 0, wktStepName_, Fit.SubfieldIndexMainField);
-        }
-        
-        ///<summary>
-        /// Retrieves the DurationType field</summary>
-        /// <returns>Returns nullable WktStepDuration enum representing the DurationType field</returns>
-        public WktStepDuration? GetDurationType()
-        {
-            object obj = GetFieldValue(1, 0, Fit.SubfieldIndexMainField);
-            WktStepDuration? value = obj == null ? (WktStepDuration?)null : (WktStepDuration)obj;
-            return value;
-        }
-
-        /// <summary>
-        /// Set DurationType field</summary>
-        /// <param name="durationType_">Nullable field value to be set</param>
-        public void SetDurationType(WktStepDuration? durationType_)
-        {
-            SetFieldValue(1, 0, durationType_, Fit.SubfieldIndexMainField);
-        }
-        
-        ///<summary>
-        /// Retrieves the DurationValue field</summary>
-        /// <returns>Returns nullable uint representing the DurationValue field</returns>
-        public uint? GetDurationValue()
-        {
-            Object val = GetFieldValue(2, 0, Fit.SubfieldIndexMainField);
-            if(val == null)
-            {
-                return null;
-            }
-
-            return (Convert.ToUInt32(val));
-            
-        }
-
-        /// <summary>
-        /// Set DurationValue field</summary>
-        /// <param name="durationValue_">Nullable field value to be set</param>
-        public void SetDurationValue(uint? durationValue_)
-        {
-            SetFieldValue(2, 0, durationValue_, Fit.SubfieldIndexMainField);
-        }
-        
-
-        /// <summary>
-        /// Retrieves the DurationTime subfield
-        /// Units: s</summary>
-        /// <returns>Nullable float representing the DurationTime subfield</returns>
-        public float? GetDurationTime()
-        {
-            Object val = GetFieldValue(2, 0, DurationValueSubfield.DurationTime);
-            if(val == null)
-            {
-                return null;
-            }
-
-            return (Convert.ToSingle(val));
-            
-        }
-
-        /// <summary>
-        ///
-        /// Set DurationTime subfield
-        /// Units: s</summary>
-        /// <param name="durationTime">Subfield value to be set</param>
-        public void SetDurationTime(float? durationTime)
-        {
-            SetFieldValue(2, 0, durationTime, DurationValueSubfield.DurationTime);
-        }
-
-        /// <summary>
-        /// Retrieves the DurationDistance subfield
-        /// Units: m</summary>
-        /// <returns>Nullable float representing the DurationDistance subfield</returns>
-        public float? GetDurationDistance()
-        {
-            Object val = GetFieldValue(2, 0, DurationValueSubfield.DurationDistance);
-            if(val == null)
-            {
-                return null;
-            }
-
-            return (Convert.ToSingle(val));
-            
-        }
-
-        /// <summary>
-        ///
-        /// Set DurationDistance subfield
-        /// Units: m</summary>
-        /// <param name="durationDistance">Subfield value to be set</param>
-        public void SetDurationDistance(float? durationDistance)
-        {
-            SetFieldValue(2, 0, durationDistance, DurationValueSubfield.DurationDistance);
-        }
-
-        /// <summary>
-        /// Retrieves the DurationHr subfield
-        /// Units: % or bpm</summary>
-        /// <returns>Nullable uint representing the DurationHr subfield</returns>
-        public uint? GetDurationHr()
-        {
-            Object val = GetFieldValue(2, 0, DurationValueSubfield.DurationHr);
-            if(val == null)
-            {
-                return null;
-            }
-
-            return (Convert.ToUInt32(val));
-            
-        }
-
-        /// <summary>
-        ///
-        /// Set DurationHr subfield
-        /// Units: % or bpm</summary>
-        /// <param name="durationHr">Subfield value to be set</param>
-        public void SetDurationHr(uint? durationHr)
-        {
-            SetFieldValue(2, 0, durationHr, DurationValueSubfield.DurationHr);
-        }
-
-        /// <summary>
-        /// Retrieves the DurationCalories subfield
-        /// Units: calories</summary>
-        /// <returns>Nullable uint representing the DurationCalories subfield</returns>
-        public uint? GetDurationCalories()
-        {
-            Object val = GetFieldValue(2, 0, DurationValueSubfield.DurationCalories);
-            if(val == null)
-            {
-                return null;
-            }
-
-            return (Convert.ToUInt32(val));
-            
-        }
-
-        /// <summary>
-        ///
-        /// Set DurationCalories subfield
-        /// Units: calories</summary>
-        /// <param name="durationCalories">Subfield value to be set</param>
-        public void SetDurationCalories(uint? durationCalories)
-        {
-            SetFieldValue(2, 0, durationCalories, DurationValueSubfield.DurationCalories);
-        }
-
-        /// <summary>
-        /// Retrieves the DurationStep subfield
-        /// Comment: message_index of step to loop back to. Steps are assumed to be in the order by message_index. custom_name and intensity members are undefined for this duration type.</summary>
-        /// <returns>Nullable uint representing the DurationStep subfield</returns>
-        public uint? GetDurationStep()
-        {
-            Object val = GetFieldValue(2, 0, DurationValueSubfield.DurationStep);
-            if(val == null)
-            {
-                return null;
-            }
-
-            return (Convert.ToUInt32(val));
-            
-        }
-
-        /// <summary>
-        ///
-        /// Set DurationStep subfield
-        /// Comment: message_index of step to loop back to. Steps are assumed to be in the order by message_index. custom_name and intensity members are undefined for this duration type.</summary>
-        /// <param name="durationStep">Subfield value to be set</param>
-        public void SetDurationStep(uint? durationStep)
-        {
-            SetFieldValue(2, 0, durationStep, DurationValueSubfield.DurationStep);
-        }
-
-        /// <summary>
-        /// Retrieves the DurationPower subfield
-        /// Units: % or watts</summary>
-        /// <returns>Nullable uint representing the DurationPower subfield</returns>
-        public uint? GetDurationPower()
-        {
-            Object val = GetFieldValue(2, 0, DurationValueSubfield.DurationPower);
-            if(val == null)
-            {
-                return null;
-            }
-
-            return (Convert.ToUInt32(val));
-            
-        }
-
-        /// <summary>
-        ///
-        /// Set DurationPower subfield
-        /// Units: % or watts</summary>
-        /// <param name="durationPower">Subfield value to be set</param>
-        public void SetDurationPower(uint? durationPower)
-        {
-            SetFieldValue(2, 0, durationPower, DurationValueSubfield.DurationPower);
-        }
-
-        /// <summary>
-        /// Retrieves the DurationReps subfield</summary>
-        /// <returns>Nullable uint representing the DurationReps subfield</returns>
-        public uint? GetDurationReps()
-        {
-            Object val = GetFieldValue(2, 0, DurationValueSubfield.DurationReps);
-            if(val == null)
-            {
-                return null;
-            }
-
-            return (Convert.ToUInt32(val));
-            
-        }
-
-        /// <summary>
-        ///
-        /// Set DurationReps subfield</summary>
-        /// <param name="durationReps">Subfield value to be set</param>
-        public void SetDurationReps(uint? durationReps)
-        {
-            SetFieldValue(2, 0, durationReps, DurationValueSubfield.DurationReps);
-        }
-        ///<summary>
-        /// Retrieves the TargetType field</summary>
-        /// <returns>Returns nullable WktStepTarget enum representing the TargetType field</returns>
-        public WktStepTarget? GetTargetType()
-        {
-            object obj = GetFieldValue(3, 0, Fit.SubfieldIndexMainField);
-            WktStepTarget? value = obj == null ? (WktStepTarget?)null : (WktStepTarget)obj;
-            return value;
-        }
-
-        /// <summary>
-        /// Set TargetType field</summary>
-        /// <param name="targetType_">Nullable field value to be set</param>
-        public void SetTargetType(WktStepTarget? targetType_)
-        {
-            SetFieldValue(3, 0, targetType_, Fit.SubfieldIndexMainField);
-        }
-        
-        ///<summary>
-        /// Retrieves the TargetValue field</summary>
-        /// <returns>Returns nullable uint representing the TargetValue field</returns>
-        public uint? GetTargetValue()
-        {
-            Object val = GetFieldValue(4, 0, Fit.SubfieldIndexMainField);
-            if(val == null)
-            {
-                return null;
-            }
-
-            return (Convert.ToUInt32(val));
-            
-        }
-
-        /// <summary>
-        /// Set TargetValue field</summary>
-        /// <param name="targetValue_">Nullable field value to be set</param>
-        public void SetTargetValue(uint? targetValue_)
-        {
-            SetFieldValue(4, 0, targetValue_, Fit.SubfieldIndexMainField);
-        }
-        
-
-        /// <summary>
-        /// Retrieves the TargetSpeedZone subfield
-        /// Comment: speed zone (1-10);Custom =0;</summary>
-        /// <returns>Nullable uint representing the TargetSpeedZone subfield</returns>
-        public uint? GetTargetSpeedZone()
-        {
-            Object val = GetFieldValue(4, 0, TargetValueSubfield.TargetSpeedZone);
-            if(val == null)
-            {
-                return null;
-            }
-
-            return (Convert.ToUInt32(val));
-            
-        }
-
-        /// <summary>
-        ///
-        /// Set TargetSpeedZone subfield
-        /// Comment: speed zone (1-10);Custom =0;</summary>
-        /// <param name="targetSpeedZone">Subfield value to be set</param>
-        public void SetTargetSpeedZone(uint? targetSpeedZone)
-        {
-            SetFieldValue(4, 0, targetSpeedZone, TargetValueSubfield.TargetSpeedZone);
-        }
-
-        /// <summary>
-        /// Retrieves the TargetHrZone subfield
-        /// Comment: hr zone (1-5);Custom =0;</summary>
-        /// <returns>Nullable uint representing the TargetHrZone subfield</returns>
-        public uint? GetTargetHrZone()
-        {
-            Object val = GetFieldValue(4, 0, TargetValueSubfield.TargetHrZone);
-            if(val == null)
-            {
-                return null;
-            }
-
-            return (Convert.ToUInt32(val));
-            
-        }
-
-        /// <summary>
-        ///
-        /// Set TargetHrZone subfield
-        /// Comment: hr zone (1-5);Custom =0;</summary>
-        /// <param name="targetHrZone">Subfield value to be set</param>
-        public void SetTargetHrZone(uint? targetHrZone)
-        {
-            SetFieldValue(4, 0, targetHrZone, TargetValueSubfield.TargetHrZone);
-        }
-
-        /// <summary>
-        /// Retrieves the TargetCadenceZone subfield
-        /// Comment: Zone (1-?); Custom = 0;</summary>
-        /// <returns>Nullable uint representing the TargetCadenceZone subfield</returns>
-        public uint? GetTargetCadenceZone()
-        {
-            Object val = GetFieldValue(4, 0, TargetValueSubfield.TargetCadenceZone);
-            if(val == null)
-            {
-                return null;
-            }
-
-            return (Convert.ToUInt32(val));
-            
-        }
-
-        /// <summary>
-        ///
-        /// Set TargetCadenceZone subfield
-        /// Comment: Zone (1-?); Custom = 0;</summary>
-        /// <param name="targetCadenceZone">Subfield value to be set</param>
-        public void SetTargetCadenceZone(uint? targetCadenceZone)
-        {
-            SetFieldValue(4, 0, targetCadenceZone, TargetValueSubfield.TargetCadenceZone);
-        }
-
-        /// <summary>
-        /// Retrieves the TargetPowerZone subfield
-        /// Comment: Power Zone ( 1-7); Custom = 0;</summary>
-        /// <returns>Nullable uint representing the TargetPowerZone subfield</returns>
-        public uint? GetTargetPowerZone()
-        {
-            Object val = GetFieldValue(4, 0, TargetValueSubfield.TargetPowerZone);
-            if(val == null)
-            {
-                return null;
-            }
-
-            return (Convert.ToUInt32(val));
-            
-        }
-
-        /// <summary>
-        ///
-        /// Set TargetPowerZone subfield
-        /// Comment: Power Zone ( 1-7); Custom = 0;</summary>
-        /// <param name="targetPowerZone">Subfield value to be set</param>
-        public void SetTargetPowerZone(uint? targetPowerZone)
-        {
-            SetFieldValue(4, 0, targetPowerZone, TargetValueSubfield.TargetPowerZone);
-        }
-
-        /// <summary>
-        /// Retrieves the RepeatSteps subfield
-        /// Comment: # of repetitions</summary>
-        /// <returns>Nullable uint representing the RepeatSteps subfield</returns>
-        public uint? GetRepeatSteps()
-        {
-            Object val = GetFieldValue(4, 0, TargetValueSubfield.RepeatSteps);
-            if(val == null)
-            {
-                return null;
-            }
-
-            return (Convert.ToUInt32(val));
-            
-        }
-
-        /// <summary>
-        ///
-        /// Set RepeatSteps subfield
-        /// Comment: # of repetitions</summary>
-        /// <param name="repeatSteps">Subfield value to be set</param>
-        public void SetRepeatSteps(uint? repeatSteps)
-        {
-            SetFieldValue(4, 0, repeatSteps, TargetValueSubfield.RepeatSteps);
-        }
-
-        /// <summary>
-        /// Retrieves the RepeatTime subfield
-        /// Units: s</summary>
-        /// <returns>Nullable float representing the RepeatTime subfield</returns>
-        public float? GetRepeatTime()
-        {
-            Object val = GetFieldValue(4, 0, TargetValueSubfield.RepeatTime);
-            if(val == null)
-            {
-                return null;
-            }
-
-            return (Convert.ToSingle(val));
-            
-        }
-
-        /// <summary>
-        ///
-        /// Set RepeatTime subfield
-        /// Units: s</summary>
-        /// <param name="repeatTime">Subfield value to be set</param>
-        public void SetRepeatTime(float? repeatTime)
-        {
-            SetFieldValue(4, 0, repeatTime, TargetValueSubfield.RepeatTime);
-        }
-
-        /// <summary>
-        /// Retrieves the RepeatDistance subfield
-        /// Units: m</summary>
-        /// <returns>Nullable float representing the RepeatDistance subfield</returns>
-        public float? GetRepeatDistance()
-        {
-            Object val = GetFieldValue(4, 0, TargetValueSubfield.RepeatDistance);
-            if(val == null)
-            {
-                return null;
-            }
-
-            return (Convert.ToSingle(val));
-            
-        }
-
-        /// <summary>
-        ///
-        /// Set RepeatDistance subfield
-        /// Units: m</summary>
-        /// <param name="repeatDistance">Subfield value to be set</param>
-        public void SetRepeatDistance(float? repeatDistance)
-        {
-            SetFieldValue(4, 0, repeatDistance, TargetValueSubfield.RepeatDistance);
-        }
-
-        /// <summary>
-        /// Retrieves the RepeatCalories subfield
-        /// Units: calories</summary>
-        /// <returns>Nullable uint representing the RepeatCalories subfield</returns>
-        public uint? GetRepeatCalories()
-        {
-            Object val = GetFieldValue(4, 0, TargetValueSubfield.RepeatCalories);
-            if(val == null)
-            {
-                return null;
-            }
-
-            return (Convert.ToUInt32(val));
-            
-        }
-
-        /// <summary>
-        ///
-        /// Set RepeatCalories subfield
-        /// Units: calories</summary>
-        /// <param name="repeatCalories">Subfield value to be set</param>
-        public void SetRepeatCalories(uint? repeatCalories)
-        {
-            SetFieldValue(4, 0, repeatCalories, TargetValueSubfield.RepeatCalories);
-        }
-
-        /// <summary>
-        /// Retrieves the RepeatHr subfield
-        /// Units: % or bpm</summary>
-        /// <returns>Nullable uint representing the RepeatHr subfield</returns>
-        public uint? GetRepeatHr()
-        {
-            Object val = GetFieldValue(4, 0, TargetValueSubfield.RepeatHr);
-            if(val == null)
-            {
-                return null;
-            }
-
-            return (Convert.ToUInt32(val));
-            
-        }
-
-        /// <summary>
-        ///
-        /// Set RepeatHr subfield
-        /// Units: % or bpm</summary>
-        /// <param name="repeatHr">Subfield value to be set</param>
-        public void SetRepeatHr(uint? repeatHr)
-        {
-            SetFieldValue(4, 0, repeatHr, TargetValueSubfield.RepeatHr);
-        }
-
-        /// <summary>
-        /// Retrieves the RepeatPower subfield
-        /// Units: % or watts</summary>
-        /// <returns>Nullable uint representing the RepeatPower subfield</returns>
-        public uint? GetRepeatPower()
-        {
-            Object val = GetFieldValue(4, 0, TargetValueSubfield.RepeatPower);
-            if(val == null)
-            {
-                return null;
-            }
-
-            return (Convert.ToUInt32(val));
-            
-        }
-
-        /// <summary>
-        ///
-        /// Set RepeatPower subfield
-        /// Units: % or watts</summary>
-        /// <param name="repeatPower">Subfield value to be set</param>
-        public void SetRepeatPower(uint? repeatPower)
-        {
-            SetFieldValue(4, 0, repeatPower, TargetValueSubfield.RepeatPower);
-        }
-
-        /// <summary>
-        /// Retrieves the TargetStrokeType subfield</summary>
-        /// <returns>Nullable SwimStroke enum representing the TargetStrokeType subfield</returns>
-        public SwimStroke? GetTargetStrokeType()
-        {
-            return (SwimStroke?)GetFieldValue(4, 0, TargetValueSubfield.TargetStrokeType);
-        }
-
-        /// <summary>
-        ///
-        /// Set TargetStrokeType subfield</summary>
-        /// <param name="targetStrokeType">Subfield value to be set</param>
-        public void SetTargetStrokeType(byte? targetStrokeType)
-        {
-            SetFieldValue(4, 0, targetStrokeType, TargetValueSubfield.TargetStrokeType);
-        }
-        ///<summary>
-        /// Retrieves the CustomTargetValueLow field</summary>
-        /// <returns>Returns nullable uint representing the CustomTargetValueLow field</returns>
-        public uint? GetCustomTargetValueLow()
-        {
-            Object val = GetFieldValue(5, 0, Fit.SubfieldIndexMainField);
-            if(val == null)
-            {
-                return null;
-            }
-
-            return (Convert.ToUInt32(val));
-            
-        }
-
-        /// <summary>
-        /// Set CustomTargetValueLow field</summary>
-        /// <param name="customTargetValueLow_">Nullable field value to be set</param>
-        public void SetCustomTargetValueLow(uint? customTargetValueLow_)
-        {
-            SetFieldValue(5, 0, customTargetValueLow_, Fit.SubfieldIndexMainField);
-        }
-        
-
-        /// <summary>
-        /// Retrieves the CustomTargetSpeedLow subfield
-        /// Units: m/s</summary>
-        /// <returns>Nullable float representing the CustomTargetSpeedLow subfield</returns>
-        public float? GetCustomTargetSpeedLow()
-        {
-            Object val = GetFieldValue(5, 0, CustomTargetValueLowSubfield.CustomTargetSpeedLow);
-            if(val == null)
-            {
-                return null;
-            }
-
-            return (Convert.ToSingle(val));
-            
-        }
-
-        /// <summary>
-        ///
-        /// Set CustomTargetSpeedLow subfield
-        /// Units: m/s</summary>
-        /// <param name="customTargetSpeedLow">Subfield value to be set</param>
-        public void SetCustomTargetSpeedLow(float? customTargetSpeedLow)
-        {
-            SetFieldValue(5, 0, customTargetSpeedLow, CustomTargetValueLowSubfield.CustomTargetSpeedLow);
-        }
-
-        /// <summary>
-        /// Retrieves the CustomTargetHeartRateLow subfield
-        /// Units: % or bpm</summary>
-        /// <returns>Nullable uint representing the CustomTargetHeartRateLow subfield</returns>
-        public uint? GetCustomTargetHeartRateLow()
-        {
-            Object val = GetFieldValue(5, 0, CustomTargetValueLowSubfield.CustomTargetHeartRateLow);
-            if(val == null)
-            {
-                return null;
-            }
-
-            return (Convert.ToUInt32(val));
-            
-        }
-
-        /// <summary>
-        ///
-        /// Set CustomTargetHeartRateLow subfield
-        /// Units: % or bpm</summary>
-        /// <param name="customTargetHeartRateLow">Subfield value to be set</param>
-        public void SetCustomTargetHeartRateLow(uint? customTargetHeartRateLow)
-        {
-            SetFieldValue(5, 0, customTargetHeartRateLow, CustomTargetValueLowSubfield.CustomTargetHeartRateLow);
-        }
-
-        /// <summary>
-        /// Retrieves the CustomTargetCadenceLow subfield
-        /// Units: rpm</summary>
-        /// <returns>Nullable uint representing the CustomTargetCadenceLow subfield</returns>
-        public uint? GetCustomTargetCadenceLow()
-        {
-            Object val = GetFieldValue(5, 0, CustomTargetValueLowSubfield.CustomTargetCadenceLow);
-            if(val == null)
-            {
-                return null;
-            }
-
-            return (Convert.ToUInt32(val));
-            
-        }
-
-        /// <summary>
-        ///
-        /// Set CustomTargetCadenceLow subfield
-        /// Units: rpm</summary>
-        /// <param name="customTargetCadenceLow">Subfield value to be set</param>
-        public void SetCustomTargetCadenceLow(uint? customTargetCadenceLow)
-        {
-            SetFieldValue(5, 0, customTargetCadenceLow, CustomTargetValueLowSubfield.CustomTargetCadenceLow);
-        }
-
-        /// <summary>
-        /// Retrieves the CustomTargetPowerLow subfield
-        /// Units: % or watts</summary>
-        /// <returns>Nullable uint representing the CustomTargetPowerLow subfield</returns>
-        public uint? GetCustomTargetPowerLow()
-        {
-            Object val = GetFieldValue(5, 0, CustomTargetValueLowSubfield.CustomTargetPowerLow);
-            if(val == null)
-            {
-                return null;
-            }
-
-            return (Convert.ToUInt32(val));
-            
-        }
-
-        /// <summary>
-        ///
-        /// Set CustomTargetPowerLow subfield
-        /// Units: % or watts</summary>
-        /// <param name="customTargetPowerLow">Subfield value to be set</param>
-        public void SetCustomTargetPowerLow(uint? customTargetPowerLow)
-        {
-            SetFieldValue(5, 0, customTargetPowerLow, CustomTargetValueLowSubfield.CustomTargetPowerLow);
-        }
-        ///<summary>
-        /// Retrieves the CustomTargetValueHigh field</summary>
-        /// <returns>Returns nullable uint representing the CustomTargetValueHigh field</returns>
-        public uint? GetCustomTargetValueHigh()
-        {
-            Object val = GetFieldValue(6, 0, Fit.SubfieldIndexMainField);
-            if(val == null)
-            {
-                return null;
-            }
-
-            return (Convert.ToUInt32(val));
-            
-        }
-
-        /// <summary>
-        /// Set CustomTargetValueHigh field</summary>
-        /// <param name="customTargetValueHigh_">Nullable field value to be set</param>
-        public void SetCustomTargetValueHigh(uint? customTargetValueHigh_)
-        {
-            SetFieldValue(6, 0, customTargetValueHigh_, Fit.SubfieldIndexMainField);
-        }
-        
-
-        /// <summary>
-        /// Retrieves the CustomTargetSpeedHigh subfield
-        /// Units: m/s</summary>
-        /// <returns>Nullable float representing the CustomTargetSpeedHigh subfield</returns>
-        public float? GetCustomTargetSpeedHigh()
-        {
-            Object val = GetFieldValue(6, 0, CustomTargetValueHighSubfield.CustomTargetSpeedHigh);
-            if(val == null)
-            {
-                return null;
-            }
-
-            return (Convert.ToSingle(val));
-            
-        }
-
-        /// <summary>
-        ///
-        /// Set CustomTargetSpeedHigh subfield
-        /// Units: m/s</summary>
-        /// <param name="customTargetSpeedHigh">Subfield value to be set</param>
-        public void SetCustomTargetSpeedHigh(float? customTargetSpeedHigh)
-        {
-            SetFieldValue(6, 0, customTargetSpeedHigh, CustomTargetValueHighSubfield.CustomTargetSpeedHigh);
-        }
-
-        /// <summary>
-        /// Retrieves the CustomTargetHeartRateHigh subfield
-        /// Units: % or bpm</summary>
-        /// <returns>Nullable uint representing the CustomTargetHeartRateHigh subfield</returns>
-        public uint? GetCustomTargetHeartRateHigh()
-        {
-            Object val = GetFieldValue(6, 0, CustomTargetValueHighSubfield.CustomTargetHeartRateHigh);
-            if(val == null)
-            {
-                return null;
-            }
-
-            return (Convert.ToUInt32(val));
-            
-        }
-
-        /// <summary>
-        ///
-        /// Set CustomTargetHeartRateHigh subfield
-        /// Units: % or bpm</summary>
-        /// <param name="customTargetHeartRateHigh">Subfield value to be set</param>
-        public void SetCustomTargetHeartRateHigh(uint? customTargetHeartRateHigh)
-        {
-            SetFieldValue(6, 0, customTargetHeartRateHigh, CustomTargetValueHighSubfield.CustomTargetHeartRateHigh);
-        }
-
-        /// <summary>
-        /// Retrieves the CustomTargetCadenceHigh subfield
-        /// Units: rpm</summary>
-        /// <returns>Nullable uint representing the CustomTargetCadenceHigh subfield</returns>
-        public uint? GetCustomTargetCadenceHigh()
-        {
-            Object val = GetFieldValue(6, 0, CustomTargetValueHighSubfield.CustomTargetCadenceHigh);
-            if(val == null)
-            {
-                return null;
-            }
-
-            return (Convert.ToUInt32(val));
-            
-        }
-
-        /// <summary>
-        ///
-        /// Set CustomTargetCadenceHigh subfield
-        /// Units: rpm</summary>
-        /// <param name="customTargetCadenceHigh">Subfield value to be set</param>
-        public void SetCustomTargetCadenceHigh(uint? customTargetCadenceHigh)
-        {
-            SetFieldValue(6, 0, customTargetCadenceHigh, CustomTargetValueHighSubfield.CustomTargetCadenceHigh);
-        }
-
-        /// <summary>
-        /// Retrieves the CustomTargetPowerHigh subfield
-        /// Units: % or watts</summary>
-        /// <returns>Nullable uint representing the CustomTargetPowerHigh subfield</returns>
-        public uint? GetCustomTargetPowerHigh()
-        {
-            Object val = GetFieldValue(6, 0, CustomTargetValueHighSubfield.CustomTargetPowerHigh);
-            if(val == null)
-            {
-                return null;
-            }
-
-            return (Convert.ToUInt32(val));
-            
-        }
-
-        /// <summary>
-        ///
-        /// Set CustomTargetPowerHigh subfield
-        /// Units: % or watts</summary>
-        /// <param name="customTargetPowerHigh">Subfield value to be set</param>
-        public void SetCustomTargetPowerHigh(uint? customTargetPowerHigh)
-        {
-            SetFieldValue(6, 0, customTargetPowerHigh, CustomTargetValueHighSubfield.CustomTargetPowerHigh);
-        }
-        ///<summary>
-        /// Retrieves the Intensity field</summary>
-        /// <returns>Returns nullable Intensity enum representing the Intensity field</returns>
-        public Intensity? GetIntensity()
-        {
-            object obj = GetFieldValue(7, 0, Fit.SubfieldIndexMainField);
-            Intensity? value = obj == null ? (Intensity?)null : (Intensity)obj;
-            return value;
-        }
-
-        /// <summary>
-        /// Set Intensity field</summary>
-        /// <param name="intensity_">Nullable field value to be set</param>
-        public void SetIntensity(Intensity? intensity_)
-        {
-            SetFieldValue(7, 0, intensity_, Fit.SubfieldIndexMainField);
-        }
-        
-        ///<summary>
-        /// Retrieves the Notes field</summary>
-        /// <returns>Returns byte[] representing the Notes field</returns>
-        public byte[] GetNotes()
-        {
-            byte[] data = (byte[])GetFieldValue(8, 0, Fit.SubfieldIndexMainField);
-            return data.Take(data.Length - 1).ToArray();
-        }
-
-        ///<summary>
-        /// Retrieves the Notes field</summary>
-        /// <returns>Returns String representing the Notes field</returns>
-        public String GetNotesAsString()
-        {
-            byte[] data = (byte[])GetFieldValue(8, 0, Fit.SubfieldIndexMainField);
-            return data != null ? Encoding.UTF8.GetString(data, 0, data.Length - 1) : null;
-        }
-
-        ///<summary>
-        /// Set Notes field</summary>
-        /// <param name="notes_"> field value to be set</param>
-        public void SetNotes(String notes_)
-        {
-            byte[] data = Encoding.UTF8.GetBytes(notes_);
-            byte[] zdata = new byte[data.Length + 1];
-            data.CopyTo(zdata, 0);
-            SetFieldValue(8, 0, zdata, Fit.SubfieldIndexMainField);
-        }
-
-        
-        /// <summary>
-        /// Set Notes field</summary>
-        /// <param name="notes_">field value to be set</param>
-        public void SetNotes(byte[] notes_)
-        {
-            SetFieldValue(8, 0, notes_, Fit.SubfieldIndexMainField);
-        }
-        
-        ///<summary>
-        /// Retrieves the Equipment field</summary>
-        /// <returns>Returns nullable WorkoutEquipment enum representing the Equipment field</returns>
-        public WorkoutEquipment? GetEquipment()
-        {
-            object obj = GetFieldValue(9, 0, Fit.SubfieldIndexMainField);
-            WorkoutEquipment? value = obj == null ? (WorkoutEquipment?)null : (WorkoutEquipment)obj;
-            return value;
-        }
-
-        /// <summary>
-        /// Set Equipment field</summary>
-        /// <param name="equipment_">Nullable field value to be set</param>
-        public void SetEquipment(WorkoutEquipment? equipment_)
-        {
-            SetFieldValue(9, 0, equipment_, Fit.SubfieldIndexMainField);
-        }
-        
-        ///<summary>
-        /// Retrieves the ExerciseCategory field</summary>
-        /// <returns>Returns nullable ushort representing the ExerciseCategory field</returns>
-        public ushort? GetExerciseCategory()
-        {
-            Object val = GetFieldValue(10, 0, Fit.SubfieldIndexMainField);
-            if(val == null)
-            {
-                return null;
-            }
-
-            return (Convert.ToUInt16(val));
-            
-        }
-
-        /// <summary>
-        /// Set ExerciseCategory field</summary>
-        /// <param name="exerciseCategory_">Nullable field value to be set</param>
-        public void SetExerciseCategory(ushort? exerciseCategory_)
-        {
-            SetFieldValue(10, 0, exerciseCategory_, Fit.SubfieldIndexMainField);
-        }
-        
-        ///<summary>
-        /// Retrieves the ExerciseName field</summary>
-        /// <returns>Returns nullable ushort representing the ExerciseName field</returns>
-        public ushort? GetExerciseName()
-        {
-            Object val = GetFieldValue(11, 0, Fit.SubfieldIndexMainField);
-            if(val == null)
-            {
-                return null;
-            }
-
-            return (Convert.ToUInt16(val));
-            
-        }
-
-        /// <summary>
-        /// Set ExerciseName field</summary>
-        /// <param name="exerciseName_">Nullable field value to be set</param>
-        public void SetExerciseName(ushort? exerciseName_)
-        {
-            SetFieldValue(11, 0, exerciseName_, Fit.SubfieldIndexMainField);
-        }
-        
-        ///<summary>
-        /// Retrieves the ExerciseWeight field
-        /// Units: kg</summary>
-        /// <returns>Returns nullable float representing the ExerciseWeight field</returns>
-        public float? GetExerciseWeight()
-        {
-            Object val = GetFieldValue(12, 0, Fit.SubfieldIndexMainField);
-            if(val == null)
-            {
-                return null;
-            }
-
-            return (Convert.ToSingle(val));
-            
-        }
-
-        /// <summary>
-        /// Set ExerciseWeight field
-        /// Units: kg</summary>
-        /// <param name="exerciseWeight_">Nullable field value to be set</param>
-        public void SetExerciseWeight(float? exerciseWeight_)
-        {
-            SetFieldValue(12, 0, exerciseWeight_, Fit.SubfieldIndexMainField);
-        }
-        
-        ///<summary>
-        /// Retrieves the WeightDisplayUnit field</summary>
-        /// <returns>Returns nullable ushort representing the WeightDisplayUnit field</returns>
-        public ushort? GetWeightDisplayUnit()
-        {
-            Object val = GetFieldValue(13, 0, Fit.SubfieldIndexMainField);
-            if(val == null)
-            {
-                return null;
-            }
-
-            return (Convert.ToUInt16(val));
-            
-        }
-
-        /// <summary>
-        /// Set WeightDisplayUnit field</summary>
-        /// <param name="weightDisplayUnit_">Nullable field value to be set</param>
-        public void SetWeightDisplayUnit(ushort? weightDisplayUnit_)
-        {
-            SetFieldValue(13, 0, weightDisplayUnit_, Fit.SubfieldIndexMainField);
-        }
-        
-        ///<summary>
-        /// Retrieves the SecondaryTargetType field</summary>
-        /// <returns>Returns nullable WktStepTarget enum representing the SecondaryTargetType field</returns>
-        public WktStepTarget? GetSecondaryTargetType()
-        {
-            object obj = GetFieldValue(19, 0, Fit.SubfieldIndexMainField);
-            WktStepTarget? value = obj == null ? (WktStepTarget?)null : (WktStepTarget)obj;
-            return value;
-        }
-
-        /// <summary>
-        /// Set SecondaryTargetType field</summary>
-        /// <param name="secondaryTargetType_">Nullable field value to be set</param>
-        public void SetSecondaryTargetType(WktStepTarget? secondaryTargetType_)
-        {
-            SetFieldValue(19, 0, secondaryTargetType_, Fit.SubfieldIndexMainField);
-        }
-        
-        ///<summary>
-        /// Retrieves the SecondaryTargetValue field</summary>
-        /// <returns>Returns nullable uint representing the SecondaryTargetValue field</returns>
-        public uint? GetSecondaryTargetValue()
-        {
-            Object val = GetFieldValue(20, 0, Fit.SubfieldIndexMainField);
-            if(val == null)
-            {
-                return null;
-            }
-
-            return (Convert.ToUInt32(val));
-            
-        }
-
-        /// <summary>
-        /// Set SecondaryTargetValue field</summary>
-        /// <param name="secondaryTargetValue_">Nullable field value to be set</param>
-        public void SetSecondaryTargetValue(uint? secondaryTargetValue_)
-        {
-            SetFieldValue(20, 0, secondaryTargetValue_, Fit.SubfieldIndexMainField);
-        }
-        
-
-        /// <summary>
-        /// Retrieves the SecondaryTargetSpeedZone subfield
-        /// Comment: speed zone (1-10);Custom =0;</summary>
-        /// <returns>Nullable uint representing the SecondaryTargetSpeedZone subfield</returns>
-        public uint? GetSecondaryTargetSpeedZone()
-        {
-            Object val = GetFieldValue(20, 0, SecondaryTargetValueSubfield.SecondaryTargetSpeedZone);
-            if(val == null)
-            {
-                return null;
-            }
-
-            return (Convert.ToUInt32(val));
-            
-        }
-
-        /// <summary>
-        ///
-        /// Set SecondaryTargetSpeedZone subfield
-        /// Comment: speed zone (1-10);Custom =0;</summary>
-        /// <param name="secondaryTargetSpeedZone">Subfield value to be set</param>
-        public void SetSecondaryTargetSpeedZone(uint? secondaryTargetSpeedZone)
-        {
-            SetFieldValue(20, 0, secondaryTargetSpeedZone, SecondaryTargetValueSubfield.SecondaryTargetSpeedZone);
-        }
-
-        /// <summary>
-        /// Retrieves the SecondaryTargetHrZone subfield
-        /// Comment: hr zone (1-5);Custom =0;</summary>
-        /// <returns>Nullable uint representing the SecondaryTargetHrZone subfield</returns>
-        public uint? GetSecondaryTargetHrZone()
-        {
-            Object val = GetFieldValue(20, 0, SecondaryTargetValueSubfield.SecondaryTargetHrZone);
-            if(val == null)
-            {
-                return null;
-            }
-
-            return (Convert.ToUInt32(val));
-            
-        }
-
-        /// <summary>
-        ///
-        /// Set SecondaryTargetHrZone subfield
-        /// Comment: hr zone (1-5);Custom =0;</summary>
-        /// <param name="secondaryTargetHrZone">Subfield value to be set</param>
-        public void SetSecondaryTargetHrZone(uint? secondaryTargetHrZone)
-        {
-            SetFieldValue(20, 0, secondaryTargetHrZone, SecondaryTargetValueSubfield.SecondaryTargetHrZone);
-        }
-
-        /// <summary>
-        /// Retrieves the SecondaryTargetCadenceZone subfield
-        /// Comment: Zone (1-?); Custom = 0;</summary>
-        /// <returns>Nullable uint representing the SecondaryTargetCadenceZone subfield</returns>
-        public uint? GetSecondaryTargetCadenceZone()
-        {
-            Object val = GetFieldValue(20, 0, SecondaryTargetValueSubfield.SecondaryTargetCadenceZone);
-            if(val == null)
-            {
-                return null;
-            }
-
-            return (Convert.ToUInt32(val));
-            
-        }
-
-        /// <summary>
-        ///
-        /// Set SecondaryTargetCadenceZone subfield
-        /// Comment: Zone (1-?); Custom = 0;</summary>
-        /// <param name="secondaryTargetCadenceZone">Subfield value to be set</param>
-        public void SetSecondaryTargetCadenceZone(uint? secondaryTargetCadenceZone)
-        {
-            SetFieldValue(20, 0, secondaryTargetCadenceZone, SecondaryTargetValueSubfield.SecondaryTargetCadenceZone);
-        }
-
-        /// <summary>
-        /// Retrieves the SecondaryTargetPowerZone subfield
-        /// Comment: Power Zone ( 1-7); Custom = 0;</summary>
-        /// <returns>Nullable uint representing the SecondaryTargetPowerZone subfield</returns>
-        public uint? GetSecondaryTargetPowerZone()
-        {
-            Object val = GetFieldValue(20, 0, SecondaryTargetValueSubfield.SecondaryTargetPowerZone);
-            if(val == null)
-            {
-                return null;
-            }
-
-            return (Convert.ToUInt32(val));
-            
-        }
-
-        /// <summary>
-        ///
-        /// Set SecondaryTargetPowerZone subfield
-        /// Comment: Power Zone ( 1-7); Custom = 0;</summary>
-        /// <param name="secondaryTargetPowerZone">Subfield value to be set</param>
-        public void SetSecondaryTargetPowerZone(uint? secondaryTargetPowerZone)
-        {
-            SetFieldValue(20, 0, secondaryTargetPowerZone, SecondaryTargetValueSubfield.SecondaryTargetPowerZone);
-        }
-
-        /// <summary>
-        /// Retrieves the SecondaryTargetStrokeType subfield</summary>
-        /// <returns>Nullable SwimStroke enum representing the SecondaryTargetStrokeType subfield</returns>
-        public SwimStroke? GetSecondaryTargetStrokeType()
-        {
-            return (SwimStroke?)GetFieldValue(20, 0, SecondaryTargetValueSubfield.SecondaryTargetStrokeType);
-        }
-
-        /// <summary>
-        ///
-        /// Set SecondaryTargetStrokeType subfield</summary>
-        /// <param name="secondaryTargetStrokeType">Subfield value to be set</param>
-        public void SetSecondaryTargetStrokeType(byte? secondaryTargetStrokeType)
-        {
-            SetFieldValue(20, 0, secondaryTargetStrokeType, SecondaryTargetValueSubfield.SecondaryTargetStrokeType);
-        }
-        ///<summary>
-        /// Retrieves the SecondaryCustomTargetValueLow field</summary>
-        /// <returns>Returns nullable uint representing the SecondaryCustomTargetValueLow field</returns>
-        public uint? GetSecondaryCustomTargetValueLow()
-        {
-            Object val = GetFieldValue(21, 0, Fit.SubfieldIndexMainField);
-            if(val == null)
-            {
-                return null;
-            }
-
-            return (Convert.ToUInt32(val));
-            
-        }
-
-        /// <summary>
-        /// Set SecondaryCustomTargetValueLow field</summary>
-        /// <param name="secondaryCustomTargetValueLow_">Nullable field value to be set</param>
-        public void SetSecondaryCustomTargetValueLow(uint? secondaryCustomTargetValueLow_)
-        {
-            SetFieldValue(21, 0, secondaryCustomTargetValueLow_, Fit.SubfieldIndexMainField);
-        }
-        
-
-        /// <summary>
-        /// Retrieves the SecondaryCustomTargetSpeedLow subfield
-        /// Units: m/s</summary>
-        /// <returns>Nullable float representing the SecondaryCustomTargetSpeedLow subfield</returns>
-        public float? GetSecondaryCustomTargetSpeedLow()
-        {
-            Object val = GetFieldValue(21, 0, SecondaryCustomTargetValueLowSubfield.SecondaryCustomTargetSpeedLow);
-            if(val == null)
-            {
-                return null;
-            }
-
-            return (Convert.ToSingle(val));
-            
-        }
-
-        /// <summary>
-        ///
-        /// Set SecondaryCustomTargetSpeedLow subfield
-        /// Units: m/s</summary>
-        /// <param name="secondaryCustomTargetSpeedLow">Subfield value to be set</param>
-        public void SetSecondaryCustomTargetSpeedLow(float? secondaryCustomTargetSpeedLow)
-        {
-            SetFieldValue(21, 0, secondaryCustomTargetSpeedLow, SecondaryCustomTargetValueLowSubfield.SecondaryCustomTargetSpeedLow);
-        }
-
-        /// <summary>
-        /// Retrieves the SecondaryCustomTargetHeartRateLow subfield
-        /// Units: % or bpm</summary>
-        /// <returns>Nullable uint representing the SecondaryCustomTargetHeartRateLow subfield</returns>
-        public uint? GetSecondaryCustomTargetHeartRateLow()
-        {
-            Object val = GetFieldValue(21, 0, SecondaryCustomTargetValueLowSubfield.SecondaryCustomTargetHeartRateLow);
-            if(val == null)
-            {
-                return null;
-            }
-
-            return (Convert.ToUInt32(val));
-            
-        }
-
-        /// <summary>
-        ///
-        /// Set SecondaryCustomTargetHeartRateLow subfield
-        /// Units: % or bpm</summary>
-        /// <param name="secondaryCustomTargetHeartRateLow">Subfield value to be set</param>
-        public void SetSecondaryCustomTargetHeartRateLow(uint? secondaryCustomTargetHeartRateLow)
-        {
-            SetFieldValue(21, 0, secondaryCustomTargetHeartRateLow, SecondaryCustomTargetValueLowSubfield.SecondaryCustomTargetHeartRateLow);
-        }
-
-        /// <summary>
-        /// Retrieves the SecondaryCustomTargetCadenceLow subfield
-        /// Units: rpm</summary>
-        /// <returns>Nullable uint representing the SecondaryCustomTargetCadenceLow subfield</returns>
-        public uint? GetSecondaryCustomTargetCadenceLow()
-        {
-            Object val = GetFieldValue(21, 0, SecondaryCustomTargetValueLowSubfield.SecondaryCustomTargetCadenceLow);
-            if(val == null)
-            {
-                return null;
-            }
-
-            return (Convert.ToUInt32(val));
-            
-        }
-
-        /// <summary>
-        ///
-        /// Set SecondaryCustomTargetCadenceLow subfield
-        /// Units: rpm</summary>
-        /// <param name="secondaryCustomTargetCadenceLow">Subfield value to be set</param>
-        public void SetSecondaryCustomTargetCadenceLow(uint? secondaryCustomTargetCadenceLow)
-        {
-            SetFieldValue(21, 0, secondaryCustomTargetCadenceLow, SecondaryCustomTargetValueLowSubfield.SecondaryCustomTargetCadenceLow);
-        }
-
-        /// <summary>
-        /// Retrieves the SecondaryCustomTargetPowerLow subfield
-        /// Units: % or watts</summary>
-        /// <returns>Nullable uint representing the SecondaryCustomTargetPowerLow subfield</returns>
-        public uint? GetSecondaryCustomTargetPowerLow()
-        {
-            Object val = GetFieldValue(21, 0, SecondaryCustomTargetValueLowSubfield.SecondaryCustomTargetPowerLow);
-            if(val == null)
-            {
-                return null;
-            }
-
-            return (Convert.ToUInt32(val));
-            
-        }
-
-        /// <summary>
-        ///
-        /// Set SecondaryCustomTargetPowerLow subfield
-        /// Units: % or watts</summary>
-        /// <param name="secondaryCustomTargetPowerLow">Subfield value to be set</param>
-        public void SetSecondaryCustomTargetPowerLow(uint? secondaryCustomTargetPowerLow)
-        {
-            SetFieldValue(21, 0, secondaryCustomTargetPowerLow, SecondaryCustomTargetValueLowSubfield.SecondaryCustomTargetPowerLow);
-        }
-        ///<summary>
-        /// Retrieves the SecondaryCustomTargetValueHigh field</summary>
-        /// <returns>Returns nullable uint representing the SecondaryCustomTargetValueHigh field</returns>
-        public uint? GetSecondaryCustomTargetValueHigh()
-        {
-            Object val = GetFieldValue(22, 0, Fit.SubfieldIndexMainField);
-            if(val == null)
-            {
-                return null;
-            }
-
-            return (Convert.ToUInt32(val));
-            
-        }
-
-        /// <summary>
-        /// Set SecondaryCustomTargetValueHigh field</summary>
-        /// <param name="secondaryCustomTargetValueHigh_">Nullable field value to be set</param>
-        public void SetSecondaryCustomTargetValueHigh(uint? secondaryCustomTargetValueHigh_)
-        {
-            SetFieldValue(22, 0, secondaryCustomTargetValueHigh_, Fit.SubfieldIndexMainField);
-        }
-        
-
-        /// <summary>
-        /// Retrieves the SecondaryCustomTargetSpeedHigh subfield
-        /// Units: m/s</summary>
-        /// <returns>Nullable float representing the SecondaryCustomTargetSpeedHigh subfield</returns>
-        public float? GetSecondaryCustomTargetSpeedHigh()
-        {
-            Object val = GetFieldValue(22, 0, SecondaryCustomTargetValueHighSubfield.SecondaryCustomTargetSpeedHigh);
-            if(val == null)
-            {
-                return null;
-            }
-
-            return (Convert.ToSingle(val));
-            
-        }
-
-        /// <summary>
-        ///
-        /// Set SecondaryCustomTargetSpeedHigh subfield
-        /// Units: m/s</summary>
-        /// <param name="secondaryCustomTargetSpeedHigh">Subfield value to be set</param>
-        public void SetSecondaryCustomTargetSpeedHigh(float? secondaryCustomTargetSpeedHigh)
-        {
-            SetFieldValue(22, 0, secondaryCustomTargetSpeedHigh, SecondaryCustomTargetValueHighSubfield.SecondaryCustomTargetSpeedHigh);
-        }
-
-        /// <summary>
-        /// Retrieves the SecondaryCustomTargetHeartRateHigh subfield
-        /// Units: % or bpm</summary>
-        /// <returns>Nullable uint representing the SecondaryCustomTargetHeartRateHigh subfield</returns>
-        public uint? GetSecondaryCustomTargetHeartRateHigh()
-        {
-            Object val = GetFieldValue(22, 0, SecondaryCustomTargetValueHighSubfield.SecondaryCustomTargetHeartRateHigh);
-            if(val == null)
-            {
-                return null;
-            }
-
-            return (Convert.ToUInt32(val));
-            
-        }
-
-        /// <summary>
-        ///
-        /// Set SecondaryCustomTargetHeartRateHigh subfield
-        /// Units: % or bpm</summary>
-        /// <param name="secondaryCustomTargetHeartRateHigh">Subfield value to be set</param>
-        public void SetSecondaryCustomTargetHeartRateHigh(uint? secondaryCustomTargetHeartRateHigh)
-        {
-            SetFieldValue(22, 0, secondaryCustomTargetHeartRateHigh, SecondaryCustomTargetValueHighSubfield.SecondaryCustomTargetHeartRateHigh);
-        }
-
-        /// <summary>
-        /// Retrieves the SecondaryCustomTargetCadenceHigh subfield
-        /// Units: rpm</summary>
-        /// <returns>Nullable uint representing the SecondaryCustomTargetCadenceHigh subfield</returns>
-        public uint? GetSecondaryCustomTargetCadenceHigh()
-        {
-            Object val = GetFieldValue(22, 0, SecondaryCustomTargetValueHighSubfield.SecondaryCustomTargetCadenceHigh);
-            if(val == null)
-            {
-                return null;
-            }
-
-            return (Convert.ToUInt32(val));
-            
-        }
-
-        /// <summary>
-        ///
-        /// Set SecondaryCustomTargetCadenceHigh subfield
-        /// Units: rpm</summary>
-        /// <param name="secondaryCustomTargetCadenceHigh">Subfield value to be set</param>
-        public void SetSecondaryCustomTargetCadenceHigh(uint? secondaryCustomTargetCadenceHigh)
-        {
-            SetFieldValue(22, 0, secondaryCustomTargetCadenceHigh, SecondaryCustomTargetValueHighSubfield.SecondaryCustomTargetCadenceHigh);
-        }
-
-        /// <summary>
-        /// Retrieves the SecondaryCustomTargetPowerHigh subfield
-        /// Units: % or watts</summary>
-        /// <returns>Nullable uint representing the SecondaryCustomTargetPowerHigh subfield</returns>
-        public uint? GetSecondaryCustomTargetPowerHigh()
-        {
-            Object val = GetFieldValue(22, 0, SecondaryCustomTargetValueHighSubfield.SecondaryCustomTargetPowerHigh);
-            if(val == null)
-            {
-                return null;
-            }
-
-            return (Convert.ToUInt32(val));
-            
-        }
-
-        /// <summary>
-        ///
-        /// Set SecondaryCustomTargetPowerHigh subfield
-        /// Units: % or watts</summary>
-        /// <param name="secondaryCustomTargetPowerHigh">Subfield value to be set</param>
-        public void SetSecondaryCustomTargetPowerHigh(uint? secondaryCustomTargetPowerHigh)
-        {
-            SetFieldValue(22, 0, secondaryCustomTargetPowerHigh, SecondaryCustomTargetValueHighSubfield.SecondaryCustomTargetPowerHigh);
-        }
-        #endregion // Methods
-    } // Class
+	/// <summary>
+	/// Implements the WorkoutStep profile message.
+	/// </summary>
+	public class WorkoutStepMesg : Mesg
+	{
+		#region Fields
+		static class DurationValueSubfield
+		{
+			public static ushort DurationTime = 0;
+			public static ushort DurationDistance = 1;
+			public static ushort DurationHr = 2;
+			public static ushort DurationCalories = 3;
+			public static ushort DurationStep = 4;
+			public static ushort DurationPower = 5;
+			public static ushort DurationReps = 6;
+			public static ushort Subfields = 7;
+			public static ushort Active = Fit.SubfieldIndexActiveSubfield;
+			public static ushort MainField = Fit.SubfieldIndexMainField;
+		}
+		static class TargetValueSubfield
+		{
+			public static ushort TargetSpeedZone = 0;
+			public static ushort TargetHrZone = 1;
+			public static ushort TargetCadenceZone = 2;
+			public static ushort TargetPowerZone = 3;
+			public static ushort RepeatSteps = 4;
+			public static ushort RepeatTime = 5;
+			public static ushort RepeatDistance = 6;
+			public static ushort RepeatCalories = 7;
+			public static ushort RepeatHr = 8;
+			public static ushort RepeatPower = 9;
+			public static ushort TargetStrokeType = 10;
+			public static ushort Subfields = 11;
+			public static ushort Active = Fit.SubfieldIndexActiveSubfield;
+			public static ushort MainField = Fit.SubfieldIndexMainField;
+		}
+		static class CustomTargetValueLowSubfield
+		{
+			public static ushort CustomTargetSpeedLow = 0;
+			public static ushort CustomTargetHeartRateLow = 1;
+			public static ushort CustomTargetCadenceLow = 2;
+			public static ushort CustomTargetPowerLow = 3;
+			public static ushort Subfields = 4;
+			public static ushort Active = Fit.SubfieldIndexActiveSubfield;
+			public static ushort MainField = Fit.SubfieldIndexMainField;
+		}
+		static class CustomTargetValueHighSubfield
+		{
+			public static ushort CustomTargetSpeedHigh = 0;
+			public static ushort CustomTargetHeartRateHigh = 1;
+			public static ushort CustomTargetCadenceHigh = 2;
+			public static ushort CustomTargetPowerHigh = 3;
+			public static ushort Subfields = 4;
+			public static ushort Active = Fit.SubfieldIndexActiveSubfield;
+			public static ushort MainField = Fit.SubfieldIndexMainField;
+		}
+		static class SecondaryTargetValueSubfield
+		{
+			public static ushort SecondaryTargetSpeedZone = 0;
+			public static ushort SecondaryTargetHrZone = 1;
+			public static ushort SecondaryTargetCadenceZone = 2;
+			public static ushort SecondaryTargetPowerZone = 3;
+			public static ushort SecondaryTargetStrokeType = 4;
+			public static ushort Subfields = 5;
+			public static ushort Active = Fit.SubfieldIndexActiveSubfield;
+			public static ushort MainField = Fit.SubfieldIndexMainField;
+		}
+		static class SecondaryCustomTargetValueLowSubfield
+		{
+			public static ushort SecondaryCustomTargetSpeedLow = 0;
+			public static ushort SecondaryCustomTargetHeartRateLow = 1;
+			public static ushort SecondaryCustomTargetCadenceLow = 2;
+			public static ushort SecondaryCustomTargetPowerLow = 3;
+			public static ushort Subfields = 4;
+			public static ushort Active = Fit.SubfieldIndexActiveSubfield;
+			public static ushort MainField = Fit.SubfieldIndexMainField;
+		}
+		static class SecondaryCustomTargetValueHighSubfield
+		{
+			public static ushort SecondaryCustomTargetSpeedHigh = 0;
+			public static ushort SecondaryCustomTargetHeartRateHigh = 1;
+			public static ushort SecondaryCustomTargetCadenceHigh = 2;
+			public static ushort SecondaryCustomTargetPowerHigh = 3;
+			public static ushort Subfields = 4;
+			public static ushort Active = Fit.SubfieldIndexActiveSubfield;
+			public static ushort MainField = Fit.SubfieldIndexMainField;
+		}
+		#endregion
+
+		/// <summary>
+		/// Field Numbers for <see cref="WorkoutStepMesg"/>
+		/// </summary>
+		public sealed class FieldDefNum
+		{
+			public const byte MessageIndex = 254;
+			public const byte WktStepName = 0;
+			public const byte DurationType = 1;
+			public const byte DurationValue = 2;
+			public const byte TargetType = 3;
+			public const byte TargetValue = 4;
+			public const byte CustomTargetValueLow = 5;
+			public const byte CustomTargetValueHigh = 6;
+			public const byte Intensity = 7;
+			public const byte Notes = 8;
+			public const byte Equipment = 9;
+			public const byte ExerciseCategory = 10;
+			public const byte ExerciseName = 11;
+			public const byte ExerciseWeight = 12;
+			public const byte WeightDisplayUnit = 13;
+			public const byte SecondaryTargetType = 19;
+			public const byte SecondaryTargetValue = 20;
+			public const byte SecondaryCustomTargetValueLow = 21;
+			public const byte SecondaryCustomTargetValueHigh = 22;
+			public const byte Invalid = Fit.FieldNumInvalid;
+		}
+
+		#region Constructors
+		public WorkoutStepMesg() : base(Profile.GetMesg(MesgNum.WorkoutStep))
+		{
+		}
+
+		public WorkoutStepMesg(Mesg mesg) : base(mesg)
+		{
+		}
+		#endregion // Constructors
+
+		#region Methods
+		///<summary>
+		/// Retrieves the MessageIndex field</summary>
+		/// <returns>Returns nullable ushort representing the MessageIndex field</returns>
+		public ushort? MessageIndex
+		{
+			get
+			{
+				Object val = GetFieldValue(254, 0, Fit.SubfieldIndexMainField);
+				if (val == null)
+				{
+					return null;
+				}
+
+				return (Convert.ToUInt16(val));
+
+			}
+			set
+			{
+				SetFieldValue(254, 0, value, Fit.SubfieldIndexMainField);
+			}
+		}
+
+		///<summary>
+		/// Retrieves the WktStepName field</summary>
+		/// <returns>Returns byte[] representing the WktStepName field</returns>
+		public byte[] WktStepName
+		{
+			get
+			{
+				byte[] data = (byte[])GetFieldValue(0, 0, Fit.SubfieldIndexMainField);
+				return data.Take(data.Length - 1).ToArray();
+			}
+			set
+			{
+				SetFieldValue(0, 0, value, Fit.SubfieldIndexMainField);
+			}
+		}
+
+		///<summary>
+		/// Retrieves the WktStepName field</summary>
+		/// <returns>Returns String representing the WktStepName field</returns>
+		public String GetWktStepNameAsString()
+		{
+			byte[] data = (byte[])GetFieldValue(0, 0, Fit.SubfieldIndexMainField);
+			return data != null ? Encoding.UTF8.GetString(data, 0, data.Length - 1) : null;
+		}
+
+		///<summary>
+		/// Set WktStepName field</summary>
+		/// <param name="wktStepName_"> field value to be set</param>
+		public void SetWktStepName(String wktStepName_)
+		{
+			byte[] data = Encoding.UTF8.GetBytes(wktStepName_);
+			byte[] zdata = new byte[data.Length + 1];
+			data.CopyTo(zdata, 0);
+			SetFieldValue(0, 0, zdata, Fit.SubfieldIndexMainField);
+		}
+
+		///<summary>
+		/// Retrieves the DurationType field</summary>
+		/// <returns>Returns nullable WktStepDuration enum representing the DurationType field</returns>
+		public WktStepDuration? DurationType
+		{
+			get
+			{
+				object obj = GetFieldValue(1, 0, Fit.SubfieldIndexMainField);
+				WktStepDuration? value = obj == null ? (WktStepDuration?)null : (WktStepDuration)obj;
+				return value;
+			}
+			set
+			{
+				SetFieldValue(1, 0, value, Fit.SubfieldIndexMainField);
+			}
+		}
+
+		///<summary>
+		/// Retrieves the DurationValue field</summary>
+		/// <returns>Returns nullable uint representing the DurationValue field</returns>
+		public uint? DurationValue
+		{
+			get
+			{
+				Object val = GetFieldValue(2, 0, Fit.SubfieldIndexMainField);
+				if (val == null)
+				{
+					return null;
+				}
+
+				return (Convert.ToUInt32(val));
+
+			}
+			set
+			{
+				SetFieldValue(2, 0, value, Fit.SubfieldIndexMainField);
+			}
+		}
+
+
+		/// <summary>
+		/// Retrieves the DurationTime subfield
+		/// Units: s</summary>
+		/// <returns>Nullable float representing the DurationTime subfield</returns>
+		public float? DurationTime
+		{
+			get
+			{
+				Object val = GetFieldValue(2, 0, DurationValueSubfield.DurationTime);
+				if (val == null)
+				{
+					return null;
+				}
+
+				return (Convert.ToSingle(val));
+
+			}
+			set
+			{
+				SetFieldValue(2, 0, value, DurationValueSubfield.DurationTime);
+			}
+		}
+
+		/// <summary>
+		/// Retrieves the DurationDistance subfield
+		/// Units: m</summary>
+		/// <returns>Nullable float representing the DurationDistance subfield</returns>
+		public float? DurationDistance
+		{
+			get
+			{
+				Object val = GetFieldValue(2, 0, DurationValueSubfield.DurationDistance);
+				if (val == null)
+				{
+					return null;
+				}
+
+				return (Convert.ToSingle(val));
+
+			}
+			set
+			{
+				SetFieldValue(2, 0, value, DurationValueSubfield.DurationDistance);
+			}
+		}
+
+		/// <summary>
+		/// Retrieves the DurationHr subfield
+		/// Units: % or bpm</summary>
+		/// <returns>Nullable uint representing the DurationHr subfield</returns>
+		public uint? DurationHr
+		{
+			get
+			{
+				Object val = GetFieldValue(2, 0, DurationValueSubfield.DurationHr);
+				if (val == null)
+				{
+					return null;
+				}
+
+				return (Convert.ToUInt32(val));
+
+			}
+			set
+			{
+				SetFieldValue(2, 0, value, DurationValueSubfield.DurationHr);
+			}
+		}
+
+		/// <summary>
+		/// Retrieves the DurationCalories subfield
+		/// Units: calories</summary>
+		/// <returns>Nullable uint representing the DurationCalories subfield</returns>
+		public uint? DurationCalories
+		{
+			get
+			{
+				Object val = GetFieldValue(2, 0, DurationValueSubfield.DurationCalories);
+				if (val == null)
+				{
+					return null;
+				}
+
+				return (Convert.ToUInt32(val));
+
+			}
+			set
+			{
+				SetFieldValue(2, 0, value, DurationValueSubfield.DurationCalories);
+			}
+		}
+
+		/// <summary>
+		/// Retrieves the DurationStep subfield
+		/// Comment: message_index of step to loop back to. Steps are assumed to be in the order by message_index. custom_name and intensity members are undefined for this duration type.</summary>
+		/// <returns>Nullable uint representing the DurationStep subfield</returns>
+		public uint? DurationStep
+		{
+			get
+			{
+				Object val = GetFieldValue(2, 0, DurationValueSubfield.DurationStep);
+				if (val == null)
+				{
+					return null;
+				}
+
+				return (Convert.ToUInt32(val));
+
+			}
+			set
+			{
+				SetFieldValue(2, 0, value, DurationValueSubfield.DurationStep);
+			}
+		}
+
+		/// <summary>
+		/// Retrieves the DurationPower subfield
+		/// Units: % or watts</summary>
+		/// <returns>Nullable uint representing the DurationPower subfield</returns>
+		public uint? DurationPower
+		{
+			get
+			{
+				Object val = GetFieldValue(2, 0, DurationValueSubfield.DurationPower);
+				if (val == null)
+				{
+					return null;
+				}
+
+				return (Convert.ToUInt32(val));
+
+			}
+			set
+			{
+				SetFieldValue(2, 0, value, DurationValueSubfield.DurationPower);
+			}
+		}
+
+		/// <summary>
+		/// Retrieves the DurationReps subfield</summary>
+		/// <returns>Nullable uint representing the DurationReps subfield</returns>
+		public uint? DurationReps
+		{
+			get
+			{
+				Object val = GetFieldValue(2, 0, DurationValueSubfield.DurationReps);
+				if (val == null)
+				{
+					return null;
+				}
+
+				return (Convert.ToUInt32(val));
+
+			}
+			set
+			{
+				SetFieldValue(2, 0, value, DurationValueSubfield.DurationReps);
+			}
+		}
+		///<summary>
+		/// Retrieves the TargetType field</summary>
+		/// <returns>Returns nullable WktStepTarget enum representing the TargetType field</returns>
+		public WktStepTarget? TargetType
+		{
+			get
+			{
+				object obj = GetFieldValue(3, 0, Fit.SubfieldIndexMainField);
+				WktStepTarget? value = obj == null ? (WktStepTarget?)null : (WktStepTarget)obj;
+				return value;
+			}
+			set
+			{
+				SetFieldValue(3, 0, value, Fit.SubfieldIndexMainField);
+			}
+		}
+
+		///<summary>
+		/// Retrieves the TargetValue field</summary>
+		/// <returns>Returns nullable uint representing the TargetValue field</returns>
+		public uint? TargetValue
+		{
+			get
+			{
+				Object val = GetFieldValue(4, 0, Fit.SubfieldIndexMainField);
+				if (val == null)
+				{
+					return null;
+				}
+
+				return (Convert.ToUInt32(val));
+
+			}
+			set
+			{
+				SetFieldValue(4, 0, value, Fit.SubfieldIndexMainField);
+			}
+		}
+
+
+		/// <summary>
+		/// Retrieves the TargetSpeedZone subfield
+		/// Comment: speed zone (1-10);Custom =0;</summary>
+		/// <returns>Nullable uint representing the TargetSpeedZone subfield</returns>
+		public uint? TargetSpeedZone
+		{
+			get
+			{
+				Object val = GetFieldValue(4, 0, TargetValueSubfield.TargetSpeedZone);
+				if (val == null)
+				{
+					return null;
+				}
+
+				return (Convert.ToUInt32(val));
+
+			}
+			set
+			{
+				SetFieldValue(4, 0, value, TargetValueSubfield.TargetSpeedZone);
+			}
+		}
+
+		/// <summary>
+		/// Retrieves the TargetHrZone subfield
+		/// Comment: hr zone (1-5);Custom =0;</summary>
+		/// <returns>Nullable uint representing the TargetHrZone subfield</returns>
+		public uint? TargetHrZone
+		{
+			get
+			{
+				Object val = GetFieldValue(4, 0, TargetValueSubfield.TargetHrZone);
+				if (val == null)
+				{
+					return null;
+				}
+
+				return (Convert.ToUInt32(val));
+
+			}
+			set
+			{
+				SetFieldValue(4, 0, value, TargetValueSubfield.TargetHrZone);
+			}
+		}
+
+		/// <summary>
+		/// Retrieves the TargetCadenceZone subfield
+		/// Comment: Zone (1-?); Custom = 0;</summary>
+		/// <returns>Nullable uint representing the TargetCadenceZone subfield</returns>
+		public uint? TargetCadenceZone
+		{
+			get
+			{
+				Object val = GetFieldValue(4, 0, TargetValueSubfield.TargetCadenceZone);
+				if (val == null)
+				{
+					return null;
+				}
+
+				return (Convert.ToUInt32(val));
+
+			}
+			set
+			{
+				SetFieldValue(4, 0, value, TargetValueSubfield.TargetCadenceZone);
+			}
+		}
+
+		/// <summary>
+		/// Retrieves the TargetPowerZone subfield
+		/// Comment: Power Zone ( 1-7); Custom = 0;</summary>
+		/// <returns>Nullable uint representing the TargetPowerZone subfield</returns>
+		public uint? TargetPowerZone
+		{
+			get
+			{
+				Object val = GetFieldValue(4, 0, TargetValueSubfield.TargetPowerZone);
+				if (val == null)
+				{
+					return null;
+				}
+
+				return (Convert.ToUInt32(val));
+
+			}
+			set
+			{
+				SetFieldValue(4, 0, value, TargetValueSubfield.TargetPowerZone);
+			}
+		}
+
+		/// <summary>
+		/// Retrieves the RepeatSteps subfield
+		/// Comment: # of repetitions</summary>
+		/// <returns>Nullable uint representing the RepeatSteps subfield</returns>
+		public uint? RepeatSteps
+		{
+			get
+			{
+				Object val = GetFieldValue(4, 0, TargetValueSubfield.RepeatSteps);
+				if (val == null)
+				{
+					return null;
+				}
+
+				return (Convert.ToUInt32(val));
+
+			}
+			set
+			{
+				SetFieldValue(4, 0, value, TargetValueSubfield.RepeatSteps);
+			}
+		}
+
+		/// <summary>
+		/// Retrieves the RepeatTime subfield
+		/// Units: s</summary>
+		/// <returns>Nullable float representing the RepeatTime subfield</returns>
+		public float? RepeatTime
+		{
+			get
+			{
+				Object val = GetFieldValue(4, 0, TargetValueSubfield.RepeatTime);
+				if (val == null)
+				{
+					return null;
+				}
+
+				return (Convert.ToSingle(val));
+
+			}
+			set
+			{
+				SetFieldValue(4, 0, value, TargetValueSubfield.RepeatTime);
+			}
+		}
+
+		/// <summary>
+		/// Retrieves the RepeatDistance subfield
+		/// Units: m</summary>
+		/// <returns>Nullable float representing the RepeatDistance subfield</returns>
+		public float? RepeatDistance
+		{
+			get
+			{
+				Object val = GetFieldValue(4, 0, TargetValueSubfield.RepeatDistance);
+				if (val == null)
+				{
+					return null;
+				}
+
+				return (Convert.ToSingle(val));
+
+			}
+			set
+			{
+				SetFieldValue(4, 0, value, TargetValueSubfield.RepeatDistance);
+			}
+		}
+
+		/// <summary>
+		/// Retrieves the RepeatCalories subfield
+		/// Units: calories</summary>
+		/// <returns>Nullable uint representing the RepeatCalories subfield</returns>
+		public uint? RepeatCalories
+		{
+			get
+			{
+				Object val = GetFieldValue(4, 0, TargetValueSubfield.RepeatCalories);
+				if (val == null)
+				{
+					return null;
+				}
+
+				return (Convert.ToUInt32(val));
+
+			}
+			set
+			{
+				SetFieldValue(4, 0, value, TargetValueSubfield.RepeatCalories);
+			}
+		}
+
+		/// <summary>
+		/// Retrieves the RepeatHr subfield
+		/// Units: % or bpm</summary>
+		/// <returns>Nullable uint representing the RepeatHr subfield</returns>
+		public uint? RepeatHr
+		{
+			get
+			{
+				Object val = GetFieldValue(4, 0, TargetValueSubfield.RepeatHr);
+				if (val == null)
+				{
+					return null;
+				}
+
+				return (Convert.ToUInt32(val));
+
+			}
+			set
+			{
+				SetFieldValue(4, 0, value, TargetValueSubfield.RepeatHr);
+			}
+		}
+
+		/// <summary>
+		/// Retrieves the RepeatPower subfield
+		/// Units: % or watts</summary>
+		/// <returns>Nullable uint representing the RepeatPower subfield</returns>
+		public uint? RepeatPower
+		{
+			get
+			{
+				Object val = GetFieldValue(4, 0, TargetValueSubfield.RepeatPower);
+				if (val == null)
+				{
+					return null;
+				}
+
+				return (Convert.ToUInt32(val));
+
+			}
+			set
+			{
+				SetFieldValue(4, 0, value, TargetValueSubfield.RepeatPower);
+			}
+		}
+
+		/// <summary>
+		/// Retrieves the TargetStrokeType subfield</summary>
+		/// <returns>Nullable SwimStroke enum representing the TargetStrokeType subfield</returns>
+		public SwimStroke? GetTargetStrokeType()
+		{
+			return (SwimStroke?)GetFieldValue(4, 0, TargetValueSubfield.TargetStrokeType);
+		}
+
+		/// <summary>
+		///
+		/// Set TargetStrokeType subfield</summary>
+		/// <param name="targetStrokeType">Subfield value to be set</param>
+		public void SetTargetStrokeType(byte? targetStrokeType)
+		{
+			SetFieldValue(4, 0, targetStrokeType, TargetValueSubfield.TargetStrokeType);
+		}
+		///<summary>
+		/// Retrieves the CustomTargetValueLow field</summary>
+		/// <returns>Returns nullable uint representing the CustomTargetValueLow field</returns>
+		public uint? CustomTargetValueLow
+		{
+			get
+			{
+				Object val = GetFieldValue(5, 0, Fit.SubfieldIndexMainField);
+				if (val == null)
+				{
+					return null;
+				}
+
+				return (Convert.ToUInt32(val));
+
+			}
+			set
+			{
+				SetFieldValue(5, 0, value, Fit.SubfieldIndexMainField);
+			}
+		}
+
+
+		/// <summary>
+		/// Retrieves the CustomTargetSpeedLow subfield
+		/// Units: m/s</summary>
+		/// <returns>Nullable float representing the CustomTargetSpeedLow subfield</returns>
+		public float? CustomTargetSpeedLow
+		{
+			get
+			{
+				Object val = GetFieldValue(5, 0, CustomTargetValueLowSubfield.CustomTargetSpeedLow);
+				if (val == null)
+				{
+					return null;
+				}
+
+				return (Convert.ToSingle(val));
+
+			}
+			set
+			{
+				SetFieldValue(5, 0, value, CustomTargetValueLowSubfield.CustomTargetSpeedLow);
+			}
+		}
+
+		/// <summary>
+		/// Retrieves the CustomTargetHeartRateLow subfield
+		/// Units: % or bpm</summary>
+		/// <returns>Nullable uint representing the CustomTargetHeartRateLow subfield</returns>
+		public uint? CustomTargetHeartRateLow
+		{
+			get
+			{
+				Object val = GetFieldValue(5, 0, CustomTargetValueLowSubfield.CustomTargetHeartRateLow);
+				if (val == null)
+				{
+					return null;
+				}
+
+				return (Convert.ToUInt32(val));
+
+			}
+			set
+			{
+				SetFieldValue(5, 0, value, CustomTargetValueLowSubfield.CustomTargetHeartRateLow);
+			}
+		}
+
+		/// <summary>
+		/// Retrieves the CustomTargetCadenceLow subfield
+		/// Units: rpm</summary>
+		/// <returns>Nullable uint representing the CustomTargetCadenceLow subfield</returns>
+		public uint? CustomTargetCadenceLow
+		{
+			get
+			{
+				Object val = GetFieldValue(5, 0, CustomTargetValueLowSubfield.CustomTargetCadenceLow);
+				if (val == null)
+				{
+					return null;
+				}
+
+				return (Convert.ToUInt32(val));
+
+			}
+			set
+			{
+				SetFieldValue(5, 0, value, CustomTargetValueLowSubfield.CustomTargetCadenceLow);
+			}
+		}
+
+		/// <summary>
+		/// Retrieves the CustomTargetPowerLow subfield
+		/// Units: % or watts</summary>
+		/// <returns>Nullable uint representing the CustomTargetPowerLow subfield</returns>
+		public uint? CustomTargetPowerLow
+		{
+			get
+			{
+				Object val = GetFieldValue(5, 0, CustomTargetValueLowSubfield.CustomTargetPowerLow);
+				if (val == null)
+				{
+					return null;
+				}
+
+				return (Convert.ToUInt32(val));
+
+			}
+			set
+			{
+				SetFieldValue(5, 0, value, CustomTargetValueLowSubfield.CustomTargetPowerLow);
+			}
+		}
+		///<summary>
+		/// Retrieves the CustomTargetValueHigh field</summary>
+		/// <returns>Returns nullable uint representing the CustomTargetValueHigh field</returns>
+		public uint? CustomTargetValueHigh
+		{
+			get
+			{
+				Object val = GetFieldValue(6, 0, Fit.SubfieldIndexMainField);
+				if (val == null)
+				{
+					return null;
+				}
+
+				return (Convert.ToUInt32(val));
+
+			}
+			set
+			{
+				SetFieldValue(6, 0, value, Fit.SubfieldIndexMainField);
+			}
+		}
+
+
+		/// <summary>
+		/// Retrieves the CustomTargetSpeedHigh subfield
+		/// Units: m/s</summary>
+		/// <returns>Nullable float representing the CustomTargetSpeedHigh subfield</returns>
+		public float? CustomTargetSpeedHigh
+		{
+			get
+			{
+				Object val = GetFieldValue(6, 0, CustomTargetValueHighSubfield.CustomTargetSpeedHigh);
+				if (val == null)
+				{
+					return null;
+				}
+
+				return (Convert.ToSingle(val));
+
+			}
+			set
+			{
+				SetFieldValue(6, 0, value, CustomTargetValueHighSubfield.CustomTargetSpeedHigh);
+			}
+		}
+
+		/// <summary>
+		/// Retrieves the CustomTargetHeartRateHigh subfield
+		/// Units: % or bpm</summary>
+		/// <returns>Nullable uint representing the CustomTargetHeartRateHigh subfield</returns>
+		public uint? CustomTargetHeartRateHigh
+		{
+			get
+			{
+				Object val = GetFieldValue(6, 0, CustomTargetValueHighSubfield.CustomTargetHeartRateHigh);
+				if (val == null)
+				{
+					return null;
+				}
+
+				return (Convert.ToUInt32(val));
+
+			}
+			set
+			{
+				SetFieldValue(6, 0, value, CustomTargetValueHighSubfield.CustomTargetHeartRateHigh);
+			}
+		}
+
+		/// <summary>
+		/// Retrieves the CustomTargetCadenceHigh subfield
+		/// Units: rpm</summary>
+		/// <returns>Nullable uint representing the CustomTargetCadenceHigh subfield</returns>
+		public uint? CustomTargetCadenceHigh
+		{
+			get
+			{
+				Object val = GetFieldValue(6, 0, CustomTargetValueHighSubfield.CustomTargetCadenceHigh);
+				if (val == null)
+				{
+					return null;
+				}
+
+				return (Convert.ToUInt32(val));
+
+			}
+			set
+			{
+				SetFieldValue(6, 0, value, CustomTargetValueHighSubfield.CustomTargetCadenceHigh);
+			}
+		}
+
+		/// <summary>
+		/// Retrieves the CustomTargetPowerHigh subfield
+		/// Units: % or watts</summary>
+		/// <returns>Nullable uint representing the CustomTargetPowerHigh subfield</returns>
+		public uint? CustomTargetPowerHigh
+		{
+			get
+			{
+				Object val = GetFieldValue(6, 0, CustomTargetValueHighSubfield.CustomTargetPowerHigh);
+				if (val == null)
+				{
+					return null;
+				}
+
+				return (Convert.ToUInt32(val));
+
+			}
+			set
+			{
+				SetFieldValue(6, 0, value, CustomTargetValueHighSubfield.CustomTargetPowerHigh);
+			}
+		}
+		///<summary>
+		/// Retrieves the Intensity field</summary>
+		/// <returns>Returns nullable Intensity enum representing the Intensity field</returns>
+		public Intensity? Intensity
+		{
+			get
+			{
+				object obj = GetFieldValue(7, 0, Fit.SubfieldIndexMainField);
+				Intensity? value = obj == null ? (Intensity?)null : (Intensity)obj;
+				return value;
+			}
+			set
+			{
+				SetFieldValue(7, 0, value, Fit.SubfieldIndexMainField);
+			}
+		}
+
+		///<summary>
+		/// Retrieves the Notes field</summary>
+		/// <returns>Returns byte[] representing the Notes field</returns>
+		public byte[] Notes
+		{
+			get
+			{
+				byte[] data = (byte[])GetFieldValue(8, 0, Fit.SubfieldIndexMainField);
+				return data.Take(data.Length - 1).ToArray();
+			}
+			set
+			{
+				SetFieldValue(8, 0, value, Fit.SubfieldIndexMainField);
+			}
+		}
+
+		///<summary>
+		/// Retrieves the Notes field</summary>
+		/// <returns>Returns String representing the Notes field</returns>
+		public String GetNotesAsString()
+		{
+			byte[] data = (byte[])GetFieldValue(8, 0, Fit.SubfieldIndexMainField);
+			return data != null ? Encoding.UTF8.GetString(data, 0, data.Length - 1) : null;
+		}
+
+		///<summary>
+		/// Set Notes field</summary>
+		/// <param name="notes_"> field value to be set</param>
+		public void SetNotes(String notes_)
+		{
+			byte[] data = Encoding.UTF8.GetBytes(notes_);
+			byte[] zdata = new byte[data.Length + 1];
+			data.CopyTo(zdata, 0);
+			SetFieldValue(8, 0, zdata, Fit.SubfieldIndexMainField);
+		}
+
+		///<summary>
+		/// Retrieves the Equipment field</summary>
+		/// <returns>Returns nullable WorkoutEquipment enum representing the Equipment field</returns>
+		public WorkoutEquipment? Equipment
+		{
+			get
+			{
+				object obj = GetFieldValue(9, 0, Fit.SubfieldIndexMainField);
+				WorkoutEquipment? value = obj == null ? (WorkoutEquipment?)null : (WorkoutEquipment)obj;
+				return value;
+			}
+			set
+			{
+				SetFieldValue(9, 0, value, Fit.SubfieldIndexMainField);
+			}
+		}
+
+		///<summary>
+		/// Retrieves the ExerciseCategory field</summary>
+		/// <returns>Returns nullable ushort representing the ExerciseCategory field</returns>
+		public ushort? ExerciseCategory
+		{
+			get
+			{
+				Object val = GetFieldValue(10, 0, Fit.SubfieldIndexMainField);
+				if (val == null)
+				{
+					return null;
+				}
+
+				return (Convert.ToUInt16(val));
+
+			}
+			set
+			{
+				SetFieldValue(10, 0, value, Fit.SubfieldIndexMainField);
+			}
+		}
+
+		///<summary>
+		/// Retrieves the ExerciseName field</summary>
+		/// <returns>Returns nullable ushort representing the ExerciseName field</returns>
+		public ushort? ExerciseName
+		{
+			get
+			{
+				Object val = GetFieldValue(11, 0, Fit.SubfieldIndexMainField);
+				if (val == null)
+				{
+					return null;
+				}
+
+				return (Convert.ToUInt16(val));
+
+			}
+			set
+			{
+				SetFieldValue(11, 0, value, Fit.SubfieldIndexMainField);
+			}
+		}
+
+		///<summary>
+		/// Retrieves the ExerciseWeight field
+		/// Units: kg</summary>
+		/// <returns>Returns nullable float representing the ExerciseWeight field</returns>
+		public float? ExerciseWeight
+		{
+			get
+			{
+				Object val = GetFieldValue(12, 0, Fit.SubfieldIndexMainField);
+				if (val == null)
+				{
+					return null;
+				}
+
+				return (Convert.ToSingle(val));
+
+			}
+			set
+			{
+				SetFieldValue(12, 0, value, Fit.SubfieldIndexMainField);
+			}
+		}
+
+		///<summary>
+		/// Retrieves the WeightDisplayUnit field</summary>
+		/// <returns>Returns nullable ushort representing the WeightDisplayUnit field</returns>
+		public ushort? WeightDisplayUnit
+		{
+			get
+			{
+				Object val = GetFieldValue(13, 0, Fit.SubfieldIndexMainField);
+				if (val == null)
+				{
+					return null;
+				}
+
+				return (Convert.ToUInt16(val));
+
+			}
+			set
+			{
+				SetFieldValue(13, 0, value, Fit.SubfieldIndexMainField);
+			}
+		}
+
+		///<summary>
+		/// Retrieves the SecondaryTargetType field</summary>
+		/// <returns>Returns nullable WktStepTarget enum representing the SecondaryTargetType field</returns>
+		public WktStepTarget? SecondaryTargetType
+		{
+			get
+			{
+				object obj = GetFieldValue(19, 0, Fit.SubfieldIndexMainField);
+				WktStepTarget? value = obj == null ? (WktStepTarget?)null : (WktStepTarget)obj;
+				return value;
+			}
+			set
+			{
+				SetFieldValue(19, 0, value, Fit.SubfieldIndexMainField);
+			}
+		}
+
+		///<summary>
+		/// Retrieves the SecondaryTargetValue field</summary>
+		/// <returns>Returns nullable uint representing the SecondaryTargetValue field</returns>
+		public uint? SecondaryTargetValue
+		{
+			get
+			{
+				Object val = GetFieldValue(20, 0, Fit.SubfieldIndexMainField);
+				if (val == null)
+				{
+					return null;
+				}
+
+				return (Convert.ToUInt32(val));
+
+			}
+			set
+			{
+				SetFieldValue(20, 0, value, Fit.SubfieldIndexMainField);
+			}
+		}
+
+
+		/// <summary>
+		/// Retrieves the SecondaryTargetSpeedZone subfield
+		/// Comment: speed zone (1-10);Custom =0;</summary>
+		/// <returns>Nullable uint representing the SecondaryTargetSpeedZone subfield</returns>
+		public uint? SecondaryTargetSpeedZone
+		{
+			get
+			{
+				Object val = GetFieldValue(20, 0, SecondaryTargetValueSubfield.SecondaryTargetSpeedZone);
+				if (val == null)
+				{
+					return null;
+				}
+
+				return (Convert.ToUInt32(val));
+
+			}
+			set
+			{
+				SetFieldValue(20, 0, value, SecondaryTargetValueSubfield.SecondaryTargetSpeedZone);
+			}
+		}
+
+		/// <summary>
+		/// Retrieves the SecondaryTargetHrZone subfield
+		/// Comment: hr zone (1-5);Custom =0;</summary>
+		/// <returns>Nullable uint representing the SecondaryTargetHrZone subfield</returns>
+		public uint? SecondaryTargetHrZone
+		{
+			get
+			{
+				Object val = GetFieldValue(20, 0, SecondaryTargetValueSubfield.SecondaryTargetHrZone);
+				if (val == null)
+				{
+					return null;
+				}
+
+				return (Convert.ToUInt32(val));
+
+			}
+			set
+			{
+				SetFieldValue(20, 0, value, SecondaryTargetValueSubfield.SecondaryTargetHrZone);
+			}
+		}
+
+		/// <summary>
+		/// Retrieves the SecondaryTargetCadenceZone subfield
+		/// Comment: Zone (1-?); Custom = 0;</summary>
+		/// <returns>Nullable uint representing the SecondaryTargetCadenceZone subfield</returns>
+		public uint? SecondaryTargetCadenceZone
+		{
+			get
+			{
+				Object val = GetFieldValue(20, 0, SecondaryTargetValueSubfield.SecondaryTargetCadenceZone);
+				if (val == null)
+				{
+					return null;
+				}
+
+				return (Convert.ToUInt32(val));
+
+			}
+			set
+			{
+				SetFieldValue(20, 0, value, SecondaryTargetValueSubfield.SecondaryTargetCadenceZone);
+			}
+		}
+
+		/// <summary>
+		/// Retrieves the SecondaryTargetPowerZone subfield
+		/// Comment: Power Zone ( 1-7); Custom = 0;</summary>
+		/// <returns>Nullable uint representing the SecondaryTargetPowerZone subfield</returns>
+		public uint? SecondaryTargetPowerZone
+		{
+			get
+			{
+				Object val = GetFieldValue(20, 0, SecondaryTargetValueSubfield.SecondaryTargetPowerZone);
+				if (val == null)
+				{
+					return null;
+				}
+
+				return (Convert.ToUInt32(val));
+
+			}
+			set
+			{
+				SetFieldValue(20, 0, value, SecondaryTargetValueSubfield.SecondaryTargetPowerZone);
+			}
+		}
+
+		/// <summary>
+		/// Retrieves the SecondaryTargetStrokeType subfield</summary>
+		/// <returns>Nullable SwimStroke enum representing the SecondaryTargetStrokeType subfield</returns>
+		public SwimStroke? GetSecondaryTargetStrokeType()
+		{
+			return (SwimStroke?)GetFieldValue(20, 0, SecondaryTargetValueSubfield.SecondaryTargetStrokeType);
+		}
+
+		/// <summary>
+		///
+		/// Set SecondaryTargetStrokeType subfield</summary>
+		/// <param name="secondaryTargetStrokeType">Subfield value to be set</param>
+		public void SetSecondaryTargetStrokeType(byte? secondaryTargetStrokeType)
+		{
+			SetFieldValue(20, 0, secondaryTargetStrokeType, SecondaryTargetValueSubfield.SecondaryTargetStrokeType);
+		}
+		///<summary>
+		/// Retrieves the SecondaryCustomTargetValueLow field</summary>
+		/// <returns>Returns nullable uint representing the SecondaryCustomTargetValueLow field</returns>
+		public uint? SecondaryCustomTargetValueLow
+		{
+			get
+			{
+				Object val = GetFieldValue(21, 0, Fit.SubfieldIndexMainField);
+				if (val == null)
+				{
+					return null;
+				}
+
+				return (Convert.ToUInt32(val));
+
+			}
+			set
+			{
+				SetFieldValue(21, 0, value, Fit.SubfieldIndexMainField);
+			}
+		}
+
+
+		/// <summary>
+		/// Retrieves the SecondaryCustomTargetSpeedLow subfield
+		/// Units: m/s</summary>
+		/// <returns>Nullable float representing the SecondaryCustomTargetSpeedLow subfield</returns>
+		public float? SecondaryCustomTargetSpeedLow
+		{
+			get
+			{
+				Object val = GetFieldValue(21, 0, SecondaryCustomTargetValueLowSubfield.SecondaryCustomTargetSpeedLow);
+				if (val == null)
+				{
+					return null;
+				}
+
+				return (Convert.ToSingle(val));
+
+			}
+			set
+			{
+				SetFieldValue(21, 0, value, SecondaryCustomTargetValueLowSubfield.SecondaryCustomTargetSpeedLow);
+			}
+		}
+
+		/// <summary>
+		/// Retrieves the SecondaryCustomTargetHeartRateLow subfield
+		/// Units: % or bpm</summary>
+		/// <returns>Nullable uint representing the SecondaryCustomTargetHeartRateLow subfield</returns>
+		public uint? SecondaryCustomTargetHeartRateLow
+		{
+			get
+			{
+				Object val = GetFieldValue(21, 0, SecondaryCustomTargetValueLowSubfield.SecondaryCustomTargetHeartRateLow);
+				if (val == null)
+				{
+					return null;
+				}
+
+				return (Convert.ToUInt32(val));
+
+			}
+			set
+			{
+				SetFieldValue(21, 0, value, SecondaryCustomTargetValueLowSubfield.SecondaryCustomTargetHeartRateLow);
+			}
+		}
+
+		/// <summary>
+		/// Retrieves the SecondaryCustomTargetCadenceLow subfield
+		/// Units: rpm</summary>
+		/// <returns>Nullable uint representing the SecondaryCustomTargetCadenceLow subfield</returns>
+		public uint? SecondaryCustomTargetCadenceLow
+		{
+			get
+			{
+				Object val = GetFieldValue(21, 0, SecondaryCustomTargetValueLowSubfield.SecondaryCustomTargetCadenceLow);
+				if (val == null)
+				{
+					return null;
+				}
+
+				return (Convert.ToUInt32(val));
+
+			}
+			set
+			{
+				SetFieldValue(21, 0, value, SecondaryCustomTargetValueLowSubfield.SecondaryCustomTargetCadenceLow);
+			}
+		}
+
+		/// <summary>
+		/// Retrieves the SecondaryCustomTargetPowerLow subfield
+		/// Units: % or watts</summary>
+		/// <returns>Nullable uint representing the SecondaryCustomTargetPowerLow subfield</returns>
+		public uint? SecondaryCustomTargetPowerLow
+		{
+			get
+			{
+				Object val = GetFieldValue(21, 0, SecondaryCustomTargetValueLowSubfield.SecondaryCustomTargetPowerLow);
+				if (val == null)
+				{
+					return null;
+				}
+
+				return (Convert.ToUInt32(val));
+
+			}
+			set
+			{
+				SetFieldValue(21, 0, value, SecondaryCustomTargetValueLowSubfield.SecondaryCustomTargetPowerLow);
+			}
+		}
+		///<summary>
+		/// Retrieves the SecondaryCustomTargetValueHigh field</summary>
+		/// <returns>Returns nullable uint representing the SecondaryCustomTargetValueHigh field</returns>
+		public uint? SecondaryCustomTargetValueHigh
+		{
+			get
+			{
+				Object val = GetFieldValue(22, 0, Fit.SubfieldIndexMainField);
+				if (val == null)
+				{
+					return null;
+				}
+
+				return (Convert.ToUInt32(val));
+
+			}
+			set
+			{
+				SetFieldValue(22, 0, value, Fit.SubfieldIndexMainField);
+			}
+		}
+
+
+		/// <summary>
+		/// Retrieves the SecondaryCustomTargetSpeedHigh subfield
+		/// Units: m/s</summary>
+		/// <returns>Nullable float representing the SecondaryCustomTargetSpeedHigh subfield</returns>
+		public float? SecondaryCustomTargetSpeedHigh
+		{
+			get
+			{
+				Object val = GetFieldValue(22, 0, SecondaryCustomTargetValueHighSubfield.SecondaryCustomTargetSpeedHigh);
+				if (val == null)
+				{
+					return null;
+				}
+
+				return (Convert.ToSingle(val));
+
+			}
+			set
+			{
+				SetFieldValue(22, 0, value, SecondaryCustomTargetValueHighSubfield.SecondaryCustomTargetSpeedHigh);
+			}
+		}
+
+		/// <summary>
+		/// Retrieves the SecondaryCustomTargetHeartRateHigh subfield
+		/// Units: % or bpm</summary>
+		/// <returns>Nullable uint representing the SecondaryCustomTargetHeartRateHigh subfield</returns>
+		public uint? SecondaryCustomTargetHeartRateHigh
+		{
+			get
+			{
+				Object val = GetFieldValue(22, 0, SecondaryCustomTargetValueHighSubfield.SecondaryCustomTargetHeartRateHigh);
+				if (val == null)
+				{
+					return null;
+				}
+
+				return (Convert.ToUInt32(val));
+
+			}
+			set
+			{
+				SetFieldValue(22, 0, value, SecondaryCustomTargetValueHighSubfield.SecondaryCustomTargetHeartRateHigh);
+			}
+		}
+
+		/// <summary>
+		/// Retrieves the SecondaryCustomTargetCadenceHigh subfield
+		/// Units: rpm</summary>
+		/// <returns>Nullable uint representing the SecondaryCustomTargetCadenceHigh subfield</returns>
+		public uint? SecondaryCustomTargetCadenceHigh
+		{
+			get
+			{
+				Object val = GetFieldValue(22, 0, SecondaryCustomTargetValueHighSubfield.SecondaryCustomTargetCadenceHigh);
+				if (val == null)
+				{
+					return null;
+				}
+
+				return (Convert.ToUInt32(val));
+
+			}
+			set
+			{
+				SetFieldValue(22, 0, value, SecondaryCustomTargetValueHighSubfield.SecondaryCustomTargetCadenceHigh);
+			}
+		}
+
+		/// <summary>
+		/// Retrieves the SecondaryCustomTargetPowerHigh subfield
+		/// Units: % or watts</summary>
+		/// <returns>Nullable uint representing the SecondaryCustomTargetPowerHigh subfield</returns>
+		public uint? SecondaryCustomTargetPowerHigh
+		{
+			get
+			{
+				Object val = GetFieldValue(22, 0, SecondaryCustomTargetValueHighSubfield.SecondaryCustomTargetPowerHigh);
+				if (val == null)
+				{
+					return null;
+				}
+
+				return (Convert.ToUInt32(val));
+
+			}
+			set
+			{
+				SetFieldValue(22, 0, value, SecondaryCustomTargetValueHighSubfield.SecondaryCustomTargetPowerHigh);
+			}
+		}
+		#endregion // Methods
+	} // Class
 } // namespace

--- a/Dynastream/Fit/Profile/Mesgs/ZonesTargetMesg.cs
+++ b/Dynastream/Fit/Profile/Mesgs/ZonesTargetMesg.cs
@@ -21,143 +21,138 @@ using System.Linq;
 
 namespace Dynastream.Fit
 {
-    /// <summary>
-    /// Implements the ZonesTarget profile message.
-    /// </summary>
-    public class ZonesTargetMesg : Mesg
-    {
-        #region Fields
-        #endregion
+	/// <summary>
+	/// Implements the ZonesTarget profile message.
+	/// </summary>
+	public class ZonesTargetMesg : Mesg
+	{
+		#region Fields
+		#endregion
 
-        /// <summary>
-        /// Field Numbers for <see cref="ZonesTargetMesg"/>
-        /// </summary>
-        public sealed class FieldDefNum
-        {
-            public const byte MaxHeartRate = 1;
-            public const byte ThresholdHeartRate = 2;
-            public const byte FunctionalThresholdPower = 3;
-            public const byte HrCalcType = 5;
-            public const byte PwrCalcType = 7;
-            public const byte Invalid = Fit.FieldNumInvalid;
-        }
+		/// <summary>
+		/// Field Numbers for <see cref="ZonesTargetMesg"/>
+		/// </summary>
+		public sealed class FieldDefNum
+		{
+			public const byte MaxHeartRate = 1;
+			public const byte ThresholdHeartRate = 2;
+			public const byte FunctionalThresholdPower = 3;
+			public const byte HrCalcType = 5;
+			public const byte PwrCalcType = 7;
+			public const byte Invalid = Fit.FieldNumInvalid;
+		}
 
-        #region Constructors
-        public ZonesTargetMesg() : base(Profile.GetMesg(MesgNum.ZonesTarget))
-        {
-        }
+		#region Constructors
+		public ZonesTargetMesg() : base(Profile.GetMesg(MesgNum.ZonesTarget))
+		{
+		}
 
-        public ZonesTargetMesg(Mesg mesg) : base(mesg)
-        {
-        }
-        #endregion // Constructors
+		public ZonesTargetMesg(Mesg mesg) : base(mesg)
+		{
+		}
+		#endregion // Constructors
 
-        #region Methods
-        ///<summary>
-        /// Retrieves the MaxHeartRate field</summary>
-        /// <returns>Returns nullable byte representing the MaxHeartRate field</returns>
-        public byte? GetMaxHeartRate()
-        {
-            Object val = GetFieldValue(1, 0, Fit.SubfieldIndexMainField);
-            if(val == null)
-            {
-                return null;
-            }
+		#region Methods
+		///<summary>
+		/// Retrieves the MaxHeartRate field</summary>
+		/// <returns>Returns nullable byte representing the MaxHeartRate field</returns>
+		public byte? MaxHeartRate
+		{
+			get
+			{
+				Object val = GetFieldValue(1, 0, Fit.SubfieldIndexMainField);
+				if (val == null)
+				{
+					return null;
+				}
 
-            return (Convert.ToByte(val));
-            
-        }
+				return (Convert.ToByte(val));
 
-        /// <summary>
-        /// Set MaxHeartRate field</summary>
-        /// <param name="maxHeartRate_">Nullable field value to be set</param>
-        public void SetMaxHeartRate(byte? maxHeartRate_)
-        {
-            SetFieldValue(1, 0, maxHeartRate_, Fit.SubfieldIndexMainField);
-        }
-        
-        ///<summary>
-        /// Retrieves the ThresholdHeartRate field</summary>
-        /// <returns>Returns nullable byte representing the ThresholdHeartRate field</returns>
-        public byte? GetThresholdHeartRate()
-        {
-            Object val = GetFieldValue(2, 0, Fit.SubfieldIndexMainField);
-            if(val == null)
-            {
-                return null;
-            }
+			}
+			set
+			{
+				SetFieldValue(1, 0, value, Fit.SubfieldIndexMainField);
+			}
+		}
 
-            return (Convert.ToByte(val));
-            
-        }
+		///<summary>
+		/// Retrieves the ThresholdHeartRate field</summary>
+		/// <returns>Returns nullable byte representing the ThresholdHeartRate field</returns>
+		public byte? ThresholdHeartRate
+		{
+			get
+			{
+				Object val = GetFieldValue(2, 0, Fit.SubfieldIndexMainField);
+				if (val == null)
+				{
+					return null;
+				}
 
-        /// <summary>
-        /// Set ThresholdHeartRate field</summary>
-        /// <param name="thresholdHeartRate_">Nullable field value to be set</param>
-        public void SetThresholdHeartRate(byte? thresholdHeartRate_)
-        {
-            SetFieldValue(2, 0, thresholdHeartRate_, Fit.SubfieldIndexMainField);
-        }
-        
-        ///<summary>
-        /// Retrieves the FunctionalThresholdPower field</summary>
-        /// <returns>Returns nullable ushort representing the FunctionalThresholdPower field</returns>
-        public ushort? GetFunctionalThresholdPower()
-        {
-            Object val = GetFieldValue(3, 0, Fit.SubfieldIndexMainField);
-            if(val == null)
-            {
-                return null;
-            }
+				return (Convert.ToByte(val));
 
-            return (Convert.ToUInt16(val));
-            
-        }
+			}
+			set
+			{
+				SetFieldValue(2, 0, value, Fit.SubfieldIndexMainField);
+			}
+		}
 
-        /// <summary>
-        /// Set FunctionalThresholdPower field</summary>
-        /// <param name="functionalThresholdPower_">Nullable field value to be set</param>
-        public void SetFunctionalThresholdPower(ushort? functionalThresholdPower_)
-        {
-            SetFieldValue(3, 0, functionalThresholdPower_, Fit.SubfieldIndexMainField);
-        }
-        
-        ///<summary>
-        /// Retrieves the HrCalcType field</summary>
-        /// <returns>Returns nullable HrZoneCalc enum representing the HrCalcType field</returns>
-        public HrZoneCalc? GetHrCalcType()
-        {
-            object obj = GetFieldValue(5, 0, Fit.SubfieldIndexMainField);
-            HrZoneCalc? value = obj == null ? (HrZoneCalc?)null : (HrZoneCalc)obj;
-            return value;
-        }
+		///<summary>
+		/// Retrieves the FunctionalThresholdPower field</summary>
+		/// <returns>Returns nullable ushort representing the FunctionalThresholdPower field</returns>
+		public ushort? FunctionalThresholdPower
+		{
+			get
+			{
+				Object val = GetFieldValue(3, 0, Fit.SubfieldIndexMainField);
+				if (val == null)
+				{
+					return null;
+				}
 
-        /// <summary>
-        /// Set HrCalcType field</summary>
-        /// <param name="hrCalcType_">Nullable field value to be set</param>
-        public void SetHrCalcType(HrZoneCalc? hrCalcType_)
-        {
-            SetFieldValue(5, 0, hrCalcType_, Fit.SubfieldIndexMainField);
-        }
-        
-        ///<summary>
-        /// Retrieves the PwrCalcType field</summary>
-        /// <returns>Returns nullable PwrZoneCalc enum representing the PwrCalcType field</returns>
-        public PwrZoneCalc? GetPwrCalcType()
-        {
-            object obj = GetFieldValue(7, 0, Fit.SubfieldIndexMainField);
-            PwrZoneCalc? value = obj == null ? (PwrZoneCalc?)null : (PwrZoneCalc)obj;
-            return value;
-        }
+				return (Convert.ToUInt16(val));
 
-        /// <summary>
-        /// Set PwrCalcType field</summary>
-        /// <param name="pwrCalcType_">Nullable field value to be set</param>
-        public void SetPwrCalcType(PwrZoneCalc? pwrCalcType_)
-        {
-            SetFieldValue(7, 0, pwrCalcType_, Fit.SubfieldIndexMainField);
-        }
-        
-        #endregion // Methods
-    } // Class
+			}
+			set
+			{
+				SetFieldValue(3, 0, value, Fit.SubfieldIndexMainField);
+			}
+		}
+
+		///<summary>
+		/// Retrieves the HrCalcType field</summary>
+		/// <returns>Returns nullable HrZoneCalc enum representing the HrCalcType field</returns>
+		public HrZoneCalc? HrCalcType
+		{
+			get
+			{
+				object obj = GetFieldValue(5, 0, Fit.SubfieldIndexMainField);
+				HrZoneCalc? value = obj == null ? (HrZoneCalc?)null : (HrZoneCalc)obj;
+				return value;
+			}
+			set
+			{
+				SetFieldValue(5, 0, value, Fit.SubfieldIndexMainField);
+			}
+		}
+
+		///<summary>
+		/// Retrieves the PwrCalcType field</summary>
+		/// <returns>Returns nullable PwrZoneCalc enum representing the PwrCalcType field</returns>
+		public PwrZoneCalc? PwrCalcType
+		{
+			get
+			{
+				object obj = GetFieldValue(7, 0, Fit.SubfieldIndexMainField);
+				PwrZoneCalc? value = obj == null ? (PwrZoneCalc?)null : (PwrZoneCalc)obj;
+				return value;
+			}
+			set
+			{
+				SetFieldValue(7, 0, value, Fit.SubfieldIndexMainField);
+			}
+		}
+
+		#endregion // Methods
+	} // Class
 } // namespace


### PR DESCRIPTION
This allows writing code in a more idiomatic style:
```
fitEncoder.Write(new SessionMesg
	{
		Event = Event.Session,
		EventType = EventType.Stop,
		Sport = Sport.Cycling,
		SubSport = SubSport.IndoorCycling,
		TotalElapsedTime = elapsed,
		TotalTimerTime = elapsed
	});
```